### PR TITLE
Add device extras, activity feed, and Pro feature scaffolding

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,11 @@
-from flask import Flask, render_template, jsonify, request, g, redirect, url_for, session
+from flask import Flask, render_template, jsonify, request, g, redirect, url_for, session, Response
 from flask_cors import CORS
 from werkzeug.security import generate_password_hash, check_password_hash
 import sqlite3
 import json
 from functools import wraps
 import os
+import csv
 import pyotp
 import qrcode
 import qrcode.image.svg
@@ -17,6 +18,17 @@ CORS(app)
 app.secret_key = os.urandom(24).hex()
 
 DATABASE = 'inventory.db'
+PRO_ENABLED = os.getenv('INVENTORY_PRO_ENABLED', '0') == '1'
+PRO_FEATURES = [
+    "maintenance_schedule",
+    "csv_export",
+    "advanced_analytics"
+]
+FREE_FEATURES = [
+    "tags",
+    "notes",
+    "activity_feed"
+]
 
 def get_db():
     db = getattr(g, '_database', None)
@@ -65,6 +77,50 @@ def init_db():
                 specs TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 FOREIGN KEY (category_id) REFERENCES categories(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS device_tags (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                device_id INTEGER NOT NULL,
+                tag TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (device_id) REFERENCES devices(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS device_notes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                device_id INTEGER NOT NULL,
+                note TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (device_id) REFERENCES devices(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS maintenance_tasks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                device_id INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                due_date TEXT,
+                status TEXT DEFAULT 'open',
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (device_id) REFERENCES devices(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS activity_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT,
+                action TEXT NOT NULL,
+                entity_type TEXT NOT NULL,
+                entity_id INTEGER,
+                details TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         ''')
 
@@ -126,6 +182,21 @@ def login_required(f):
             return redirect(url_for('login'))
         return f(*args, **kwargs)
     return decorated_function
+
+def log_activity(db, action, entity_type, entity_id=None, details=None):
+    username = session.get('username', 'system')
+    db.execute('''
+        INSERT INTO activity_log (username, action, entity_type, entity_id, details)
+        VALUES (?, ?, ?, ?, ?)
+    ''', (username, action, entity_type, entity_id, json.dumps(details or {})))
+
+def pro_required(f):
+    @wraps(f)
+    def wrapped(*args, **kwargs):
+        if not PRO_ENABLED:
+            return jsonify({"error": "Pro feature locked"}), 403
+        return f(*args, **kwargs)
+    return wrapped
 
 @app.route('/login', methods=['GET', 'POST'])
 def login():
@@ -193,6 +264,7 @@ def handle_category(category_id):
             if result.rowcount == 0:
                 return jsonify({"error": "Kategorie nicht gefunden"}), 404
 
+            log_activity(db, "update", "category", category_id, {"name": name})
             db.commit()
             return jsonify({"status": "updated"}), 200
 
@@ -204,6 +276,7 @@ def handle_category(category_id):
         if result.rowcount == 0:
             return jsonify({"error": "Kategorie nicht gefunden"}), 404
 
+        log_activity(db, "delete", "category", category_id)
         db.commit()
         return jsonify({"status": "deleted"}), 200
 
@@ -218,6 +291,7 @@ def handle_categories():
                 INSERT INTO categories (name, icon, fields)
                 VALUES (?, ?, ?)
             ''', (data['name'], data.get('icon', 'cpu'), json.dumps(data['fields'])))
+            log_activity(db, "create", "category", details={"name": data['name']})
             db.commit()
             return jsonify({"status": "success"}), 201
         except sqlite3.IntegrityError:
@@ -248,6 +322,7 @@ def handle_device(device_id):
             if result.rowcount == 0:
                 return jsonify({"error": "Gerät nicht gefunden"}), 404
 
+            log_activity(db, "update", "device", device_id, {"name": name})
             db.commit()
             return jsonify({"status": "updated"}), 200
 
@@ -259,6 +334,7 @@ def handle_device(device_id):
         if result.rowcount == 0:
             return jsonify({"error": "Gerät nicht gefunden"}), 404
 
+        log_activity(db, "delete", "device", device_id)
         db.commit()
         return jsonify({"status": "deleted"}), 200
 
@@ -281,6 +357,7 @@ def handle_devices():
             data.get('serial_number', '').strip(),
             json.dumps(data.get('specs', {}))
         ))
+        log_activity(db, "create", "device", details={"name": data['name']})
         db.commit()
         return jsonify({"status": "created"}), 201
 
@@ -319,6 +396,213 @@ def get_devices():
     
     devices = db.execute(query, params).fetchall()
     return jsonify([dict(row) for row in devices])
+
+@app.route('/api/features', methods=['GET'])
+@login_required
+def feature_flags():
+    return jsonify({
+        "pro_enabled": PRO_ENABLED,
+        "pro_features": PRO_FEATURES,
+        "free_features": FREE_FEATURES
+    })
+
+@app.route('/api/activity', methods=['GET'])
+@login_required
+def activity_feed():
+    db = get_db()
+    limit = int(request.args.get('limit', 8))
+    rows = db.execute('''
+        SELECT username, action, entity_type, entity_id, details, created_at
+        FROM activity_log
+        ORDER BY created_at DESC
+        LIMIT ?
+    ''', (limit,)).fetchall()
+    activity = []
+    for row in rows:
+        entry = dict(row)
+        try:
+            entry['details'] = json.loads(entry.get('details') or '{}')
+        except json.JSONDecodeError:
+            entry['details'] = {}
+        activity.append(entry)
+    return jsonify(activity)
+
+@app.route('/api/devices/<int:device_id>/tags', methods=['GET', 'POST'])
+@login_required
+def device_tags(device_id):
+    db = get_db()
+    if request.method == 'POST':
+        data = request.get_json()
+        tag = (data.get('tag') or '').strip()
+        if not tag:
+            return jsonify({"error": "Tag darf nicht leer sein"}), 400
+        db.execute('''
+            INSERT INTO device_tags (device_id, tag)
+            VALUES (?, ?)
+        ''', (device_id, tag))
+        log_activity(db, "create", "tag", device_id, {"tag": tag})
+        db.commit()
+        return jsonify({"status": "created"}), 201
+
+    tags = db.execute('''
+        SELECT id, tag, created_at
+        FROM device_tags
+        WHERE device_id = ?
+        ORDER BY created_at DESC
+    ''', (device_id,)).fetchall()
+    return jsonify([dict(row) for row in tags])
+
+@app.route('/api/devices/<int:device_id>/tags/<int:tag_id>', methods=['DELETE'])
+@login_required
+def delete_device_tag(device_id, tag_id):
+    db = get_db()
+    result = db.execute('''
+        DELETE FROM device_tags
+        WHERE id = ? AND device_id = ?
+    ''', (tag_id, device_id))
+    if result.rowcount == 0:
+        return jsonify({"error": "Tag nicht gefunden"}), 404
+    log_activity(db, "delete", "tag", device_id, {"tag_id": tag_id})
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/devices/<int:device_id>/notes', methods=['GET', 'POST'])
+@login_required
+def device_notes(device_id):
+    db = get_db()
+    if request.method == 'POST':
+        data = request.get_json()
+        note = (data.get('note') or '').strip()
+        if not note:
+            return jsonify({"error": "Notiz darf nicht leer sein"}), 400
+        db.execute('''
+            INSERT INTO device_notes (device_id, note)
+            VALUES (?, ?)
+        ''', (device_id, note))
+        log_activity(db, "create", "note", device_id)
+        db.commit()
+        return jsonify({"status": "created"}), 201
+
+    notes = db.execute('''
+        SELECT id, note, created_at
+        FROM device_notes
+        WHERE device_id = ?
+        ORDER BY created_at DESC
+    ''', (device_id,)).fetchall()
+    return jsonify([dict(row) for row in notes])
+
+@app.route('/api/devices/<int:device_id>/notes/<int:note_id>', methods=['DELETE'])
+@login_required
+def delete_device_note(device_id, note_id):
+    db = get_db()
+    result = db.execute('''
+        DELETE FROM device_notes
+        WHERE id = ? AND device_id = ?
+    ''', (note_id, device_id))
+    if result.rowcount == 0:
+        return jsonify({"error": "Notiz nicht gefunden"}), 404
+    log_activity(db, "delete", "note", device_id, {"note_id": note_id})
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/maintenance', methods=['GET', 'POST'])
+@login_required
+@pro_required
+def maintenance_tasks():
+    db = get_db()
+    if request.method == 'POST':
+        data = request.get_json()
+        device_id = data.get('device_id')
+        title = (data.get('title') or '').strip()
+        due_date = (data.get('due_date') or '').strip()
+        if not device_id or not title:
+            return jsonify({"error": "Gerät und Titel sind erforderlich"}), 400
+        db.execute('''
+            INSERT INTO maintenance_tasks (device_id, title, due_date, status)
+            VALUES (?, ?, ?, ?)
+        ''', (device_id, title, due_date, 'open'))
+        log_activity(db, "create", "maintenance", device_id, {"title": title})
+        db.commit()
+        return jsonify({"status": "created"}), 201
+
+    device_id = request.args.get('device_id')
+    params = []
+    query = '''
+        SELECT m.id, m.device_id, m.title, m.due_date, m.status, m.created_at, d.name as device_name
+        FROM maintenance_tasks m
+        JOIN devices d ON d.id = m.device_id
+    '''
+    if device_id:
+        query += ' WHERE m.device_id = ?'
+        params.append(device_id)
+    query += ' ORDER BY m.created_at DESC'
+    tasks = db.execute(query, params).fetchall()
+    return jsonify([dict(row) for row in tasks])
+
+@app.route('/api/maintenance/<int:task_id>', methods=['PATCH'])
+@login_required
+@pro_required
+def update_maintenance(task_id):
+    db = get_db()
+    data = request.get_json()
+    status = (data.get('status') or '').strip().lower()
+    if status not in {'open', 'done'}:
+        return jsonify({"error": "Ungültiger Status"}), 400
+    result = db.execute('''
+        UPDATE maintenance_tasks
+        SET status = ?
+        WHERE id = ?
+    ''', (status, task_id))
+    if result.rowcount == 0:
+        return jsonify({"error": "Wartung nicht gefunden"}), 404
+    log_activity(db, "update", "maintenance", task_id, {"status": status})
+    db.commit()
+    return jsonify({"status": "updated"}), 200
+
+@app.route('/api/maintenance/summary', methods=['GET'])
+@login_required
+def maintenance_summary():
+    if not PRO_ENABLED:
+        return jsonify({"pro_locked": True, "open": 0, "overdue": 0})
+    db = get_db()
+    open_count = db.execute('''
+        SELECT COUNT(*) FROM maintenance_tasks WHERE status = 'open'
+    ''').fetchone()[0]
+    overdue_count = db.execute('''
+        SELECT COUNT(*) FROM maintenance_tasks
+        WHERE status = 'open' AND due_date != '' AND date(due_date) < date('now')
+    ''').fetchone()[0]
+    return jsonify({"pro_locked": False, "open": open_count, "overdue": overdue_count})
+
+@app.route('/api/export/devices', methods=['GET'])
+@login_required
+@pro_required
+def export_devices():
+    db = get_db()
+    devices = db.execute('''
+        SELECT d.id, d.name, d.serial_number, d.specs, d.created_at, c.name as category_name
+        FROM devices d
+        JOIN categories c ON d.category_id = c.id
+        ORDER BY d.created_at DESC
+    ''').fetchall()
+    output = BytesIO()
+    writer = csv.writer(output)
+    writer.writerow(["ID", "Name", "Kategorie", "Besitzer", "Spezifikationen", "Erstellt"])
+    for device in devices:
+        writer.writerow([
+            device['id'],
+            device['name'],
+            device['category_name'],
+            device['serial_number'] or '',
+            device['specs'] or '',
+            device['created_at']
+        ])
+    output.seek(0)
+    return Response(
+        output.getvalue(),
+        mimetype='text/csv',
+        headers={'Content-Disposition': 'attachment; filename=devices.csv'}
+    )
 
 @app.route('/stats')
 @login_required

--- a/static/script.js
+++ b/static/script.js
@@ -7,6 +7,28 @@ document.addEventListener('alpine:init', () => {
         activeCategory: null,
         searchQuery: '',
         sortDropdownOpen: false,
+        featureFlags: {
+            pro_enabled: false,
+            pro_features: [],
+            free_features: []
+        },
+        maintenanceSummary: {
+            pro_locked: true,
+            open: 0,
+            overdue: 0
+        },
+        activityFeed: [],
+        selectedDevice: null,
+        deviceDetailOpen: false,
+        deviceTags: [],
+        deviceNotes: [],
+        maintenanceTasks: [],
+        newTag: '',
+        newNote: '',
+        newMaintenance: {
+            title: '',
+            due_date: ''
+        },
         currentSort: { field: null, direction: null },
 		
 		showSortMenu: false,
@@ -46,8 +68,44 @@ document.addEventListener('alpine:init', () => {
         async init() {
             await this.loadCategories();
             await this.loadDevices();
+            await this.loadFeatureFlags();
+            await this.loadMaintenanceSummary();
+            await this.loadActivityFeed();
             this.$watch('searchQuery', () => this.searchDevices());
             feather.replace();
+        },
+
+        async loadFeatureFlags() {
+            try {
+                const response = await fetch('/api/features');
+                if (response.ok) {
+                    this.featureFlags = await response.json();
+                }
+            } catch (error) {
+                console.error('Error loading feature flags:', error);
+            }
+        },
+
+        async loadMaintenanceSummary() {
+            try {
+                const response = await fetch('/api/maintenance/summary');
+                if (response.ok) {
+                    this.maintenanceSummary = await response.json();
+                }
+            } catch (error) {
+                console.error('Error loading maintenance summary:', error);
+            }
+        },
+
+        async loadActivityFeed() {
+            try {
+                const response = await fetch('/api/activity?limit=6');
+                if (response.ok) {
+                    this.activityFeed = await response.json();
+                }
+            } catch (error) {
+                console.error('Error loading activity feed:', error);
+            }
         },
 		
         // Data Loading
@@ -65,6 +123,12 @@ document.addEventListener('alpine:init', () => {
             const response = await fetch(url);
             this.devices = await response.json();
             this.filteredDevices = this.devices;
+            if (this.selectedDevice) {
+                const updated = this.devices.find(device => device.id === this.selectedDevice.id);
+                if (updated) {
+                    this.selectedDevice = updated;
+                }
+            }
         },
 
         // Search and Sort
@@ -169,6 +233,7 @@ document.addEventListener('alpine:init', () => {
                 if (response.ok) {
                     await this.loadCategories();
                     this.closeCategoryModal();
+                    await this.loadActivityFeed();
                 } else {
                     const error = await response.json();
                     throw new Error(error.error || 'Failed to save category');
@@ -190,6 +255,7 @@ document.addEventListener('alpine:init', () => {
                         await this.loadDevices();
                     }
                     this.categoryMenuOpen = null; // Menü schließen nach Löschen
+                    await this.loadActivityFeed();
                 } else {
                     const error = await response.json();
                     alert('Error deleting category: ' + (error.error || 'Unknown error'));
@@ -261,6 +327,7 @@ document.addEventListener('alpine:init', () => {
                 if (response.ok) {
                     await this.loadDevices(this.activeCategory);
                     this.closeDeviceModal();
+                    await this.loadActivityFeed();
                 } else {
                     const error = await response.json();
                     throw new Error(error.error || 'Failed to save device');
@@ -278,6 +345,7 @@ document.addEventListener('alpine:init', () => {
                 });
                 if (response.ok) {
                     await this.loadDevices(this.activeCategory);
+                    await this.loadActivityFeed();
                 } else {
                     const error = await response.json();
                     alert('Error deleting device: ' + (error.error || 'Unknown error'));
@@ -291,6 +359,171 @@ document.addEventListener('alpine:init', () => {
             if (this.openDeviceId !== null) {
                 this.categoryMenuOpen = null;
             }
+        },
+
+        async openDeviceDetail(device) {
+            this.selectedDevice = device;
+            this.deviceDetailOpen = true;
+            await this.loadDeviceExtras(device.id);
+        },
+
+        closeDeviceDetail() {
+            this.deviceDetailOpen = false;
+            this.selectedDevice = null;
+            this.deviceTags = [];
+            this.deviceNotes = [];
+            this.maintenanceTasks = [];
+        },
+
+        async loadDeviceExtras(deviceId) {
+            try {
+                const [tagsRes, notesRes] = await Promise.all([
+                    fetch(`/api/devices/${deviceId}/tags`),
+                    fetch(`/api/devices/${deviceId}/notes`)
+                ]);
+                if (tagsRes.ok) {
+                    this.deviceTags = await tagsRes.json();
+                }
+                if (notesRes.ok) {
+                    this.deviceNotes = await notesRes.json();
+                }
+            } catch (error) {
+                console.error('Error loading device extras:', error);
+            }
+
+            if (this.featureFlags.pro_enabled) {
+                try {
+                    const maintenanceRes = await fetch(`/api/maintenance?device_id=${deviceId}`);
+                    if (maintenanceRes.ok) {
+                        this.maintenanceTasks = await maintenanceRes.json();
+                    }
+                } catch (error) {
+                    console.error('Error loading maintenance tasks:', error);
+                }
+            }
+        },
+
+        async addTag() {
+            if (!this.newTag.trim() || !this.selectedDevice) return;
+            try {
+                const response = await fetch(`/api/devices/${this.selectedDevice.id}/tags`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ tag: this.newTag.trim() })
+                });
+                if (response.ok) {
+                    this.newTag = '';
+                    await this.loadDeviceExtras(this.selectedDevice.id);
+                    await this.loadActivityFeed();
+                } else {
+                    const error = await response.json();
+                    alert(error.error || 'Tag konnte nicht gespeichert werden');
+                }
+            } catch (error) {
+                console.error('Error adding tag:', error);
+            }
+        },
+
+        async removeTag(tagId) {
+            if (!this.selectedDevice) return;
+            try {
+                const response = await fetch(`/api/devices/${this.selectedDevice.id}/tags/${tagId}`, {
+                    method: 'DELETE'
+                });
+                if (response.ok) {
+                    await this.loadDeviceExtras(this.selectedDevice.id);
+                    await this.loadActivityFeed();
+                }
+            } catch (error) {
+                console.error('Error removing tag:', error);
+            }
+        },
+
+        async addNote() {
+            if (!this.newNote.trim() || !this.selectedDevice) return;
+            try {
+                const response = await fetch(`/api/devices/${this.selectedDevice.id}/notes`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ note: this.newNote.trim() })
+                });
+                if (response.ok) {
+                    this.newNote = '';
+                    await this.loadDeviceExtras(this.selectedDevice.id);
+                    await this.loadActivityFeed();
+                } else {
+                    const error = await response.json();
+                    alert(error.error || 'Notiz konnte nicht gespeichert werden');
+                }
+            } catch (error) {
+                console.error('Error adding note:', error);
+            }
+        },
+
+        async deleteNote(noteId) {
+            if (!this.selectedDevice) return;
+            try {
+                const response = await fetch(`/api/devices/${this.selectedDevice.id}/notes/${noteId}`, {
+                    method: 'DELETE'
+                });
+                if (response.ok) {
+                    await this.loadDeviceExtras(this.selectedDevice.id);
+                    await this.loadActivityFeed();
+                }
+            } catch (error) {
+                console.error('Error deleting note:', error);
+            }
+        },
+
+        async addMaintenanceTask() {
+            if (!this.featureFlags.pro_enabled || !this.selectedDevice) return;
+            if (!this.newMaintenance.title.trim()) return;
+            try {
+                const response = await fetch('/api/maintenance', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        device_id: this.selectedDevice.id,
+                        title: this.newMaintenance.title.trim(),
+                        due_date: this.newMaintenance.due_date
+                    })
+                });
+                if (response.ok) {
+                    this.newMaintenance = { title: '', due_date: '' };
+                    await this.loadDeviceExtras(this.selectedDevice.id);
+                    await this.loadMaintenanceSummary();
+                    await this.loadActivityFeed();
+                } else {
+                    const error = await response.json();
+                    alert(error.error || 'Wartung konnte nicht gespeichert werden');
+                }
+            } catch (error) {
+                console.error('Error adding maintenance task:', error);
+            }
+        },
+
+        async updateMaintenanceStatus(taskId, status) {
+            if (!this.featureFlags.pro_enabled) return;
+            try {
+                const response = await fetch(`/api/maintenance/${taskId}`, {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ status })
+                });
+                if (response.ok) {
+                    await this.loadDeviceExtras(this.selectedDevice.id);
+                    await this.loadMaintenanceSummary();
+                    await this.loadActivityFeed();
+                }
+            } catch (error) {
+                console.error('Error updating maintenance task:', error);
+            }
+        },
+
+        formatActivity(item) {
+            const name = item.details?.name || item.details?.tag || '';
+            const label = `${item.action} ${item.entity_type}`.replace('_', ' ');
+            return `${label}${name ? ` • ${name}` : ''}`;
         },
 
         // Helper Methods
@@ -353,4 +586,3 @@ document.addEventListener('alpine:init', () => {
 		
     }));
 });
-

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
             min-height: 100vh;
         }
         .sidebar {
-            width: 240px;
+            width: 280px;
             position: fixed;
             height: 100%;
             left: 0;
@@ -25,24 +25,29 @@
             z-index: 40;
         }
         .main-content {
-            margin-left: 240px;
+            margin-left: 280px;
             flex: 1;
             min-height: 100vh;
         }
         .app-header {
-            width: calc(100% - 240px);
+            width: calc(100% - 280px);
         }
     </style>
 </head>
-<body class="bg-gray-50 text-gray-900">
+<body class="bg-slate-950/5 text-slate-900">
     <div class="app-container">
         <!-- Sidebar -->
-        <div class="sidebar bg-white border-r border-gray-200">
-            <div class="sidebar-header p-6 border-b border-gray-200">
+        <div class="sidebar bg-white/90 backdrop-blur-xl border-r border-slate-200 shadow-sm">
+            <div class="sidebar-header p-6 border-b border-slate-200">
                 <a href="https://inv.pondsec.com">
                 <div class="logo flex items-center space-x-3">
-                    <i data-feather="cpu" class="text-blue-500 w-6 h-6"></i>
-                    <span class="text-xl font-semibold">Inventory Pro</span>
+                    <span class="inline-flex items-center justify-center w-10 h-10 rounded-2xl bg-gradient-to-br from-blue-500 via-indigo-500 to-purple-500 text-white shadow-lg">
+                        <i data-feather="cpu" class="w-5 h-5"></i>
+                    </span>
+                    <div>
+                        <p class="text-lg font-semibold text-slate-900">Inventory Pro</p>
+                        <p class="text-xs text-slate-500">Smart Asset Hub</p>
+                    </div>
                 </div>
                 </a>
             </div>
@@ -113,19 +118,35 @@
 			  }
 			}"
 			class="sidebar-nav p-4 overflow-y-auto max-h-[calc(100vh-8rem)]">
+			  <div class="mb-4 rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm">
+				<p class="text-xs uppercase tracking-widest text-slate-400">Willkommen zurück</p>
+				<p class="text-lg font-semibold text-slate-900">{{ username }}</p>
+				<div class="mt-2 flex items-center gap-2 text-xs text-slate-500">
+				  <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1">
+					<i data-feather="activity" class="w-3 h-3"></i>
+					Live-Übersicht
+				  </span>
+				  <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1">
+					<i data-feather="clock" class="w-3 h-3"></i>
+					<span x-text="new Date().toLocaleDateString('de-DE')"></span>
+				  </span>
+				</div>
+			  </div>
 
-			  <div class="space-y-2">
+			  <div class="space-y-3">
 
 				<!-- Kategorien-Accordion -->
-				<div class="border border-gray-200 rounded-lg overflow-hidden">
+				<div class="border border-slate-200 rounded-2xl overflow-hidden shadow-sm bg-white">
 				  <div @click="categoriesOpen = !categoriesOpen"
-					   class="flex items-center justify-between px-4 py-3 bg-white hover:bg-gray-100 cursor-pointer transition-colors">
+					   class="flex items-center justify-between px-4 py-3 bg-white hover:bg-slate-50 cursor-pointer transition-colors">
 					<div class="flex items-center space-x-3">
-					  <i data-feather="layers" class="w-4 h-4 text-gray-500"></i>
-					  <span class="text-sm font-medium text-gray-800">Kategorien</span>
+					  <span class="flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-600">
+						<i data-feather="layers" class="w-4 h-4"></i>
+					  </span>
+					  <span class="text-sm font-semibold text-slate-800">Kategorien</span>
 					</div>
 					<svg :class="{ 'rotate-180': categoriesOpen }"
-						 class="w-4 h-4 text-gray-500 transition-transform duration-200"
+						 class="w-4 h-4 text-slate-500 transition-transform duration-200"
 						 fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
 							d="M19 9l-7 7-7-7"/>
@@ -134,22 +155,22 @@
 
 				  <!-- Alle Kategorien im Dropdown -->
 				  <div x-show="categoriesOpen" x-transition
-					   class="bg-gray-50 px-2 py-2 space-y-1 text-sm text-gray-800">
+					   class="bg-slate-50 px-2 py-2 space-y-1 text-sm text-slate-800">
 
 					<template x-for="category in categories" :key="category.id">
-					  <div class="group flex items-center justify-between px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors">
+					  <div class="group flex items-center justify-between px-3 py-2 rounded-xl hover:bg-white transition-colors">
 						<button @click="loadDevices(category.id)" class="flex items-center space-x-2 flex-1 text-left">
 						  <!-- Dynamisches Icon -->
-						  <div x-html="feather.icons[category.icon]?.toSvg({ class: 'w-4 h-4 text-gray-500' })"></div>
+						  <div x-html="feather.icons[category.icon]?.toSvg({ class: 'w-4 h-4 text-slate-500' })"></div>
 						  <span x-text="category.name"></span>
 						</button>
 						<div class="flex items-center space-x-2">
 						  <button @click="editCategoryModal(category)"
-								  class="text-gray-500 hover:text-black">
+								  class="text-slate-500 hover:text-slate-900">
 							<i data-feather="edit" class="w-4 h-4"></i>
 						  </button>
 						  <button @click="deleteCategory(category.id)"
-								  class="text-red-500 hover:text-red-700">
+								  class="text-rose-500 hover:text-rose-700">
 							<i data-feather="trash-2" class="w-4 h-4"></i>
 						  </button>
 						</div>
@@ -157,7 +178,7 @@
 					</template>
 					<!-- Kategorie hinzufügen -->
 					<button @click="openAddCategoryModal()"
-							class="flex justify-center items-center px-4 py-3 text-sm font-medium text-blue-600 hover:text-blue-800 w-full rounded-lg hover:bg-gray-50 transition-colors">
+							class="flex justify-center items-center px-4 py-3 text-sm font-medium text-blue-600 hover:text-blue-800 w-full rounded-xl hover:bg-white transition-colors">
 					  <i data-feather="plus-circle" class="w-4 h-4 mr-2"></i>
 					</button>
 				  </div>
@@ -165,15 +186,22 @@
 
 				<!-- Statistiken -->
 				<a href="https://inv.pondsec.com/stats"
-				   class="flex items-center px-4 py-3 text-sm font-medium text-gray-700 hover:text-black w-full rounded-lg hover:bg-gray-50 transition-colors">
-				  <i data-feather="bar-chart-2" class="w-5 h-5 mr-3"></i>
-				  <span>Statistiken</span>
+				   class="flex items-center justify-between px-4 py-3 text-sm font-semibold text-slate-700 hover:text-slate-900 w-full rounded-2xl hover:bg-white transition-colors border border-slate-200 bg-white/70 shadow-sm">
+				  <span class="flex items-center">
+					<span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-indigo-50 text-indigo-600 mr-3">
+					  <i data-feather="bar-chart-2" class="w-4 h-4"></i>
+					</span>
+					Statistiken
+				  </span>
+				  <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
 				</a>
 				
 				<!-- OTP Setup Button -->
 				<button @click="setupOTP()"
-						class="flex items-center px-4 py-3 text-sm font-medium text-green-600 hover:text-green-800 w-full rounded-lg hover:bg-gray-50 transition-colors mt-4">
-				  <i data-feather="shield" class="w-5 h-5 mr-3"></i>
+						class="flex items-center px-4 py-3 text-sm font-semibold text-emerald-600 hover:text-emerald-800 w-full rounded-2xl hover:bg-white transition-colors border border-emerald-100 bg-emerald-50/70 mt-4">
+				  <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-emerald-100 text-emerald-600 mr-3">
+					<i data-feather="shield" class="w-4 h-4"></i>
+				  </span>
 				  <span>2FA Einrichten</span>
 				  <span x-show="otpEnabled" class="ml-2 text-green-500">
 					<i data-feather="check-circle" class="w-4 h-4"></i>
@@ -183,8 +211,11 @@
 				  </span>
 				</button>
 				
-				<a href="/reset" class="block px-4 py-2 rounded hover:bg-gray-100">
-				  <i data-feather="lock" class="inline mr-2 w-4 h-4"></i> Passwort setzen
+				<a href="/reset" class="flex items-center px-4 py-3 text-sm font-semibold text-slate-600 hover:text-slate-900 w-full rounded-2xl hover:bg-white transition-colors border border-slate-200 bg-white/50">
+				  <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+					<i data-feather="lock" class="w-4 h-4"></i>
+				  </span>
+				  Passwort setzen
 				</a>
 
 			  </div>
@@ -228,24 +259,22 @@
         
         <!-- Main Content -->
         <div class="main-content">
-			<header class="app-header bg-white border-b border-gray-200 px-6 flex justify-between items-center fixed top-0 left-[240px] z-30 h-[77px]" style="width: calc(100% - 240px);">
+			<header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 left-[280px] z-30 h-[82px]" style="width: calc(100% - 280px);">
 				<!-- Linke Seite: Titel -->
-				<h1 class="text-2xl font-semibold" x-text="activeCategory ? getCategoryName(activeCategory) : 'All Devices'"></h1>
+				<div>
+					<p class="text-xs uppercase tracking-[0.2em] text-slate-400">Dashboard</p>
+					<h1 class="text-2xl font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h1>
+				</div>
 
 				<!-- Rechte Seite: Button-Gruppe -->
-				<div class="flex items-center space-x-4">
-				  <!-- Add Device Button im Logout-Style -->
-				  <button @click="openAddDeviceModal()" class="text-red-600 hover:text-red-800 flex items-center">
-					<i data-feather="plus" class="w-5 h-5 mr-2"></i>
-					<span>Add Device</span>
+				<div class="flex items-center space-x-3">
+				  <button @click="openAddDeviceModal()" class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-blue-200 hover:from-blue-500 hover:to-indigo-500">
+					<i data-feather="plus" class="w-4 h-4"></i>
+					<span>Neues Gerät</span>
 				  </button>
 
-				  <!-- Trennlinie -->
-				  <div class="h-5 w-px bg-gray-300"></div>
-
-				  <!-- Logout Button -->
-				  <button onclick="logout()" class="text-red-600 hover:text-red-800 flex items-center">
-					<i data-feather="log-out" class="w-5 h-5 mr-2"></i>
+				  <button onclick="logout()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+					<i data-feather="log-out" class="w-4 h-4"></i>
 					Abmelden
 				  </button>
 				</div>
@@ -273,77 +302,215 @@
 				</script>
 			</header>
 
-            <main class="p-6 mt-16">
-				<div class="mb-6 w-full max-w-md mx-auto">
-				  <div class="relative w-full">
-					<input 
-					  type="text" 
-					  placeholder="Search devices..." 
-					  class="w-full pl-10 pr-12 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
-					  x-model="searchQuery" @input.debounce.300ms="searchDevices()"
-					>
-					
-
-					<button 
-					  @click="toggleSortDropdown()" 
-					  aria-label="Sort options"
-					  class="absolute right-1 top-1/2 transform -translate-y-1/2 px-3 py-1.5 bg-white border border-gray-300 rounded-md text-gray-700 shadow-sm hover:bg-gray-50 active:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 transition-all duration-200 ease-in-out flex items-center gap-1"
-					>
-
-					  <i data-feather="filter" class="w-4 h-4"></i>
-					</button>
-
-					<div 
-					  x-show="sortDropdownOpen" 
-					  @click.away="sortDropdownOpen = false"
-					  class="absolute right-0 mt-10 w-52 rounded-xl bg-white border border-gray-200 shadow-lg z-50 overflow-hidden transition-all duration-200"
-					  style="display: none;"
-					  x-transition
-					>
-					  <div class="divide-y divide-gray-100">
-						<a href="#" @click.prevent="sortDevices('name', 'asc')"
-						   class="block px-5 py-3 text-sm text-gray-800 hover:bg-gray-50 hover:text-black transition-colors duration-150">
-						  Name (A–Z)
-						</a>
-						<a href="#" @click.prevent="sortDevices('name', 'desc')"
-						   class="block px-5 py-3 text-sm text-gray-800 hover:bg-gray-50 hover:text-black transition-colors duration-150">
-						  Name (Z–A)
-						</a>
-						<a href="#" @click.prevent="sortDevices('serial_number', 'asc')"
-						   class="block px-5 py-3 text-sm text-gray-800 hover:bg-gray-50 hover:text-black transition-colors duration-150">
-						  Owner (aufsteigend)
-						</a>
-						<a href="#" @click.prevent="sortDevices('serial_number', 'desc')"
-						   class="block px-5 py-3 text-sm text-gray-800 hover:bg-gray-50 hover:text-black transition-colors duration-150">
-						  Owner (absteigend)
-						</a>
-					  </div>
+            <main class="p-8 mt-20 space-y-8">
+				<section class="rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-indigo-900 px-8 py-10 text-white shadow-2xl shadow-slate-300/50">
+					<div class="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+						<div>
+							<p class="text-sm uppercase tracking-[0.3em] text-slate-300">Inventory Pro</p>
+							<h2 class="mt-2 text-3xl font-semibold leading-tight">Dein smarter Überblick über Assets, Geräte &amp; Kategorien.</h2>
+							<p class="mt-3 max-w-xl text-slate-200">Verfolge Bestände in Echtzeit, behalte Verantwortlichkeiten im Blick und finde Geräte in Sekunden.</p>
+							<div class="mt-6 flex flex-wrap gap-3">
+								<button @click="openAddDeviceModal()" class="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-md hover:bg-slate-100">
+									<i data-feather="plus" class="w-4 h-4"></i>
+									Gerät hinzufügen
+								</button>
+								<button @click="openAddCategoryModal()" class="inline-flex items-center gap-2 rounded-full border border-white/30 px-4 py-2 text-sm font-semibold text-white/90 hover:bg-white/10">
+									<i data-feather="folder-plus" class="w-4 h-4"></i>
+									Kategorie anlegen
+								</button>
+								<a href="/stats" class="inline-flex items-center gap-2 rounded-full border border-white/30 px-4 py-2 text-sm font-semibold text-white/90 hover:bg-white/10">
+									<i data-feather="bar-chart-2" class="w-4 h-4"></i>
+									Dashboard öffnen
+								</a>
+							</div>
+						</div>
+						<div class="grid w-full max-w-sm grid-cols-2 gap-4">
+							<div class="rounded-2xl bg-white/10 p-4 backdrop-blur">
+								<p class="text-xs uppercase tracking-widest text-slate-300">Geräte</p>
+								<p class="mt-2 text-2xl font-semibold" x-text="devices.length"></p>
+								<p class="text-xs text-slate-300">Gesamt im System</p>
+							</div>
+							<div class="rounded-2xl bg-white/10 p-4 backdrop-blur">
+								<p class="text-xs uppercase tracking-widest text-slate-300">Kategorien</p>
+								<p class="mt-2 text-2xl font-semibold" x-text="categories.length"></p>
+								<p class="text-xs text-slate-300">Aktiv gepflegt</p>
+							</div>
+							<div class="rounded-2xl bg-white/10 p-4 backdrop-blur">
+								<p class="text-xs uppercase tracking-widest text-slate-300">Treffer</p>
+								<p class="mt-2 text-2xl font-semibold" x-text="filteredDevices.length"></p>
+								<p class="text-xs text-slate-300">Aktuell gefiltert</p>
+							</div>
+							<div class="rounded-2xl bg-white/10 p-4 backdrop-blur">
+								<p class="text-xs uppercase tracking-widest text-slate-300">Kategorie</p>
+								<p class="mt-2 text-lg font-semibold" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle'"></p>
+								<p class="text-xs text-slate-300">Aktiver Fokus</p>
+							</div>
+						</div>
 					</div>
-				  </div>
-				</div>
+				</section>
+
+				<section class="grid gap-4 lg:grid-cols-4">
+					<div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+						<div class="flex items-center justify-between">
+							<div>
+								<p class="text-sm font-semibold text-slate-900">Geräte durchsuchen</p>
+								<p class="text-xs text-slate-500">Schneller Zugriff auf Assets</p>
+							</div>
+							<span class="inline-flex items-center justify-center rounded-full bg-blue-50 p-2 text-blue-500">
+								<i data-feather="search" class="h-4 w-4"></i>
+							</span>
+						</div>
+						<div class="mt-4">
+							<div class="relative w-full">
+								<input 
+								  type="text" 
+								  placeholder="Gerät, Besitzer oder Spezifikation suchen..." 
+								  class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 pr-12 text-sm text-slate-700 shadow-inner focus:border-blue-500 focus:ring-blue-500"
+								  x-model="searchQuery" @input.debounce.300ms="searchDevices()"
+								>
+								<button 
+								  @click="toggleSortDropdown()" 
+								  aria-label="Sort options"
+								  class="absolute right-2 top-1/2 -translate-y-1/2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-slate-600 shadow-sm hover:bg-slate-50"
+								>
+								  <i data-feather="filter" class="w-4 h-4"></i>
+								</button>
+
+								<div 
+								  x-show="sortDropdownOpen" 
+								  @click.away="sortDropdownOpen = false"
+								  class="absolute right-0 mt-3 w-56 rounded-2xl bg-white border border-slate-200 shadow-xl z-50 overflow-hidden"
+								  style="display: none;"
+								  x-transition
+								>
+								  <div class="divide-y divide-slate-100">
+									<a href="#" @click.prevent="sortDevices('name', 'asc')"
+									   class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">
+									  Name (A–Z)
+									</a>
+									<a href="#" @click.prevent="sortDevices('name', 'desc')"
+									   class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">
+									  Name (Z–A)
+									</a>
+									<a href="#" @click.prevent="sortDevices('serial_number', 'asc')"
+									   class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">
+									  Owner (aufsteigend)
+									</a>
+									<a href="#" @click.prevent="sortDevices('serial_number', 'desc')"
+									   class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">
+									  Owner (absteigend)
+									</a>
+								  </div>
+								</div>
+							  </div>
+						</div>
+					</div>
+					<div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+						<div class="flex items-center justify-between">
+							<div>
+								<p class="text-sm font-semibold text-slate-900">Insights</p>
+								<p class="text-xs text-slate-500">Letzte Aktivität</p>
+							</div>
+							<span class="inline-flex items-center justify-center rounded-full bg-indigo-50 p-2 text-indigo-500">
+								<i data-feather="activity" class="h-4 w-4"></i>
+							</span>
+						</div>
+						<div class="mt-4 space-y-3 text-sm text-slate-600">
+							<div class="flex items-center justify-between">
+								<span>Aktive Kategorie</span>
+								<span class="font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></span>
+							</div>
+							<div class="flex items-center justify-between">
+								<span>Geräte im Fokus</span>
+								<span class="font-semibold text-slate-900" x-text="filteredDevices.length"></span>
+							</div>
+							<div class="flex items-center justify-between">
+								<span>Wartungen (Pro)</span>
+								<span class="font-semibold text-slate-900" x-text="maintenanceSummary.pro_locked ? 'Gesperrt' : maintenanceSummary.open"></span>
+							</div>
+							<div class="flex items-center justify-between">
+								<span>Überfällig</span>
+								<span class="font-semibold text-rose-600" x-text="maintenanceSummary.pro_locked ? '-' : maintenanceSummary.overdue"></span>
+							</div>
+							<div class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-500">
+								<i data-feather="lock" class="w-3 h-3"></i>
+								<span x-show="maintenanceSummary.pro_locked">Upgrade für Wartungen</span>
+								<span x-show="!maintenanceSummary.pro_locked">Pro aktiv</span>
+							</div>
+						</div>
+					</div>
+					<div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+						<div class="flex items-center justify-between">
+							<div>
+								<p class="text-sm font-semibold text-slate-900">Schnellaktionen</p>
+								<p class="text-xs text-slate-500">Arbeitsabläufe beschleunigen</p>
+							</div>
+							<span class="inline-flex items-center justify-center rounded-full bg-emerald-50 p-2 text-emerald-500">
+								<i data-feather="zap" class="h-4 w-4"></i>
+							</span>
+						</div>
+						<div class="mt-4 space-y-3">
+							<button @click="openAddDeviceModal()" class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">
+								Gerät hinzufügen
+							</button>
+							<button @click="openAddCategoryModal()" class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">
+								Kategorie erstellen
+							</button>
+							<a href="/stats" class="block w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">
+								Statistiken ansehen
+							</a>
+							<a href="/api/export/devices" class="block w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">
+								Export (Pro)
+							</a>
+						</div>
+					</div>
+					<div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+						<div class="flex items-center justify-between">
+							<div>
+								<p class="text-sm font-semibold text-slate-900">Aktivitäten</p>
+								<p class="text-xs text-slate-500">Letzte Änderungen im System</p>
+							</div>
+							<span class="inline-flex items-center justify-center rounded-full bg-slate-100 p-2 text-slate-500">
+								<i data-feather="list" class="h-4 w-4"></i>
+							</span>
+						</div>
+						<div class="mt-4 space-y-3 text-sm text-slate-600">
+							<template x-for="item in activityFeed" :key="item.created_at">
+								<div class="flex items-start justify-between gap-2">
+									<span class="font-semibold text-slate-800" x-text="formatActivity(item)"></span>
+									<span class="text-xs text-slate-400" x-text="item.created_at.slice(11, 16)"></span>
+								</div>
+							</template>
+							<p x-show="activityFeed.length === 0" class="text-xs text-slate-400">Noch keine Aktivitäten.</p>
+						</div>
+					</div>
+				</section>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
                     <template x-for="device in filteredDevices" :key="device.id">
 
-						<div class="device-card bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden transition-all hover:shadow-md">
+						<div class="device-card bg-white rounded-2xl shadow-sm border border-slate-200 overflow-hidden transition-all hover:shadow-lg hover:-translate-y-0.5">
 							<div class="p-5">
 								<div class="flex justify-between items-start">
 									<div>
-										<span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
+										<span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide"
 											:class="getCategoryColor(device.category_name)">
 											<span x-text="device.category_name"></span>
 										</span>
-										<h3 class="mt-2 text-lg font-medium text-gray-900" x-text="device.name"></h3>
+										<h3 class="mt-3 text-lg font-semibold text-slate-900" x-text="device.name"></h3>
 									</div>
-									<div class="flex items-center space-x-2 text-gray-600 hover:text-black">
-										<button @click="openEditDeviceModal(device)" class="p-1 hover:bg-gray-100 rounded">
+									<div class="flex items-center space-x-2 text-slate-500 hover:text-slate-900">
+										<button @click="openEditDeviceModal(device)" class="p-2 hover:bg-slate-100 rounded-xl">
 											<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
 													d="M15.232 5.232l3.536 3.536M4 20h4l10-10-4-4L4 16v4z" />
 											</svg>
 										</button>
-										<button @click="deleteDevice(device.id)" class="p-1 hover:bg-red-100 rounded">
-											<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<button @click="openDeviceDetail(device)" class="p-2 hover:bg-blue-100 rounded-xl text-blue-600">
+											<i data-feather="info" class="w-5 h-5"></i>
+										</button>
+										<button @click="deleteDevice(device.id)" class="p-2 hover:bg-rose-100 rounded-xl">
+											<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-rose-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
 													d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22" />
 											</svg>
@@ -351,18 +518,18 @@
 									</div>
 								</div>
 								
-								<div class="mt-4 space-y-2">
+								<div class="mt-4 space-y-2 rounded-2xl bg-slate-50 p-3">
 									<template x-if="device.serial_number">
 										<div class="flex justify-between text-sm">
-											<span class="text-gray-500">Owner</span>
-											<span class="font-medium" x-text="device.serial_number"></span>
+											<span class="text-slate-500">Owner</span>
+											<span class="font-semibold text-slate-800" x-text="device.serial_number"></span>
 										</div>
 									</template>
 									
 									<template x-for="(value, key) in JSON.parse(device.specs || '{}')" :key="key">
 										<div class="flex justify-between text-sm">
-											<span class="text-gray-500" x-text="key"></span>
-											<span class="font-medium" x-text="value"></span>
+											<span class="text-slate-500" x-text="key"></span>
+											<span class="font-semibold text-slate-800" x-text="value"></span>
 										</div>
 									</template>
 								</div>
@@ -376,9 +543,143 @@
                 </div>
             </main>
         </div>
-		</div>
-		
-		<!-- Add/Edit Category Modal -->
+			</div>
+
+			<!-- Device Detail Modal -->
+			<div x-show="deviceDetailOpen" @click.away="closeDeviceDetail()"
+				 class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-6"
+				 x-transition>
+				<div class="bg-white rounded-3xl shadow-2xl w-full max-w-4xl overflow-hidden">
+					<div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+						<div>
+							<p class="text-xs uppercase tracking-[0.2em] text-slate-400">Geräteübersicht</p>
+							<h3 class="text-xl font-semibold text-slate-900" x-text="selectedDevice?.name"></h3>
+						</div>
+						<button @click="closeDeviceDetail()" class="text-slate-400 hover:text-slate-600">
+							<i data-feather="x" class="w-6 h-6"></i>
+						</button>
+					</div>
+					<div class="grid gap-6 p-6 lg:grid-cols-3">
+						<div class="lg:col-span-2 space-y-6">
+							<div class="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+								<p class="text-sm font-semibold text-slate-700">Kurzprofil</p>
+								<div class="mt-3 grid gap-2 text-sm text-slate-600">
+									<div class="flex justify-between">
+										<span>Kategorie</span>
+										<span class="font-semibold text-slate-900" x-text="selectedDevice?.category_name"></span>
+									</div>
+									<div class="flex justify-between">
+										<span>Owner</span>
+										<span class="font-semibold text-slate-900" x-text="selectedDevice?.serial_number || '-'"></span>
+									</div>
+									<div class="flex justify-between">
+										<span>Erstellt</span>
+										<span class="font-semibold text-slate-900" x-text="selectedDevice?.created_at?.slice(0, 10) || '-'"></span>
+									</div>
+								</div>
+							</div>
+
+							<div class="rounded-2xl border border-slate-200 bg-white p-4">
+								<div class="flex items-center justify-between">
+									<div>
+										<p class="text-sm font-semibold text-slate-900">Notizen</p>
+										<p class="text-xs text-slate-500">Freigabe für alle Nutzer</p>
+									</div>
+									<i data-feather="file-text" class="w-4 h-4 text-slate-400"></i>
+								</div>
+								<div class="mt-3 flex gap-2">
+									<input type="text" placeholder="Neue Notiz hinzufügen" x-model="newNote"
+										   class="flex-1 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-blue-500 focus:ring-blue-500">
+									<button @click="addNote()" class="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">Speichern</button>
+								</div>
+								<div class="mt-4 space-y-3">
+									<template x-for="note in deviceNotes" :key="note.id">
+										<div class="flex items-start justify-between rounded-2xl border border-slate-100 bg-slate-50 px-3 py-2">
+											<div>
+												<p class="text-sm text-slate-700" x-text="note.note"></p>
+												<p class="text-xs text-slate-400" x-text="note.created_at.slice(0, 10)"></p>
+											</div>
+											<button @click="deleteNote(note.id)" class="text-slate-400 hover:text-rose-500">
+												<i data-feather="trash-2" class="w-4 h-4"></i>
+											</button>
+										</div>
+									</template>
+									<p x-show="deviceNotes.length === 0" class="text-xs text-slate-400">Noch keine Notizen.</p>
+								</div>
+							</div>
+						</div>
+
+						<div class="space-y-6">
+							<div class="rounded-2xl border border-slate-200 bg-white p-4">
+								<div class="flex items-center justify-between">
+									<div>
+										<p class="text-sm font-semibold text-slate-900">Tags</p>
+										<p class="text-xs text-slate-500">Freie Labels für Ordnung</p>
+									</div>
+									<i data-feather="tag" class="w-4 h-4 text-slate-400"></i>
+								</div>
+								<div class="mt-3 flex gap-2">
+									<input type="text" placeholder="Tag hinzufügen" x-model="newTag"
+										   class="flex-1 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-blue-500 focus:ring-blue-500">
+									<button @click="addTag()" class="rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50">Add</button>
+								</div>
+								<div class="mt-4 flex flex-wrap gap-2">
+									<template x-for="tag in deviceTags" :key="tag.id">
+										<span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+											<span x-text="tag.tag"></span>
+											<button @click="removeTag(tag.id)" class="text-slate-400 hover:text-rose-500">
+												<i data-feather="x" class="w-3 h-3"></i>
+											</button>
+										</span>
+									</template>
+									<p x-show="deviceTags.length === 0" class="text-xs text-slate-400">Noch keine Tags.</p>
+								</div>
+							</div>
+
+							<div class="rounded-2xl border border-indigo-100 bg-indigo-50/60 p-4">
+								<div class="flex items-center justify-between">
+									<div>
+										<p class="text-sm font-semibold text-indigo-700">Wartungsplan (Pro)</p>
+										<p class="text-xs text-indigo-500">Erinnerungen &amp; Checklisten</p>
+									</div>
+									<i data-feather="shield" class="w-4 h-4 text-indigo-400"></i>
+								</div>
+								<div class="mt-3 space-y-3" :class="maintenanceSummary.pro_locked ? 'opacity-60' : ''">
+									<div class="flex gap-2">
+										<input type="text" placeholder="Wartungstitel" x-model="newMaintenance.title"
+											   class="flex-1 rounded-2xl border border-indigo-100 bg-white px-3 py-2 text-sm focus:border-indigo-400 focus:ring-indigo-400">
+									</div>
+									<div class="flex gap-2">
+										<input type="date" x-model="newMaintenance.due_date"
+											   class="flex-1 rounded-2xl border border-indigo-100 bg-white px-3 py-2 text-sm focus:border-indigo-400 focus:ring-indigo-400">
+										<button @click="addMaintenanceTask()" class="rounded-2xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500">
+											Planen
+										</button>
+									</div>
+								</div>
+								<div class="mt-4 space-y-3">
+									<template x-for="task in maintenanceTasks" :key="task.id">
+										<div class="flex items-start justify-between rounded-2xl border border-indigo-100 bg-white px-3 py-2 text-sm">
+											<div>
+												<p class="font-semibold text-slate-800" x-text="task.title"></p>
+												<p class="text-xs text-slate-400" x-text="task.due_date ? `Fällig: ${task.due_date}` : 'Kein Datum'"></p>
+											</div>
+											<button @click="updateMaintenanceStatus(task.id, task.status === 'open' ? 'done' : 'open')"
+													class="text-xs font-semibold text-indigo-600">
+												<span x-text="task.status === 'open' ? 'Erledigt' : 'Offen'"></span>
+											</button>
+										</div>
+									</template>
+									<p x-show="maintenanceSummary.pro_locked" class="text-xs text-indigo-500">Pro-Funktion aktivieren, um Wartungen zu planen.</p>
+									<p x-show="!maintenanceSummary.pro_locked && maintenanceTasks.length === 0" class="text-xs text-slate-400">Keine Wartungen geplant.</p>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			
+			<!-- Add/Edit Category Modal -->
 		<div x-show="isCategoryModalOpen" @click.away="closeCategoryModal()"
 			 class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 animate__animated"
 			 :class="{'animate__fadeIn': isCategoryModalOpen}"

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -9,49 +9,69 @@
     <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
     <style>
         .stat-card:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+            transform: translateY(-4px);
+            box-shadow: 0 18px 30px -12px rgba(15, 23, 42, 0.25);
         }
         .progress-bar {
             height: 6px;
-            border-radius: 3px;
+            border-radius: 999px;
         }
     </style>
 </head>
-<body class="bg-gray-50">
+<body class="bg-slate-950/5 text-slate-900">
     <div class="flex h-screen">
 	
 	
         <!-- Sidebar -->
-        <div class="w-64 bg-white border-r border-gray-200">
-            <div class="sidebar-header p-6 border-b border-gray-200">
+        <div class="w-[280px] bg-white/90 backdrop-blur-xl border-r border-slate-200 shadow-sm">
+            <div class="sidebar-header p-6 border-b border-slate-200">
                 <a href="https://inv.pondsec.com">
                 <div class="logo flex items-center space-x-3">
-                    <i data-feather="cpu" class="text-black w-6 h-6"></i>
-                    <span class="text-xl font-semibold">Inventory Pro</span>
+                    <span class="inline-flex items-center justify-center w-10 h-10 rounded-2xl bg-gradient-to-br from-blue-500 via-indigo-500 to-purple-500 text-white shadow-lg">
+                        <i data-feather="cpu" class="w-5 h-5"></i>
+                    </span>
+                    <div>
+                        <p class="text-lg font-semibold text-slate-900">Inventory Pro</p>
+                        <p class="text-xs text-slate-500">Smart Asset Hub</p>
+                    </div>
                 </div>
                 </a>
             </div>
-            <nav class="p-4 space-y-2">
-                <a href="/" class="block px-4 py-2 rounded hover:bg-gray-100">
-                    <i data-feather="layers" class="inline mr-2 w-4 h-4"></i> Kategorien
+            <nav class="p-4 space-y-3">
+                <a href="/" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+                            <i data-feather="layers" class="w-4 h-4"></i>
+                        </span>
+                        Kategorien
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
                 </a>
-				<a href="/stats" class="block px-4 py-2 bg-blue-50 text-blue-600 rounded">
-                    <i data-feather="bar-chart-2" class="inline mr-2 w-4 h-4"></i> Statistiken
+				<a href="/stats" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-indigo-100 bg-indigo-50 text-sm font-semibold text-indigo-700">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-indigo-100 text-indigo-600 mr-3">
+                            <i data-feather="bar-chart-2" class="w-4 h-4"></i>
+                        </span>
+                        Statistiken
+                    </span>
+                    <i data-feather="trending-up" class="w-4 h-4 text-indigo-400"></i>
                 </a>
             </nav>
         </div>
 		
-		<header class="app-header bg-white border-b border-gray-200 px-6 flex justify-between items-center fixed top-0 left-[240px] z-30 h-[77px]" style="width: calc(100% - 240px);">
+		<header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 left-[280px] z-30 h-[82px]" style="width: calc(100% - 280px);">
 			<!-- Linke Seite: Titel -->
-			<h1 class="text-2xl font-semibold" x-text="activeCategory ? getCategoryName(activeCategory) : 'All Devices'"></h1>
+			<div>
+                <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Analytics</p>
+			    <h1 class="text-2xl font-semibold text-slate-900">Bestandsstatistiken</h1>
+            </div>
 
 			<!-- Rechte Seite: Button-Gruppe -->
 			<div class="flex items-center space-x-4">
 
 			  <!-- Logout Button -->
-			  <button onclick="logout()" class="text-red-600 hover:text-red-800 flex items-center">
-				<i data-feather="log-out" class="w-5 h-5 mr-2"></i>
+			  <button onclick="logout()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+				<i data-feather="log-out" class="w-4 h-4"></i>
 				Abmelden
 			  </button>
 			</div>
@@ -80,58 +100,113 @@
 		</header>
 		
         <!-- Main Content -->
-        <div class="flex-1 overflow-auto p-8">
-            <h1 class="text-3xl font-bold text-gray-800 mb-6">Bestandsstatistiken</h1>
-            
+        <div class="flex-1 overflow-auto p-8 pt-24 space-y-8">
+            <section class="rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-indigo-900 px-8 py-10 text-white shadow-2xl shadow-slate-300/50">
+                <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                    <div>
+                        <p class="text-xs uppercase tracking-[0.3em] text-slate-300">Analytics</p>
+                        <h1 class="mt-2 text-3xl font-semibold">Bestandsstatistiken auf einen Blick</h1>
+                        <p class="mt-3 max-w-xl text-slate-200">Entscheidungsrelevante KPIs, Verteilungen und Trendübersichten in einer konsistenten Übersicht.</p>
+                    </div>
+                    <div class="grid grid-cols-2 gap-4">
+                        <div class="rounded-2xl bg-white/10 p-4">
+                            <p class="text-xs uppercase tracking-widest text-slate-300">Geräte</p>
+                            <p class="mt-2 text-2xl font-semibold">{{ total_devices }}</p>
+                            <p class="text-xs text-slate-300">Gesamtbestand</p>
+                        </div>
+                        <div class="rounded-2xl bg-white/10 p-4">
+                            <p class="text-xs uppercase tracking-widest text-slate-300">Kategorien</p>
+                            <p class="mt-2 text-2xl font-semibold">{{ total_categories }}</p>
+                            <p class="text-xs text-slate-300">Aktive Bereiche</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
             <!-- Statistik-Karten -->
-			<div class="grid grid-cols-4 gap-4 mb-8">
-				<!-- Gesamtgeräte -->
-				<div class="bg-white p-6 rounded-lg shadow">
-					<h3 class="text-gray-500">Gesamtgeräte</h3>
-					<p class="text-3xl font-bold">{{ total_devices }}</p>
+			<div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+				<div class="stat-card bg-white p-6 rounded-2xl border border-slate-200 shadow-sm transition">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <h3 class="text-sm font-semibold text-slate-500">Gesamtgeräte</h3>
+                            <p class="mt-2 text-3xl font-semibold text-slate-900">{{ total_devices }}</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-blue-50 p-3 text-blue-600">
+                            <i data-feather="box" class="h-5 w-5"></i>
+                        </span>
+                    </div>
 				</div>
 				
-				<!-- Kategorien -->
-				<div class="bg-white p-6 rounded-lg shadow">
-					<h3 class="text-gray-500">Kategorien</h3>
-					<p class="text-3xl font-bold">{{ total_categories }}</p>
+				<div class="stat-card bg-white p-6 rounded-2xl border border-slate-200 shadow-sm transition">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <h3 class="text-sm font-semibold text-slate-500">Kategorien</h3>
+                            <p class="mt-2 text-3xl font-semibold text-slate-900">{{ total_categories }}</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-indigo-50 p-3 text-indigo-600">
+                            <i data-feather="layers" class="h-5 w-5"></i>
+                        </span>
+                    </div>
 				</div>
 				
-				<!-- Aktiv-Status -->
-				<div class="bg-white p-6 rounded-lg shadow">
-					<h3 class="text-gray-500">Verwendet</h3>
-					<p class="text-3xl font-bold">{{ status_data['Verwendet'] }}</p>
+				<div class="stat-card bg-white p-6 rounded-2xl border border-slate-200 shadow-sm transition">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <h3 class="text-sm font-semibold text-slate-500">Verwendet</h3>
+                            <p class="mt-2 text-3xl font-semibold text-slate-900">{{ status_data['Verwendet'] }}</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-emerald-50 p-3 text-emerald-600">
+                            <i data-feather="check-circle" class="h-5 w-5"></i>
+                        </span>
+                    </div>
 				</div>
 				
-				<!-- In Wartung -->
-				<div class="bg-white p-6 rounded-lg shadow">
-					<h3 class="text-gray-500">Lager</h3>
-					<p class="text-3xl font-bold">{{ status_data['Lager'] }}</p>
+				<div class="stat-card bg-white p-6 rounded-2xl border border-slate-200 shadow-sm transition">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <h3 class="text-sm font-semibold text-slate-500">Lager</h3>
+                            <p class="mt-2 text-3xl font-semibold text-slate-900">{{ status_data['Lager'] }}</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-amber-50 p-3 text-amber-600">
+                            <i data-feather="archive" class="h-5 w-5"></i>
+                        </span>
+                    </div>
 				</div>
 			</div>
 
 			<!-- Kategorieverteilung Chart -->
-			<div class="bg-white p-6 rounded-lg shadow mb-8">
-				<h2 class="text-xl font-semibold mb-4">Verteilung nach Kategorien</h2>
-				<div class="grid grid-cols-2 gap-4">
+			<div class="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm">
+				<div class="flex items-center justify-between mb-4">
+                    <div>
+                        <h2 class="text-xl font-semibold text-slate-900">Verteilung nach Kategorien</h2>
+                        <p class="text-sm text-slate-500">Welche Bereiche aktuell dominieren.</p>
+                    </div>
+                    <span class="inline-flex items-center justify-center rounded-2xl bg-slate-100 p-2 text-slate-500">
+                        <i data-feather="pie-chart" class="h-4 w-4"></i>
+                    </span>
+                </div>
+				<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 					{% for category in categories %}
-					<div class="flex items-center">
-						<div class="w-4 h-4 rounded-full mr-2" 
+					<div class="flex items-center rounded-2xl border border-slate-100 bg-slate-50 px-4 py-3">
+						<div class="w-3 h-3 rounded-full mr-3" 
 							 style="background-color: {{ loop.cycle('#3B82F6', '#10B981', '#6366F1', '#F59E0B') }}"></div>
-						<span>{{ category['name'] }}</span>
-						<span class="ml-auto font-medium">{{ category['device_count'] }}</span>
+						<span class="text-sm text-slate-700">{{ category['name'] }}</span>
+						<span class="ml-auto text-sm font-semibold text-slate-900">{{ category['device_count'] }}</span>
 					</div>
 					{% endfor %}
 				</div>
 			</div>
 			
 			<!-- Charts Section -->
-            <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 <!-- Kategorieverteilung -->
-                <div class="bg-white p-6 rounded-lg shadow">
+                <div class="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm">
                     <div class="flex justify-between items-center mb-4">
-                        <h2 class="text-xl font-semibold">Verteilung nach Kategorien</h2>
-                        <select x-model="chartTimeRange" class="border rounded px-2 py-1 text-sm">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-900">Verteilung nach Kategorien</h2>
+                            <p class="text-sm text-slate-500">Auswertung nach Zeitraum filtern.</p>
+                        </div>
+                        <select x-model="chartTimeRange" class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">
                             <option value="all">Alle</option>
                             <option value="month">Letzter Monat</option>
                             <option value="week">Letzte Woche</option>
@@ -141,35 +216,46 @@
                 </div>
                 
                 <!-- Statusverteilung -->
-                <div class="bg-white p-6 rounded-lg shadow">
-                    <h2 class="text-xl font-semibold mb-4">Gerätestatus</h2>
+                <div class="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm">
+                    <h2 class="text-xl font-semibold text-slate-900 mb-2">Gerätestatus</h2>
+                    <p class="text-sm text-slate-500 mb-4">Live-Überblick über den Status deiner Geräte.</p>
                     <canvas id="statusChart" height="300"></canvas>
                 </div>
             </div>
 
 			<!-- Letzte Geräte -->
-			<div class="bg-white p-6 rounded-lg shadow">
-				<h2 class="text-xl font-semibold mb-4">Zuletzt hinzugefügt</h2>
-				<table class="min-w-full">
-					<thead>
-						<tr class="border-b">
-							<th class="text-left py-2">Name</th>
-							<th class="text-left py-2">Kategorie</th>
-							<th class="text-left py-2">Besitzer</th>
-							<th class="text-left py-2">Datum</th>
-						</tr>
-					</thead>
-					<tbody>
-						{% for device in recent_devices %}
-						<tr class="border-b">
-							<td class="py-2">{{ device['name'] }}</td>
-							<td class="py-2">{{ device['category_name'] }}</td>
-							<td class="py-2">{{ device['serial_number'] or '-' }}</td>
-							<td class="py-2">{{ device['created_at'][:10] }}</td>
-						</tr>
-						{% endfor %}
-					</tbody>
-				</table>
+			<div class="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm">
+				<div class="flex items-center justify-between mb-4">
+                    <div>
+                        <h2 class="text-xl font-semibold text-slate-900">Zuletzt hinzugefügt</h2>
+                        <p class="text-sm text-slate-500">Neueste Geräte mit Owner-Status.</p>
+                    </div>
+                    <span class="inline-flex items-center justify-center rounded-2xl bg-slate-100 p-2 text-slate-500">
+                        <i data-feather="clock" class="h-4 w-4"></i>
+                    </span>
+                </div>
+				<div class="overflow-x-auto">
+                    <table class="min-w-full text-sm">
+                        <thead class="text-left text-slate-500">
+                            <tr class="border-b border-slate-200">
+                                <th class="py-3 font-semibold">Name</th>
+                                <th class="py-3 font-semibold">Kategorie</th>
+                                <th class="py-3 font-semibold">Besitzer</th>
+                                <th class="py-3 font-semibold">Datum</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-slate-100">
+                            {% for device in recent_devices %}
+                            <tr class="hover:bg-slate-50">
+                                <td class="py-3 font-semibold text-slate-900">{{ device['name'] }}</td>
+                                <td class="py-3 text-slate-600">{{ device['category_name'] }}</td>
+                                <td class="py-3 text-slate-600">{{ device['serial_number'] or '-' }}</td>
+                                <td class="py-3 text-slate-600">{{ device['created_at'][:10] }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
 			</div>
         </div>
     </div>


### PR DESCRIPTION
### Motivation
- Make the inventory app more useful by adding device-level metadata (tags, notes), activity logging, and Pro-only workflow features (maintenance, CSV export) and expose those in the redesigned dashboard UI. 
- Provide a feature-flag endpoint so the frontend can adapt UI/UX when Pro features are enabled or locked. 
- Improve traceability by logging create/update/delete actions for categories and devices.

### Description
- Backend: added Pro flag + feature lists (`PRO_ENABLED`, `PRO_FEATURES`, `FREE_FEATURES`) and created new tables (`device_tags`, `device_notes`, `maintenance_tasks`, `activity_log`) in `init_db()`; added `log_activity()` helper and `pro_required()` decorator. 
- API: implemented endpoints for feature flags (`GET /api/features`), activity feed (`GET /api/activity`), tags (`GET/POST /api/devices/<id>/tags`, `DELETE /api/devices/<id>/tags/<tag_id>`), notes (`GET/POST /api/devices/<id>/notes`, `DELETE /api/devices/<id>/notes/<note_id>`), maintenance tasks (Pro-gated: `GET/POST /api/maintenance`, `PATCH /api/maintenance/<task_id>`), maintenance summary (`GET /api/maintenance/summary`), and CSV export (Pro-gated: `GET /api/export/devices`). 
- Instrumentation: activity logging calls added to category/device create/update/delete flows and to tag/note/maintenance operations. 
- Frontend: wired feature flags and new device extras into `static/script.js` (load feature flags, maintenance summary, activity feed; device detail modal with tags/notes/maintenance; actions to add/remove tags and notes; Pro-gated maintenance UI flows) and updated `templates/index.html` and `templates/stats.html` to surface activities, maintenance widgets, export link, and a device detail modal with notes/tags/maintenance. 

### Testing
- Started the development server with `python app.py` and confirmed the server booted normally and printed the temporary admin creation message (dev mode). (succeeded)
- Ran an automated Playwright script that opened `/login`, signed in with the temporary admin, navigated to the dashboard and saved a full-page screenshot (`artifacts/inventory-dashboard-pro.png`). (succeeded)
- Observed successful HTTP responses (200) during the automated run for key new and existing endpoints including `GET /api/categories`, `GET /api/otp/status`, `GET /api/devices`, `GET /api/features`, `GET /api/maintenance/summary`, and `GET /api/activity`. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69730e58888c832dbc3882631c8779c1)