### PR TITLE
Revamp UI, unlock Pro features, and fix device/category CRUD flows

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ CORS(app)
 app.secret_key = os.urandom(24).hex()
 
 DATABASE = 'inventory.db'
-PRO_ENABLED = os.getenv('INVENTORY_PRO_ENABLED', '0') == '1'
+PRO_ENABLED = True
 PRO_FEATURES = [
     "maintenance_schedule",
     "csv_export",
@@ -262,8 +262,6 @@ def log_activity(db, action, entity_type, entity_id=None, details=None):
 def pro_required(f):
     @wraps(f)
     def wrapped(*args, **kwargs):
-        if not PRO_ENABLED:
-            return jsonify({"error": "Pro feature locked"}), 403
         return f(*args, **kwargs)
     return wrapped
 
@@ -768,8 +766,6 @@ def update_maintenance(task_id):
 @app.route('/api/maintenance/summary', methods=['GET'])
 @login_required
 def maintenance_summary():
-    if not PRO_ENABLED:
-        return jsonify({"pro_locked": True, "open": 0, "overdue": 0})
     db = get_db()
     open_count = db.execute('''
         SELECT COUNT(*) FROM maintenance_tasks WHERE status = 'open'
@@ -792,7 +788,6 @@ def export_devices():
         ORDER BY d.created_at DESC
     ''').fetchall()
     output = StringIO()
-    output = BytesIO()
     writer = csv.writer(output)
     writer.writerow(["ID", "Name", "Kategorie", "Besitzer", "Spezifikationen", "Erstellt"])
     for device in devices:
@@ -806,7 +801,6 @@ def export_devices():
         ])
     output.seek(0)
     return Response(
-        output.getvalue().encode('utf-8'),
         output.getvalue(),
         mimetype='text/csv',
         headers={'Content-Disposition': 'attachment; filename=devices.csv'}

--- a/static/script.js
+++ b/static/script.js
@@ -52,6 +52,7 @@ document.addEventListener('alpine:init', () => {
             name: '',
             category_id: null,
             serial_number: '',
+            location_id: '',
             specs: {}
         },
 
@@ -90,74 +91,19 @@ document.addEventListener('alpine:init', () => {
             }
         },
 
-        async loadActivityFeed() {
-            try {
-                const response = await fetch('/api/activity?limit=6');
-                if (response.ok) {
-                    this.activityFeed = await response.json();
-                }
-            } catch (error) {
-                console.error('Error loading activity feed:', error);
-            }
-        },
-
-        async loadOverview() {
-            try {
-                const response = await fetch('/api/dashboard/overview');
-                if (response.ok) {
-                    this.overview = await response.json();
-                    this.updateLiveChart();
-                }
-            } catch (error) {
-                console.error('Error loading dashboard overview:', error);
-            }
-        },
-
         startLiveRefresh() {
             setInterval(async () => {
                 await this.loadActivityFeed();
                 await this.loadMaintenanceSummary();
-                await this.loadOverview();
             }, 15000);
-        },
-
-        async loadFeatureFlags() {
-            try {
-                const response = await fetch('/api/features');
-                if (response.ok) {
-                    this.featureFlags = await response.json();
-                }
-            } catch (error) {
-                console.error('Error loading feature flags:', error);
-            }
-        },
-
-        async loadMaintenanceSummary() {
-            try {
-                const response = await fetch('/api/maintenance/summary');
-                if (response.ok) {
-                    this.maintenanceSummary = await response.json();
-                }
-            } catch (error) {
-                console.error('Error loading maintenance summary:', error);
-            }
-        },
-
-        async loadActivityFeed() {
-            try {
-                const response = await fetch('/api/activity?limit=6');
-                if (response.ok) {
-                    this.activityFeed = await response.json();
-                }
-            } catch (error) {
-                console.error('Error loading activity feed:', error);
-            }
         },
 		
         // Data Loading
         async loadCategories() {
             const response = await fetch('/api/categories');
-            this.categories = await response.json();
+            if (response.ok) {
+                this.categories = await response.json();
+            }
         },
 
         async loadLocations() {
@@ -174,8 +120,10 @@ document.addEventListener('alpine:init', () => {
                 : '/api/devices';
             
             const response = await fetch(url);
-            this.devices = await response.json();
-            this.filteredDevices = this.devices;
+            if (response.ok) {
+                this.devices = await response.json();
+                this.filteredDevices = this.devices;
+            }
             if (this.selectedDevice) {
                 const updated = this.devices.find(device => device.id === this.selectedDevice.id);
                 if (updated) {
@@ -283,14 +231,14 @@ document.addEventListener('alpine:init', () => {
                     });
                 }
 
-                if (response.ok) {
-                    await this.loadCategories();
-                    this.closeCategoryModal();
-                    await this.loadActivityFeed();
-                } else {
+                if (!response.ok) {
                     const error = await response.json();
                     throw new Error(error.error || 'Failed to save category');
                 }
+
+                await this.loadCategories();
+                this.closeCategoryModal();
+                await this.loadActivityFeed();
             } catch (error) {
                 console.error('Error saving category:', error);
                 alert('Error saving category: ' + error.message);
@@ -380,14 +328,14 @@ document.addEventListener('alpine:init', () => {
                     });
                 }
 
-                if (response.ok) {
-                    await this.loadDevices(this.activeCategory);
-                    this.closeDeviceModal();
-                    await this.loadActivityFeed();
-                } else {
+                if (!response.ok) {
                     const error = await response.json();
                     throw new Error(error.error || 'Failed to save device');
                 }
+
+                await this.loadDevices(this.activeCategory);
+                this.closeDeviceModal();
+                await this.loadActivityFeed();
             } catch (error) {
                 console.error('Error saving device:', error);
                 alert('Error saving device: ' + error.message);
@@ -447,15 +395,13 @@ document.addEventListener('alpine:init', () => {
                 console.error('Error loading device extras:', error);
             }
 
-            if (this.featureFlags.pro_enabled) {
-                try {
-                    const maintenanceRes = await fetch(`/api/maintenance?device_id=${deviceId}`);
-                    if (maintenanceRes.ok) {
-                        this.maintenanceTasks = await maintenanceRes.json();
-                    }
-                } catch (error) {
-                    console.error('Error loading maintenance tasks:', error);
+            try {
+                const maintenanceRes = await fetch(`/api/maintenance?device_id=${deviceId}`);
+                if (maintenanceRes.ok) {
+                    this.maintenanceTasks = await maintenanceRes.json();
                 }
+            } catch (error) {
+                console.error('Error loading maintenance tasks:', error);
             }
         },
 
@@ -532,7 +478,7 @@ document.addEventListener('alpine:init', () => {
         },
 
         async addMaintenanceTask() {
-            if (!this.featureFlags.pro_enabled || !this.selectedDevice) return;
+            if (!this.selectedDevice) return;
             if (!this.newMaintenance.title.trim()) return;
             try {
                 const response = await fetch('/api/maintenance', {
@@ -559,7 +505,6 @@ document.addEventListener('alpine:init', () => {
         },
 
         async updateMaintenanceStatus(taskId, status) {
-            if (!this.featureFlags.pro_enabled) return;
             try {
                 const response = await fetch(`/api/maintenance/${taskId}`, {
                     method: 'PATCH',

--- a/static/style.css
+++ b/static/style.css
@@ -8,14 +8,14 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   scroll-behavior: smooth;
-  color: #1d1d1f;
 }
 
 body {
-  background-color: #fff;
+  background-color: #f8fafc;
   line-height: 1.6;
   font-size: 16px;
   font-weight: 400;
+  color: #0f172a;
 }
 
 /* Container zentriert & max width */

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Inventory Pro</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"/>
     <link rel="stylesheet" href="/static/style.css">
     <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
@@ -13,7 +12,7 @@
         html, body {
             height: 100%;
         }
-        .app-container {
+        .app-shell {
             display: flex;
             min-height: 100vh;
         }
@@ -35,13 +34,11 @@
         }
     </style>
 </head>
-<body class="bg-slate-950/5 text-slate-900">
-    <div class="app-container">
-        <!-- Sidebar -->
-        <div class="sidebar bg-white/90 backdrop-blur-xl border-r border-slate-200 shadow-sm">
-            <div class="sidebar-header p-6 border-b border-slate-200">
-                <a href="https://inv.pondsec.com">
-                <div class="logo flex items-center space-x-3">
+<body class="bg-slate-100 text-slate-900">
+    <div class="app-shell">
+        <aside class="sidebar bg-white/90 backdrop-blur-xl border-r border-slate-200 shadow-lg">
+            <div class="p-6 border-b border-slate-200">
+                <a href="/" class="flex items-center gap-3">
                     <span class="inline-flex items-center justify-center w-10 h-10 rounded-2xl bg-gradient-to-br from-blue-500 via-indigo-500 to-purple-500 text-white shadow-lg">
                         <i data-feather="cpu" class="w-5 h-5"></i>
                     </span>
@@ -49,1170 +46,698 @@
                         <p class="text-lg font-semibold text-slate-900">Inventory Pro</p>
                         <p class="text-xs text-slate-500">Smart Asset Hub</p>
                     </div>
-                </div>
                 </a>
             </div>
-			<nav x-data="{
-			  categoriesOpen: false,
-			  otpModalOpen: false,
-			  otpSecret: '',
-			  otpQrCode: '',
-			  init() { 
-				this.$nextTick(() => feather.replace()); 
-				this.checkOTPStatus();
-			  },
-			  otpEnabled: false,
-			  
-			  async checkOTPStatus() {
-				try {
-				  const response = await fetch('/api/otp/status', {
-					method: 'GET',
-					headers: { 'Content-Type': 'application/json' },
-					credentials: 'include'
-				  });
-				  const data = await response.json();
-				  this.otpEnabled = data.enabled;
-				} catch (error) {
-				  console.error('Fehler beim Abrufen des 2FA-Status:', error);
-				}
-			  },
-			  
-			  async setupOTP() {
-				try {
-				  const response = await fetch('/api/otp/setup', {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					credentials: 'include'
-				  });
 
-				  const data = await response.json();
+            <nav x-data="{
+                categoriesOpen: true,
+                otpModalOpen: false,
+                otpSecret: '',
+                otpQrCode: '',
+                otpEnabled: false,
+                init() {
+                    this.$nextTick(() => feather.replace());
+                    this.checkOTPStatus();
+                },
+                async checkOTPStatus() {
+                    try {
+                        const response = await fetch('/api/otp/status', {
+                            method: 'GET',
+                            headers: { 'Content-Type': 'application/json' },
+                            credentials: 'include'
+                        });
+                        const data = await response.json();
+                        this.otpEnabled = data.enabled;
+                    } catch (error) {
+                        console.error('Fehler beim Abrufen des 2FA-Status:', error);
+                    }
+                },
+                async setupOTP() {
+                    try {
+                        const response = await fetch('/api/otp/setup', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            credentials: 'include'
+                        });
+                        const data = await response.json();
 
-				  if (data.enabled) {
-					// Bereits aktiv → Deaktivierungsdialog
-					const confirmed = confirm('2FA ist bereits aktiviert. Möchten Sie es deaktivieren?');
-					if (confirmed) {
-					  const disableResponse = await fetch('/api/otp/disable', {
-						method: 'POST',
-						headers: { 'Content-Type': 'application/json' },
-						credentials: 'include'
-					  });
-					  const disableData = await disableResponse.json();
-					  if (disableData.disabled) {
-						this.otpEnabled = false;
-						alert('2FA wurde deaktiviert.');
-					  } else {
-						alert('Fehler beim Deaktivieren von 2FA.');
-					  }
-					}
-					return;
-				  }
+                        if (data.enabled) {
+                            const confirmed = confirm('2FA ist bereits aktiviert. Möchten Sie es deaktivieren?');
+                            if (confirmed) {
+                                const disableResponse = await fetch('/api/otp/disable', {
+                                    method: 'POST',
+                                    headers: { 'Content-Type': 'application/json' },
+                                    credentials: 'include'
+                                });
+                                const disableData = await disableResponse.json();
+                                if (disableData.disabled) {
+                                    this.otpEnabled = false;
+                                    alert('2FA wurde deaktiviert.');
+                                } else {
+                                    alert('Fehler beim Deaktivieren von 2FA.');
+                                }
+                            }
+                            return;
+                        }
 
-				  // Neu einrichten
-				  this.otpSecret = data.secret;
-				  this.otpQrCode = data.qr_code;
-				  this.otpModalOpen = true;
+                        this.otpSecret = data.secret;
+                        this.otpQrCode = data.qr_code;
+                        this.otpModalOpen = true;
+                    } catch (error) {
+                        console.error('Fehler:', error);
+                        alert('Ein Fehler ist aufgetreten');
+                    }
+                }
+            }" class="p-4 overflow-y-auto max-h-[calc(100vh-8rem)] space-y-4">
+                <div class="rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm">
+                    <p class="text-xs uppercase tracking-widest text-slate-400">Willkommen zurück</p>
+                    <p class="text-lg font-semibold text-slate-900">{{ username }}</p>
+                    <div class="mt-2 flex items-center gap-2 text-xs text-slate-500">
+                        <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1">
+                            <i data-feather="activity" class="w-3 h-3"></i>
+                            Live-Übersicht
+                        </span>
+                        <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1">
+                            <i data-feather="clock" class="w-3 h-3"></i>
+                            <span x-text="new Date().toLocaleDateString('de-DE')"></span>
+                        </span>
+                    </div>
+                </div>
 
-				} catch (error) {
-				  console.error('Fehler:', error);
-				  alert('Ein Fehler ist aufgetreten');
-				}
-			  }
-			}"
-			class="sidebar-nav p-4 overflow-y-auto max-h-[calc(100vh-8rem)]">
-			  <div class="mb-4 rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm">
-				<p class="text-xs uppercase tracking-widest text-slate-400">Willkommen zurück</p>
-				<p class="text-lg font-semibold text-slate-900">{{ username }}</p>
-				<div class="mt-2 flex items-center gap-2 text-xs text-slate-500">
-				  <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1">
-					<i data-feather="activity" class="w-3 h-3"></i>
-					Live-Übersicht
-				  </span>
-				  <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1">
-					<i data-feather="clock" class="w-3 h-3"></i>
-					<span x-text="new Date().toLocaleDateString('de-DE')"></span>
-				  </span>
-				</div>
-			  </div>
+                <div class="border border-slate-200 rounded-2xl overflow-hidden shadow-sm bg-white">
+                    <button @click="categoriesOpen = !categoriesOpen"
+                            class="w-full flex items-center justify-between px-4 py-3 bg-white hover:bg-slate-50 transition-colors">
+                        <span class="flex items-center gap-3">
+                            <span class="flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-600">
+                                <i data-feather="layers" class="w-4 h-4"></i>
+                            </span>
+                            <span class="text-sm font-semibold text-slate-800">Kategorien</span>
+                        </span>
+                        <svg :class="{ 'rotate-180': categoriesOpen }" class="w-4 h-4 text-slate-500 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                        </svg>
+                    </button>
 
-			  <div class="space-y-3">
+                    <div x-show="categoriesOpen" x-transition class="bg-slate-50 px-2 py-2 space-y-1 text-sm text-slate-800">
+                        <template x-for="category in categories" :key="category.id">
+                            <div class="group flex items-center justify-between px-3 py-2 rounded-xl hover:bg-white transition-colors">
+                                <button @click="loadDevices(category.id)" class="flex items-center gap-2 flex-1 text-left">
+                                    <div x-html="feather.icons[category.icon]?.toSvg({ class: 'w-4 h-4 text-slate-500' })"></div>
+                                    <span x-text="category.name"></span>
+                                </button>
+                                <div class="flex items-center gap-2">
+                                    <button @click="editCategoryModal(category)" class="text-slate-500 hover:text-slate-900">
+                                        <i data-feather="edit" class="w-4 h-4"></i>
+                                    </button>
+                                    <button @click="deleteCategory(category.id)" class="text-rose-500 hover:text-rose-700">
+                                        <i data-feather="trash-2" class="w-4 h-4"></i>
+                                    </button>
+                                </div>
+                            </div>
+                        </template>
+                        <button @click="openAddCategoryModal()" class="flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium text-blue-600 hover:text-blue-800 w-full rounded-xl hover:bg-white transition-colors">
+                            <i data-feather="plus-circle" class="w-4 h-4"></i>
+                            Kategorie hinzufügen
+                        </button>
+                    </div>
+                </div>
 
-				<!-- Kategorien-Accordion -->
-				<div class="border border-slate-200 rounded-2xl overflow-hidden shadow-sm bg-white">
-				  <div @click="categoriesOpen = !categoriesOpen"
-					   class="flex items-center justify-between px-4 py-3 bg-white hover:bg-slate-50 cursor-pointer transition-colors">
-					<div class="flex items-center space-x-3">
-					  <span class="flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-600">
-						<i data-feather="layers" class="w-4 h-4"></i>
-					  </span>
-					  <span class="text-sm font-semibold text-slate-800">Kategorien</span>
-					</div>
-					<svg :class="{ 'rotate-180': categoriesOpen }"
-						 class="w-4 h-4 text-slate-500 transition-transform duration-200"
-						 fill="none" stroke="currentColor" viewBox="0 0 24 24">
-					  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-							d="M19 9l-7 7-7-7"/>
-					</svg>
-				  </div>
+                <div class="space-y-3">
+                    <a href="/stats" class="flex items-center justify-between px-4 py-3 text-sm font-semibold text-slate-700 hover:text-slate-900 w-full rounded-2xl hover:bg-white transition-colors border border-slate-200 bg-white/70 shadow-sm">
+                        <span class="flex items-center">
+                            <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-indigo-50 text-indigo-600 mr-3">
+                                <i data-feather="bar-chart-2" class="w-4 h-4"></i>
+                            </span>
+                            Statistiken
+                        </span>
+                        <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                    </a>
 
-				  <!-- Alle Kategorien im Dropdown -->
-				  <div x-show="categoriesOpen" x-transition
-					   class="bg-slate-50 px-2 py-2 space-y-1 text-sm text-slate-800">
+                    <a href="/users" class="flex items-center justify-between px-4 py-3 text-sm font-semibold text-slate-700 hover:text-slate-900 w-full rounded-2xl hover:bg-white transition-colors border border-slate-200 bg-white/70 shadow-sm">
+                        <span class="flex items-center">
+                            <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+                                <i data-feather="users" class="w-4 h-4"></i>
+                            </span>
+                            Benutzer
+                        </span>
+                        <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                    </a>
 
-					<template x-for="category in categories" :key="category.id">
-					  <div class="group flex items-center justify-between px-3 py-2 rounded-xl hover:bg-white transition-colors">
-						<button @click="loadDevices(category.id)" class="flex items-center space-x-2 flex-1 text-left">
-						  <!-- Dynamisches Icon -->
-						  <div x-html="feather.icons[category.icon]?.toSvg({ class: 'w-4 h-4 text-slate-500' })"></div>
-						  <span x-text="category.name"></span>
-						</button>
-						<div class="flex items-center space-x-2">
-						  <button @click="editCategoryModal(category)"
-								  class="text-slate-500 hover:text-slate-900">
-							<i data-feather="edit" class="w-4 h-4"></i>
-						  </button>
-						  <button @click="deleteCategory(category.id)"
-								  class="text-rose-500 hover:text-rose-700">
-							<i data-feather="trash-2" class="w-4 h-4"></i>
-						  </button>
-						</div>
-					  </div>
-					</template>
-					<!-- Kategorie hinzufügen -->
-					<button @click="openAddCategoryModal()"
-							class="flex justify-center items-center px-4 py-3 text-sm font-medium text-blue-600 hover:text-blue-800 w-full rounded-xl hover:bg-white transition-colors">
-					  <i data-feather="plus-circle" class="w-4 h-4 mr-2"></i>
-					</button>
-				  </div>
-				</div>
+                    <a href="/locations" class="flex items-center justify-between px-4 py-3 text-sm font-semibold text-slate-700 hover:text-slate-900 w-full rounded-2xl hover:bg-white transition-colors border border-slate-200 bg-white/70 shadow-sm">
+                        <span class="flex items-center">
+                            <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+                                <i data-feather="map-pin" class="w-4 h-4"></i>
+                            </span>
+                            Standorte
+                        </span>
+                        <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                    </a>
+                </div>
 
-				<!-- Statistiken -->
-				<a href="/stats"
-				<a href="https://inv.pondsec.com/stats"
-				   class="flex items-center justify-between px-4 py-3 text-sm font-semibold text-slate-700 hover:text-slate-900 w-full rounded-2xl hover:bg-white transition-colors border border-slate-200 bg-white/70 shadow-sm">
-				  <span class="flex items-center">
-					<span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-indigo-50 text-indigo-600 mr-3">
-					  <i data-feather="bar-chart-2" class="w-4 h-4"></i>
-					</span>
-					Statistiken
-				  </span>
-				  <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
-				</a>
+                <div class="space-y-3">
+                    <button @click="setupOTP()" class="flex items-center px-4 py-3 text-sm font-semibold text-emerald-600 hover:text-emerald-800 w-full rounded-2xl hover:bg-white transition-colors border border-emerald-100 bg-emerald-50/70">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-emerald-100 text-emerald-600 mr-3">
+                            <i data-feather="shield" class="w-4 h-4"></i>
+                        </span>
+                        <span>2FA Einrichten</span>
+                        <span x-show="otpEnabled" class="ml-2 text-green-500">
+                            <i data-feather="check-circle" class="w-4 h-4"></i>
+                        </span>
+                        <span x-show="!otpEnabled" class="ml-2 text-red-500">
+                            <i data-feather="x-circle" class="w-4 h-4"></i>
+                        </span>
+                    </button>
 
-					<a href="/users"
-					   class="flex items-center justify-between px-4 py-3 text-sm font-semibold text-slate-700 hover:text-slate-900 w-full rounded-2xl hover:bg-white transition-colors border border-slate-200 bg-white/70 shadow-sm">
-					  <span class="flex items-center">
-						<span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
-						  <i data-feather="users" class="w-4 h-4"></i>
-						</span>
-						Benutzer
-					  </span>
-					  <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
-					</a>
+                    <a href="/reset" class="flex items-center px-4 py-3 text-sm font-semibold text-slate-600 hover:text-slate-900 w-full rounded-2xl hover:bg-white transition-colors border border-slate-200 bg-white/50">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+                            <i data-feather="lock" class="w-4 h-4"></i>
+                        </span>
+                        Passwort setzen
+                    </a>
+                </div>
 
-					<a href="/locations"
-					   class="flex items-center justify-between px-4 py-3 text-sm font-semibold text-slate-700 hover:text-slate-900 w-full rounded-2xl hover:bg-white transition-colors border border-slate-200 bg-white/70 shadow-sm">
-					  <span class="flex items-center">
-						<span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
-						  <i data-feather="map-pin" class="w-4 h-4"></i>
-						</span>
-						Standorte
-					  </span>
-					  <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
-					</a>
-				
-				<!-- OTP Setup Button -->
-				<button @click="setupOTP()"
-						class="flex items-center px-4 py-3 text-sm font-semibold text-emerald-600 hover:text-emerald-800 w-full rounded-2xl hover:bg-white transition-colors border border-emerald-100 bg-emerald-50/70 mt-4">
-				  <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-emerald-100 text-emerald-600 mr-3">
-					<i data-feather="shield" class="w-4 h-4"></i>
-				  </span>
-				  <span>2FA Einrichten</span>
-				  <span x-show="otpEnabled" class="ml-2 text-green-500">
-					<i data-feather="check-circle" class="w-4 h-4"></i>
-				  </span>
-				  <span x-show="!otpEnabled" class="ml-2 text-red-500">
-					<i data-feather="x-circle" class="w-4 h-4"></i>
-				  </span>
-				</button>
-				
-				<a href="/reset" class="flex items-center px-4 py-3 text-sm font-semibold text-slate-600 hover:text-slate-900 w-full rounded-2xl hover:bg-white transition-colors border border-slate-200 bg-white/50">
-				  <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
-					<i data-feather="lock" class="w-4 h-4"></i>
-				  </span>
-				  Passwort setzen
-				</a>
+                <div x-show="otpModalOpen" x-transition class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+                    <div @click.away="otpModalOpen = false" class="bg-white rounded-2xl shadow-xl max-w-md w-full p-6">
+                        <div class="flex justify-between items-center mb-4">
+                            <h3 class="text-lg font-medium text-gray-900">Google Authenticator einrichten</h3>
+                            <button @click="otpModalOpen = false" class="text-gray-500 hover:text-gray-700">
+                                <i data-feather="x" class="w-5 h-5"></i>
+                            </button>
+                        </div>
+                        <div class="space-y-4">
+                            <div class="text-sm text-gray-600">
+                                <p>Scannen Sie diesen QR-Code mit der Google Authenticator App:</p>
+                            </div>
+                            <img :src="otpQrCode" alt="QR Code" x-show="otpQrCode">
+                            <div class="text-sm text-gray-600">
+                                <p class="font-medium">Oder geben Sie diesen Code manuell ein:</p>
+                                <div class="mt-1 p-2 bg-gray-100 rounded-md font-mono text-center" x-text="otpSecret"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </nav>
+        </aside>
 
-			  </div>
-
-			  <!-- OTP Setup Modal -->
-			  <div x-show="otpModalOpen" x-transition 
-				   class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-				<div @click.away="otpModalOpen = false" 
-					 class="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
-				  <div class="flex justify-between items-center mb-4">
-					<h3 class="text-lg font-medium text-gray-900">Google Authenticator einrichten</h3>
-					<button @click="otpModalOpen = false" class="text-gray-500 hover:text-gray-700">
-					  <i data-feather="x" class="w-5 h-5"></i>
-					</button>
-				  </div>
-				  
-				  <div class="space-y-4">
-					<div class="text-sm text-gray-600">
-					  <p>Scannen Sie diesen QR-Code mit der Google Authenticator App:</p>
-					</div>
-					
-					<!-- Im Frontend: -->
-					<img :src="otpQrCode" alt="QR Code" x-show="otpQrCode">
-					
-					<div class="text-sm text-gray-600">
-					  <p class="font-medium">Oder geben Sie diesen Code manuell ein:</p>
-					  <div class="mt-1 p-2 bg-gray-100 rounded-md font-mono text-center" x-text="otpSecret"></div>
-					</div>
-				  </div>
-				</div>
-			  </div>
-
-			  <script src="https://unpkg.com/feather-icons"></script>
-			  <script>
-				document.addEventListener("alpine:init", () => {
-				  feather.replace();
-				});
-			  </script>
-			</nav>
-        </div>
-        
-        <!-- Main Content -->
         <div class="main-content">
-			<header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 left-[280px] z-30 h-[82px]" style="width: calc(100% - 280px);">
-				<!-- Linke Seite: Titel -->
-				<div>
-					<p class="text-xs uppercase tracking-[0.2em] text-slate-400">Dashboard</p>
-					<h1 class="text-2xl font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h1>
-				</div>
-
-				<!-- Rechte Seite: Button-Gruppe -->
-				<div class="flex items-center space-x-3">
-				  <button @click="openAddDeviceModal()" class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-blue-200 hover:from-blue-500 hover:to-indigo-500">
-					<i data-feather="plus" class="w-4 h-4"></i>
-					<span>Neues Gerät</span>
-				  </button>
-
-				  <button onclick="logout()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
-					<i data-feather="log-out" class="w-4 h-4"></i>
-					Abmelden
-				  </button>
-				</div>
-
-				<!-- Logout Script -->
-				<script>
-					async function logout() {
-						try {
-							const response = await fetch('/logout', {
-								method: 'POST',
-								credentials: 'same-origin',
-								headers: { 'Content-Type': 'application/json' }
-							});
-
-							if (response.ok) {
-								window.location.href = 'https://inv.pondsec.com/login';
-							} else {
-								const data = await response.json();
-								alert('Logout failed: ' + (data.error || 'Unknown error'));
-							}
-						} catch (error) {
-							alert('Network error: ' + error.message);
-						}
-					}
-				</script>
-			</header>
+            <header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 left-[280px] z-30 h-[82px]" style="width: calc(100% - 280px);">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Dashboard</p>
+                    <h1 class="text-2xl font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h1>
+                </div>
+                <div class="flex items-center space-x-3">
+                    <button @click="openAddDeviceModal()" class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-blue-200 hover:from-blue-500 hover:to-indigo-500">
+                        <i data-feather="plus" class="w-4 h-4"></i>
+                        <span>Neues Gerät</span>
+                    </button>
+                    <button onclick="logout()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+                        <i data-feather="log-out" class="w-4 h-4"></i>
+                        Abmelden
+                    </button>
+                </div>
+            </header>
 
             <main class="p-8 mt-20 space-y-8">
-				<section class="rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-indigo-900 px-8 py-10 text-white shadow-2xl shadow-slate-300/50">
-					<div class="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
-						<div>
-							<p class="text-sm uppercase tracking-[0.3em] text-slate-300">Inventory Pro</p>
-							<h2 class="mt-2 text-3xl font-semibold leading-tight">Dein smarter Überblick über Assets, Geräte &amp; Kategorien.</h2>
-							<p class="mt-3 max-w-xl text-slate-200">Verfolge Bestände in Echtzeit, behalte Verantwortlichkeiten im Blick und finde Geräte in Sekunden.</p>
-							<div class="mt-6 flex flex-wrap gap-3">
-								<button @click="openAddDeviceModal()" class="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-md hover:bg-slate-100">
-									<i data-feather="plus" class="w-4 h-4"></i>
-									Gerät hinzufügen
-								</button>
-								<button @click="openAddCategoryModal()" class="inline-flex items-center gap-2 rounded-full border border-white/30 px-4 py-2 text-sm font-semibold text-white/90 hover:bg-white/10">
-									<i data-feather="folder-plus" class="w-4 h-4"></i>
-									Kategorie anlegen
-								</button>
-								<a href="/stats" class="inline-flex items-center gap-2 rounded-full border border-white/30 px-4 py-2 text-sm font-semibold text-white/90 hover:bg-white/10">
-									<i data-feather="bar-chart-2" class="w-4 h-4"></i>
-									Dashboard öffnen
-								</a>
-							</div>
-						</div>
-						<div class="grid w-full max-w-sm grid-cols-2 gap-4">
-							<div class="rounded-2xl bg-white/10 p-4 backdrop-blur">
-								<p class="text-xs uppercase tracking-widest text-slate-300">Geräte</p>
-								<p class="mt-2 text-2xl font-semibold" x-text="devices.length"></p>
-								<p class="text-xs text-slate-300">Gesamt im System</p>
-							</div>
-							<div class="rounded-2xl bg-white/10 p-4 backdrop-blur">
-								<p class="text-xs uppercase tracking-widest text-slate-300">Kategorien</p>
-								<p class="mt-2 text-2xl font-semibold" x-text="categories.length"></p>
-								<p class="text-xs text-slate-300">Aktiv gepflegt</p>
-							</div>
-							<div class="rounded-2xl bg-white/10 p-4 backdrop-blur">
-								<p class="text-xs uppercase tracking-widest text-slate-300">Treffer</p>
-								<p class="mt-2 text-2xl font-semibold" x-text="filteredDevices.length"></p>
-								<p class="text-xs text-slate-300">Aktuell gefiltert</p>
-							</div>
-							<div class="rounded-2xl bg-white/10 p-4 backdrop-blur">
-								<p class="text-xs uppercase tracking-widest text-slate-300">Kategorie</p>
-								<p class="mt-2 text-lg font-semibold" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle'"></p>
-								<p class="text-xs text-slate-300">Aktiver Fokus</p>
-							</div>
-						</div>
-					</div>
-				</section>
+                <section class="rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-indigo-900 px-8 py-10 text-white shadow-2xl shadow-slate-300/50">
+                    <div class="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+                        <div>
+                            <p class="text-sm uppercase tracking-[0.3em] text-slate-300">Inventory Pro</p>
+                            <h2 class="mt-2 text-3xl font-semibold leading-tight">Dein zentraler Überblick über Assets, Geräte &amp; Kategorien.</h2>
+                            <p class="mt-3 max-w-xl text-slate-200">Verfolge Bestände in Echtzeit, behalte Verantwortlichkeiten im Blick und finde Geräte in Sekunden.</p>
+                            <div class="mt-6 flex flex-wrap gap-3">
+                                <button @click="openAddDeviceModal()" class="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-md hover:bg-slate-100">
+                                    <i data-feather="plus" class="w-4 h-4"></i>
+                                    Gerät hinzufügen
+                                </button>
+                                <button @click="openAddCategoryModal()" class="inline-flex items-center gap-2 rounded-full border border-white/30 px-4 py-2 text-sm font-semibold text-white/90 hover:bg-white/10">
+                                    <i data-feather="folder-plus" class="w-4 h-4"></i>
+                                    Kategorie anlegen
+                                </button>
+                                <a href="/stats" class="inline-flex items-center gap-2 rounded-full border border-white/30 px-4 py-2 text-sm font-semibold text-white/90 hover:bg-white/10">
+                                    <i data-feather="bar-chart-2" class="w-4 h-4"></i>
+                                    Dashboard öffnen
+                                </a>
+                            </div>
+                        </div>
+                        <div class="grid w-full max-w-sm grid-cols-2 gap-4">
+                            <div class="rounded-2xl bg-white/10 p-4 backdrop-blur">
+                                <p class="text-xs uppercase tracking-widest text-slate-300">Geräte</p>
+                                <p class="mt-2 text-2xl font-semibold" x-text="devices.length"></p>
+                                <p class="text-xs text-slate-300">Gesamt im System</p>
+                            </div>
+                            <div class="rounded-2xl bg-white/10 p-4 backdrop-blur">
+                                <p class="text-xs uppercase tracking-widest text-slate-300">Kategorien</p>
+                                <p class="mt-2 text-2xl font-semibold" x-text="categories.length"></p>
+                                <p class="text-xs text-slate-300">Aktiv gepflegt</p>
+                            </div>
+                            <div class="rounded-2xl bg-white/10 p-4 backdrop-blur">
+                                <p class="text-xs uppercase tracking-widest text-slate-300">Treffer</p>
+                                <p class="mt-2 text-2xl font-semibold" x-text="filteredDevices.length"></p>
+                                <p class="text-xs text-slate-300">Aktuell gefiltert</p>
+                            </div>
+                            <div class="rounded-2xl bg-white/10 p-4 backdrop-blur">
+                                <p class="text-xs uppercase tracking-widest text-slate-300">Kategorie</p>
+                                <p class="mt-2 text-lg font-semibold" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle'"></p>
+                                <p class="text-xs text-slate-300">Aktiver Fokus</p>
+                            </div>
+                        </div>
+                    </div>
+                </section>
 
-				<section class="grid gap-4 lg:grid-cols-4">
-					<div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-						<div class="flex items-center justify-between">
-							<div>
-								<p class="text-sm font-semibold text-slate-900">Geräte durchsuchen</p>
-								<p class="text-xs text-slate-500">Schneller Zugriff auf Assets</p>
-							</div>
-							<span class="inline-flex items-center justify-center rounded-full bg-blue-50 p-2 text-blue-500">
-								<i data-feather="search" class="h-4 w-4"></i>
-							</span>
-						</div>
-						<div class="mt-4">
-							<div class="relative w-full">
-								<input 
-								  type="text" 
-								  placeholder="Gerät, Besitzer oder Spezifikation suchen..." 
-								  class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 pr-12 text-sm text-slate-700 shadow-inner focus:border-blue-500 focus:ring-blue-500"
-								  x-model="searchQuery" @input.debounce.300ms="searchDevices()"
-								>
-								<button 
-								  @click="toggleSortDropdown()" 
-								  aria-label="Sort options"
-								  class="absolute right-2 top-1/2 -translate-y-1/2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-slate-600 shadow-sm hover:bg-slate-50"
-								>
-								  <i data-feather="filter" class="w-4 h-4"></i>
-								</button>
+                <section class="grid gap-4 lg:grid-cols-4">
+                    <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-slate-900">Geräte durchsuchen</p>
+                                <p class="text-xs text-slate-500">Schneller Zugriff auf Assets</p>
+                            </div>
+                            <span class="inline-flex items-center justify-center rounded-full bg-blue-50 p-2 text-blue-500">
+                                <i data-feather="search" class="h-4 w-4"></i>
+                            </span>
+                        </div>
+                        <div class="mt-4">
+                            <div class="relative w-full">
+                                <input type="text" placeholder="Gerät, Owner oder Spezifikation suchen..." class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 pr-12 text-sm text-slate-700 shadow-inner focus:border-blue-500 focus:ring-blue-500" x-model="searchQuery" @input.debounce.300ms="searchDevices()">
+                                <button @click="toggleSortDropdown()" aria-label="Sort options" class="absolute right-2 top-1/2 -translate-y-1/2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-slate-600 shadow-sm hover:bg-slate-50">
+                                    <i data-feather="filter" class="w-4 h-4"></i>
+                                </button>
+                                <div x-show="sortDropdownOpen" @click.away="sortDropdownOpen = false" class="absolute right-0 mt-3 w-56 rounded-2xl bg-white border border-slate-200 shadow-xl z-50 overflow-hidden" style="display: none;" x-transition>
+                                    <div class="divide-y divide-slate-100">
+                                        <a href="#" @click.prevent="sortDevices('name', 'asc')" class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">Name (A–Z)</a>
+                                        <a href="#" @click.prevent="sortDevices('name', 'desc')" class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">Name (Z–A)</a>
+                                        <a href="#" @click.prevent="sortDevices('serial_number', 'asc')" class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">Owner (aufsteigend)</a>
+                                        <a href="#" @click.prevent="sortDevices('serial_number', 'desc')" class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">Owner (absteigend)</a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
 
-								<div 
-								  x-show="sortDropdownOpen" 
-								  @click.away="sortDropdownOpen = false"
-								  class="absolute right-0 mt-3 w-56 rounded-2xl bg-white border border-slate-200 shadow-xl z-50 overflow-hidden"
-								  style="display: none;"
-								  x-transition
-								>
-								  <div class="divide-y divide-slate-100">
-									<a href="#" @click.prevent="sortDevices('name', 'asc')"
-									   class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">
-									  Name (A–Z)
-									</a>
-									<a href="#" @click.prevent="sortDevices('name', 'desc')"
-									   class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">
-									  Name (Z–A)
-									</a>
-									<a href="#" @click.prevent="sortDevices('serial_number', 'asc')"
-									   class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">
-									  Owner (aufsteigend)
-									</a>
-									<a href="#" @click.prevent="sortDevices('serial_number', 'desc')"
-									   class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">
-									  Owner (absteigend)
-									</a>
-								  </div>
-								</div>
-							  </div>
-						</div>
-					</div>
-					<div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-						<div class="flex items-center justify-between">
-							<div>
-								<p class="text-sm font-semibold text-slate-900">Insights</p>
-								<p class="text-xs text-slate-500">Letzte Aktivität</p>
-							</div>
-							<span class="inline-flex items-center justify-center rounded-full bg-indigo-50 p-2 text-indigo-500">
-								<i data-feather="activity" class="h-4 w-4"></i>
-							</span>
-						</div>
-						<div class="mt-4 space-y-3 text-sm text-slate-600">
-							<div class="flex items-center justify-between">
-								<span>Aktive Kategorie</span>
-								<span class="font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></span>
-							</div>
-							<div class="flex items-center justify-between">
-								<span>Geräte im Fokus</span>
-								<span class="font-semibold text-slate-900" x-text="filteredDevices.length"></span>
-							</div>
-							<div class="flex items-center justify-between">
-								<span>Wartungen (Pro)</span>
-								<span class="font-semibold text-slate-900" x-text="maintenanceSummary.pro_locked ? 'Gesperrt' : maintenanceSummary.open"></span>
-							</div>
-							<div class="flex items-center justify-between">
-								<span>Überfällig</span>
-								<span class="font-semibold text-rose-600" x-text="maintenanceSummary.pro_locked ? '-' : maintenanceSummary.overdue"></span>
-							</div>
-							<div class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-500">
-								<i data-feather="lock" class="w-3 h-3"></i>
-								<span x-show="maintenanceSummary.pro_locked">Upgrade für Wartungen</span>
-								<span x-show="!maintenanceSummary.pro_locked">Pro aktiv</span>
-							</div>
-						</div>
-					</div>
-					<div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-						<div class="flex items-center justify-between">
-							<div>
-								<p class="text-sm font-semibold text-slate-900">Schnellaktionen</p>
-								<p class="text-xs text-slate-500">Arbeitsabläufe beschleunigen</p>
-							</div>
-							<span class="inline-flex items-center justify-center rounded-full bg-emerald-50 p-2 text-emerald-500">
-								<i data-feather="zap" class="h-4 w-4"></i>
-							</span>
-						</div>
-						<div class="mt-4 space-y-3">
-							<button @click="openAddDeviceModal()" class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">
-								Gerät hinzufügen
-							</button>
-							<button @click="openAddCategoryModal()" class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">
-								Kategorie erstellen
-							</button>
-							<a href="/stats" class="block w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">
-								Statistiken ansehen
-							</a>
-							<a href="/api/export/devices" class="block w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">
-								Export (Pro)
-							</a>
-						</div>
-					</div>
-					<div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-						<div class="flex items-center justify-between">
-							<div>
-								<p class="text-sm font-semibold text-slate-900">Aktivitäten</p>
-								<p class="text-xs text-slate-500">Letzte Änderungen im System</p>
-							</div>
-							<span class="inline-flex items-center justify-center rounded-full bg-slate-100 p-2 text-slate-500">
-								<i data-feather="list" class="h-4 w-4"></i>
-							</span>
-						</div>
-						<div class="mt-4 space-y-3 text-sm text-slate-600">
-							<template x-for="item in activityFeed" :key="item.created_at">
-								<div class="flex items-start justify-between gap-2">
-									<span class="font-semibold text-slate-800" x-text="formatActivity(item)"></span>
-									<span class="text-xs text-slate-400" x-text="item.created_at.slice(11, 16)"></span>
-								</div>
-							</template>
-							<p x-show="activityFeed.length === 0" class="text-xs text-slate-400">Noch keine Aktivitäten.</p>
-						</div>
-					</div>
-				</section>
+                    <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-slate-900">Insights</p>
+                                <p class="text-xs text-slate-500">Letzte Aktivität</p>
+                            </div>
+                            <span class="inline-flex items-center justify-center rounded-full bg-indigo-50 p-2 text-indigo-500">
+                                <i data-feather="activity" class="h-4 w-4"></i>
+                            </span>
+                        </div>
+                        <div class="mt-4 space-y-3 text-sm text-slate-600">
+                            <div class="flex items-center justify-between">
+                                <span>Aktive Kategorie</span>
+                                <span class="font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></span>
+                            </div>
+                            <div class="flex items-center justify-between">
+                                <span>Geräte im Fokus</span>
+                                <span class="font-semibold text-slate-900" x-text="filteredDevices.length"></span>
+                            </div>
+                            <div class="flex items-center justify-between">
+                                <span>Wartungen offen</span>
+                                <span class="font-semibold text-slate-900" x-text="maintenanceSummary.open"></span>
+                            </div>
+                            <div class="flex items-center justify-between">
+                                <span>Überfällig</span>
+                                <span class="font-semibold text-rose-600" x-text="maintenanceSummary.overdue"></span>
+                            </div>
+                            <div class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-500">
+                                <i data-feather="refresh-ccw" class="w-3 h-3"></i>
+                                Letztes Update
+                                <span class="font-semibold text-slate-900" x-text="new Date().toLocaleDateString('de-DE')"></span>
+                            </div>
+                        </div>
+                    </div>
 
-				<div class="rounded-3xl border border-slate-200 bg-white shadow-sm">
-					<div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
-						<div>
-							<h3 class="text-lg font-semibold text-slate-900">Geräteliste</h3>
-							<p class="text-sm text-slate-500">Übersicht aller Assets mit Standort und Owner.</p>
-						</div>
-						<span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
-							<i data-feather="database" class="w-3 h-3"></i>
-							<span x-text="filteredDevices.length"></span> Einträge
-						</span>
-					</div>
-					<div class="overflow-x-auto">
-						<table class="min-w-full text-sm">
-							<thead class="text-left text-slate-500">
-								<tr class="border-b border-slate-200">
-									<th class="py-3 px-6 font-semibold">Gerät</th>
-									<th class="py-3 px-6 font-semibold">Kategorie</th>
-									<th class="py-3 px-6 font-semibold">Standort</th>
-									<th class="py-3 px-6 font-semibold">Owner</th>
-									<th class="py-3 px-6 font-semibold">Specs</th>
-									<th class="py-3 px-6 font-semibold text-right">Aktionen</th>
-								</tr>
-							</thead>
-							<tbody class="divide-y divide-slate-100">
-								<template x-for="device in filteredDevices" :key="device.id">
-									<tr class="hover:bg-slate-50">
-										<td class="py-4 px-6">
-											<p class="font-semibold text-slate-900" x-text="device.name"></p>
-											<p class="text-xs text-slate-500" x-text="device.created_at?.slice(0, 10) || ''"></p>
-										</td>
-										<td class="py-4 px-6">
-											<span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide"
-												:class="getCategoryColor(device.category_name)">
-												<span x-text="device.category_name"></span>
-											</span>
-										</td>
-										<td class="py-4 px-6 text-slate-700" x-text="device.location_name || '-'"></td>
-										<td class="py-4 px-6 text-slate-700" x-text="device.serial_number || '-'"></td>
-										<td class="py-4 px-6">
-											<div class="flex flex-wrap gap-2">
-												<template x-for="(value, key) in Object.entries(JSON.parse(device.specs || '{}')).slice(0, 3)" :key="key">
-													<span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
-														<span x-text="key"></span>: <span class="ml-1 text-slate-800" x-text="value"></span>
-													</span>
-												</template>
-												<span x-show="Object.keys(JSON.parse(device.specs || '{}')).length === 0" class="text-xs text-slate-400">Keine Specs</span>
-											</div>
-										</td>
-										<td class="py-4 px-6 text-right">
-											<div class="inline-flex items-center gap-2">
-												<button @click="openEditDeviceModal(device)" class="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-100">
-													Bearbeiten
-												</button>
-												<button @click="openDeviceDetail(device)" class="rounded-full border border-blue-100 px-3 py-1 text-xs font-semibold text-blue-600 hover:bg-blue-50">
-													Details
-												</button>
-												<button @click="deleteDevice(device.id)" class="rounded-full border border-rose-200 px-3 py-1 text-xs font-semibold text-rose-600 hover:bg-rose-50">
-													Löschen
-												</button>
-											</div>
-										</td>
-									</tr>
-								</template>
-							</tbody>
-						</table>
-						<p x-show="filteredDevices.length === 0" class="px-6 py-6 text-sm text-slate-400">Keine Geräte gefunden.</p>
-					</div>
-				</div>
-            </main>
-        </div>
-			</div>
-					</div>
-				</section>
+                    <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-slate-900">Schnellaktionen</p>
+                                <p class="text-xs text-slate-500">Arbeitsabläufe beschleunigen</p>
+                            </div>
+                            <span class="inline-flex items-center justify-center rounded-full bg-emerald-50 p-2 text-emerald-500">
+                                <i data-feather="zap" class="h-4 w-4"></i>
+                            </span>
+                        </div>
+                        <div class="mt-4 space-y-3">
+                            <button @click="openAddDeviceModal()" class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">Gerät hinzufügen</button>
+                            <button @click="openAddCategoryModal()" class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">Kategorie erstellen</button>
+                            <a href="/stats" class="block w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">Statistiken ansehen</a>
+                            <a href="/api/export/devices" class="block w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">CSV Export</a>
+                        </div>
+                    </div>
 
-				<section class="grid gap-4 lg:grid-cols-4">
-				<section class="grid gap-4 lg:grid-cols-3">
-					<div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-						<div class="flex items-center justify-between">
-							<div>
-								<p class="text-sm font-semibold text-slate-900">Geräte durchsuchen</p>
-								<p class="text-xs text-slate-500">Schneller Zugriff auf Assets</p>
-							</div>
-							<span class="inline-flex items-center justify-center rounded-full bg-blue-50 p-2 text-blue-500">
-								<i data-feather="search" class="h-4 w-4"></i>
-							</span>
-						</div>
-						<div class="mt-4">
-							<div class="relative w-full">
-								<input 
-								  type="text" 
-								  placeholder="Gerät, Besitzer oder Spezifikation suchen..." 
-								  class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 pr-12 text-sm text-slate-700 shadow-inner focus:border-blue-500 focus:ring-blue-500"
-								  x-model="searchQuery" @input.debounce.300ms="searchDevices()"
-								>
-								<button 
-								  @click="toggleSortDropdown()" 
-								  aria-label="Sort options"
-								  class="absolute right-2 top-1/2 -translate-y-1/2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-slate-600 shadow-sm hover:bg-slate-50"
-								>
-								  <i data-feather="filter" class="w-4 h-4"></i>
-								</button>
+                    <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-slate-900">Aktivitäten</p>
+                                <p class="text-xs text-slate-500">Letzte Änderungen im System</p>
+                            </div>
+                            <span class="inline-flex items-center justify-center rounded-full bg-slate-100 p-2 text-slate-500">
+                                <i data-feather="list" class="h-4 w-4"></i>
+                            </span>
+                        </div>
+                        <div class="mt-4 space-y-3 text-sm text-slate-600">
+                            <template x-for="item in activityFeed" :key="item.created_at">
+                                <div class="flex items-start justify-between gap-2">
+                                    <span class="font-semibold text-slate-800" x-text="formatActivity(item)"></span>
+                                    <span class="text-xs text-slate-400" x-text="item.created_at.slice(11, 16)"></span>
+                                </div>
+                            </template>
+                            <p x-show="activityFeed.length === 0" class="text-xs text-slate-400">Noch keine Aktivitäten.</p>
+                        </div>
+                    </div>
+                </section>
 
-								<div 
-								  x-show="sortDropdownOpen" 
-								  @click.away="sortDropdownOpen = false"
-								  class="absolute right-0 mt-3 w-56 rounded-2xl bg-white border border-slate-200 shadow-xl z-50 overflow-hidden"
-								  style="display: none;"
-								  x-transition
-								>
-								  <div class="divide-y divide-slate-100">
-									<a href="#" @click.prevent="sortDevices('name', 'asc')"
-									   class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">
-									  Name (A–Z)
-									</a>
-									<a href="#" @click.prevent="sortDevices('name', 'desc')"
-									   class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">
-									  Name (Z–A)
-									</a>
-									<a href="#" @click.prevent="sortDevices('serial_number', 'asc')"
-									   class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">
-									  Owner (aufsteigend)
-									</a>
-									<a href="#" @click.prevent="sortDevices('serial_number', 'desc')"
-									   class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">
-									  Owner (absteigend)
-									</a>
-								  </div>
-								</div>
-							  </div>
-						</div>
-					</div>
-					<div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-						<div class="flex items-center justify-between">
-							<div>
-								<p class="text-sm font-semibold text-slate-900">Insights</p>
-								<p class="text-xs text-slate-500">Letzte Aktivität</p>
-							</div>
-							<span class="inline-flex items-center justify-center rounded-full bg-indigo-50 p-2 text-indigo-500">
-								<i data-feather="activity" class="h-4 w-4"></i>
-							</span>
-						</div>
-						<div class="mt-4 space-y-3 text-sm text-slate-600">
-							<div class="flex items-center justify-between">
-								<span>Aktive Kategorie</span>
-								<span class="font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></span>
-							</div>
-							<div class="flex items-center justify-between">
-								<span>Geräte im Fokus</span>
-								<span class="font-semibold text-slate-900" x-text="filteredDevices.length"></span>
-							</div>
-							<div class="flex items-center justify-between">
-								<span>Wartungen (Pro)</span>
-								<span class="font-semibold text-slate-900" x-text="maintenanceSummary.pro_locked ? 'Gesperrt' : maintenanceSummary.open"></span>
-							</div>
-							<div class="flex items-center justify-between">
-								<span>Überfällig</span>
-								<span class="font-semibold text-rose-600" x-text="maintenanceSummary.pro_locked ? '-' : maintenanceSummary.overdue"></span>
-							</div>
-							<div class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-500">
-								<i data-feather="lock" class="w-3 h-3"></i>
-								<span x-show="maintenanceSummary.pro_locked">Upgrade für Wartungen</span>
-								<span x-show="!maintenanceSummary.pro_locked">Pro aktiv</span>
-								<span>Letztes Update</span>
-								<span class="font-semibold text-slate-900" x-text="new Date().toLocaleDateString('de-DE')"></span>
-							</div>
-						</div>
-					</div>
-					<div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-						<div class="flex items-center justify-between">
-							<div>
-								<p class="text-sm font-semibold text-slate-900">Schnellaktionen</p>
-								<p class="text-xs text-slate-500">Arbeitsabläufe beschleunigen</p>
-							</div>
-							<span class="inline-flex items-center justify-center rounded-full bg-emerald-50 p-2 text-emerald-500">
-								<i data-feather="zap" class="h-4 w-4"></i>
-							</span>
-						</div>
-						<div class="mt-4 space-y-3">
-							<button @click="openAddDeviceModal()" class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">
-								Gerät hinzufügen
-							</button>
-							<button @click="openAddCategoryModal()" class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">
-								Kategorie erstellen
-							</button>
-							<a href="/stats" class="block w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">
-								Statistiken ansehen
-							</a>
-							<a href="/api/export/devices" class="block w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">
-								Export (Pro)
-							</a>
-						</div>
-					</div>
-					<div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-						<div class="flex items-center justify-between">
-							<div>
-								<p class="text-sm font-semibold text-slate-900">Aktivitäten</p>
-								<p class="text-xs text-slate-500">Letzte Änderungen im System</p>
-							</div>
-							<span class="inline-flex items-center justify-center rounded-full bg-slate-100 p-2 text-slate-500">
-								<i data-feather="list" class="h-4 w-4"></i>
-							</span>
-						</div>
-						<div class="mt-4 space-y-3 text-sm text-slate-600">
-							<template x-for="item in activityFeed" :key="item.created_at">
-								<div class="flex items-start justify-between gap-2">
-									<span class="font-semibold text-slate-800" x-text="formatActivity(item)"></span>
-									<span class="text-xs text-slate-400" x-text="item.created_at.slice(11, 16)"></span>
-								</div>
-							</template>
-							<p x-show="activityFeed.length === 0" class="text-xs text-slate-400">Noch keine Aktivitäten.</p>
-						</div>
-					</div>
-				</section>
-
-			<!-- Device Detail Modal -->
-			<div x-show="deviceDetailOpen" @click.away="closeDeviceDetail()"
-				 class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-6"
-				 x-transition>
-				<div class="bg-white rounded-3xl shadow-2xl w-full max-w-4xl overflow-hidden">
-					<div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
-						<div>
-							<p class="text-xs uppercase tracking-[0.2em] text-slate-400">Geräteübersicht</p>
-							<h3 class="text-xl font-semibold text-slate-900" x-text="selectedDevice?.name"></h3>
-						</div>
-						<button @click="closeDeviceDetail()" class="text-slate-400 hover:text-slate-600">
-							<i data-feather="x" class="w-6 h-6"></i>
-						</button>
-					</div>
-					<div class="grid gap-6 p-6 lg:grid-cols-3">
-						<div class="lg:col-span-2 space-y-6">
-							<div class="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-								<p class="text-sm font-semibold text-slate-700">Kurzprofil</p>
-								<div class="mt-3 grid gap-2 text-sm text-slate-600">
-										<div class="flex justify-between">
-											<span>Kategorie</span>
-											<span class="font-semibold text-slate-900" x-text="selectedDevice?.category_name"></span>
-										</div>
-										<div class="flex justify-between">
-											<span>Standort</span>
-											<span class="font-semibold text-slate-900" x-text="selectedDevice?.location_name || '-'"></span>
-										</div>
-									<div class="flex justify-between">
-										<span>Owner</span>
-										<span class="font-semibold text-slate-900" x-text="selectedDevice?.serial_number || '-'"></span>
-									</div>
-									<div class="flex justify-between">
-										<span>Erstellt</span>
-										<span class="font-semibold text-slate-900" x-text="selectedDevice?.created_at?.slice(0, 10) || '-'"></span>
-									</div>
-								</div>
-							</div>
-
-							<div class="rounded-2xl border border-slate-200 bg-white p-4">
-								<div class="flex items-center justify-between">
-									<div>
-										<p class="text-sm font-semibold text-slate-900">Notizen</p>
-										<p class="text-xs text-slate-500">Freigabe für alle Nutzer</p>
-									</div>
-									<i data-feather="file-text" class="w-4 h-4 text-slate-400"></i>
-								</div>
-								<div class="mt-3 flex gap-2">
-									<input type="text" placeholder="Neue Notiz hinzufügen" x-model="newNote"
-										   class="flex-1 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-blue-500 focus:ring-blue-500">
-									<button @click="addNote()" class="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">Speichern</button>
-								</div>
-								<div class="mt-4 space-y-3">
-									<template x-for="note in deviceNotes" :key="note.id">
-										<div class="flex items-start justify-between rounded-2xl border border-slate-100 bg-slate-50 px-3 py-2">
-											<div>
-												<p class="text-sm text-slate-700" x-text="note.note"></p>
-												<p class="text-xs text-slate-400" x-text="note.created_at.slice(0, 10)"></p>
-											</div>
-											<button @click="deleteNote(note.id)" class="text-slate-400 hover:text-rose-500">
-												<i data-feather="trash-2" class="w-4 h-4"></i>
-											</button>
-										</div>
-									</template>
-									<p x-show="deviceNotes.length === 0" class="text-xs text-slate-400">Noch keine Notizen.</p>
-								</div>
-							</div>
-						</div>
-
-						<div class="space-y-6">
-							<div class="rounded-2xl border border-slate-200 bg-white p-4">
-								<div class="flex items-center justify-between">
-									<div>
-										<p class="text-sm font-semibold text-slate-900">Tags</p>
-										<p class="text-xs text-slate-500">Freie Labels für Ordnung</p>
-									</div>
-									<i data-feather="tag" class="w-4 h-4 text-slate-400"></i>
-								</div>
-								<div class="mt-3 flex gap-2">
-									<input type="text" placeholder="Tag hinzufügen" x-model="newTag"
-										   class="flex-1 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-blue-500 focus:ring-blue-500">
-									<button @click="addTag()" class="rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50">Add</button>
-								</div>
-								<div class="mt-4 flex flex-wrap gap-2">
-									<template x-for="tag in deviceTags" :key="tag.id">
-										<span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
-											<span x-text="tag.tag"></span>
-											<button @click="removeTag(tag.id)" class="text-slate-400 hover:text-rose-500">
-												<i data-feather="x" class="w-3 h-3"></i>
-											</button>
-										</span>
-									</template>
-									<p x-show="deviceTags.length === 0" class="text-xs text-slate-400">Noch keine Tags.</p>
-								</div>
-							</div>
-
-							<div class="rounded-2xl border border-indigo-100 bg-indigo-50/60 p-4">
-								<div class="flex items-center justify-between">
-									<div>
-										<p class="text-sm font-semibold text-indigo-700">Wartungsplan (Pro)</p>
-										<p class="text-xs text-indigo-500">Erinnerungen &amp; Checklisten</p>
-									</div>
-									<i data-feather="shield" class="w-4 h-4 text-indigo-400"></i>
-								</div>
-								<div class="mt-3 space-y-3" :class="maintenanceSummary.pro_locked ? 'opacity-60' : ''">
-									<div class="flex gap-2">
-										<input type="text" placeholder="Wartungstitel" x-model="newMaintenance.title"
-											   class="flex-1 rounded-2xl border border-indigo-100 bg-white px-3 py-2 text-sm focus:border-indigo-400 focus:ring-indigo-400">
-									</div>
-									<div class="flex gap-2">
-										<input type="date" x-model="newMaintenance.due_date"
-											   class="flex-1 rounded-2xl border border-indigo-100 bg-white px-3 py-2 text-sm focus:border-indigo-400 focus:ring-indigo-400">
-										<button @click="addMaintenanceTask()" class="rounded-2xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500">
-											Planen
-										</button>
-									</div>
-								</div>
-								<div class="mt-4 space-y-3">
-									<template x-for="task in maintenanceTasks" :key="task.id">
-										<div class="flex items-start justify-between rounded-2xl border border-indigo-100 bg-white px-3 py-2 text-sm">
-											<div>
-												<p class="font-semibold text-slate-800" x-text="task.title"></p>
-												<p class="text-xs text-slate-400" x-text="task.due_date ? `Fällig: ${task.due_date}` : 'Kein Datum'"></p>
-											</div>
-											<button @click="updateMaintenanceStatus(task.id, task.status === 'open' ? 'done' : 'open')"
-													class="text-xs font-semibold text-indigo-600">
-												<span x-text="task.status === 'open' ? 'Erledigt' : 'Offen'"></span>
-											</button>
-						<div class="device-card bg-white rounded-2xl shadow-sm border border-slate-200 overflow-hidden transition-all hover:shadow-lg hover:-translate-y-0.5">
-							<div class="p-5">
-								<div class="flex justify-between items-start">
-									<div>
-										<span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide"
-											:class="getCategoryColor(device.category_name)">
-											<span x-text="device.category_name"></span>
-										</span>
-										<h3 class="mt-3 text-lg font-semibold text-slate-900" x-text="device.name"></h3>
-									</div>
-									<div class="flex items-center space-x-2 text-slate-500 hover:text-slate-900">
-										<button @click="openEditDeviceModal(device)" class="p-2 hover:bg-slate-100 rounded-xl">
-											<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-													d="M15.232 5.232l3.536 3.536M4 20h4l10-10-4-4L4 16v4z" />
-											</svg>
-										</button>
-										<button @click="openDeviceDetail(device)" class="p-2 hover:bg-blue-100 rounded-xl text-blue-600">
-											<i data-feather="info" class="w-5 h-5"></i>
-										</button>
-										<button @click="deleteDevice(device.id)" class="p-2 hover:bg-rose-100 rounded-xl">
-											<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-rose-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-													d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22" />
-											</svg>
-										</button>
-									</div>
-								</div>
-								
-								<div class="mt-4 space-y-2 rounded-2xl bg-slate-50 p-3">
-									<template x-if="device.serial_number">
-										<div class="flex justify-between text-sm">
-											<span class="text-slate-500">Owner</span>
-											<span class="font-semibold text-slate-800" x-text="device.serial_number"></span>
-										</div>
-									</template>
-									
-									<template x-for="(value, key) in JSON.parse(device.specs || '{}')" :key="key">
-										<div class="flex justify-between text-sm">
-											<span class="text-slate-500" x-text="key"></span>
-											<span class="font-semibold text-slate-800" x-text="value"></span>
-										</div>
-									</template>
-									<p x-show="maintenanceSummary.pro_locked" class="text-xs text-indigo-500">Pro-Funktion aktivieren, um Wartungen zu planen.</p>
-									<p x-show="!maintenanceSummary.pro_locked && maintenanceTasks.length === 0" class="text-xs text-slate-400">Keine Wartungen geplant.</p>
-								</div>
-							</div>
-						</div>
-						
-						
-						
-						
-                    </template>
+                <div class="rounded-3xl border border-slate-200 bg-white shadow-sm">
+                    <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+                        <div>
+                            <h3 class="text-lg font-semibold text-slate-900">Geräteliste</h3>
+                            <p class="text-sm text-slate-500">Übersicht aller Assets mit Standort und Owner.</p>
+                        </div>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+                            <i data-feather="database" class="w-3 h-3"></i>
+                            <span x-text="filteredDevices.length"></span> Einträge
+                        </span>
+                    </div>
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full text-sm">
+                            <thead class="text-left text-slate-500">
+                                <tr class="border-b border-slate-200">
+                                    <th class="py-3 px-6 font-semibold">Gerät</th>
+                                    <th class="py-3 px-6 font-semibold">Kategorie</th>
+                                    <th class="py-3 px-6 font-semibold">Standort</th>
+                                    <th class="py-3 px-6 font-semibold">Owner</th>
+                                    <th class="py-3 px-6 font-semibold">Specs</th>
+                                    <th class="py-3 px-6 font-semibold text-right">Aktionen</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100">
+                                <template x-for="device in filteredDevices" :key="device.id">
+                                    <tr class="hover:bg-slate-50">
+                                        <td class="py-4 px-6">
+                                            <p class="font-semibold text-slate-900" x-text="device.name"></p>
+                                            <p class="text-xs text-slate-500" x-text="device.created_at?.slice(0, 10) || ''"></p>
+                                        </td>
+                                        <td class="py-4 px-6">
+                                            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide" :class="getCategoryColor(device.category_name)">
+                                                <span x-text="device.category_name"></span>
+                                            </span>
+                                        </td>
+                                        <td class="py-4 px-6 text-slate-700" x-text="device.location_name || '-' "></td>
+                                        <td class="py-4 px-6 text-slate-700" x-text="device.serial_number || '-' "></td>
+                                        <td class="py-4 px-6">
+                                            <div class="flex flex-wrap gap-2">
+                                                <template x-for="(value, key) in Object.entries(JSON.parse(device.specs || '{}')).slice(0, 3)" :key="key">
+                                                    <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+                                                        <span x-text="key"></span>: <span class="ml-1 text-slate-800" x-text="value"></span>
+                                                    </span>
+                                                </template>
+                                                <span x-show="Object.keys(JSON.parse(device.specs || '{}')).length === 0" class="text-xs text-slate-400">Keine Specs</span>
+                                            </div>
+                                        </td>
+                                        <td class="py-4 px-6 text-right">
+                                            <div class="inline-flex items-center gap-2">
+                                                <button @click="openEditDeviceModal(device)" class="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-100">Bearbeiten</button>
+                                                <button @click="openDeviceDetail(device)" class="rounded-full border border-blue-100 px-3 py-1 text-xs font-semibold text-blue-600 hover:bg-blue-50">Details</button>
+                                                <button @click="deleteDevice(device.id)" class="rounded-full border border-rose-200 px-3 py-1 text-xs font-semibold text-rose-600 hover:bg-rose-50">Löschen</button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </template>
+                            </tbody>
+                        </table>
+                        <p x-show="filteredDevices.length === 0" class="px-6 py-6 text-sm text-slate-400">Keine Geräte gefunden.</p>
+                    </div>
                 </div>
             </main>
         </div>
-			</div>
-
-			<!-- Device Detail Modal -->
-			<div x-show="deviceDetailOpen" @click.away="closeDeviceDetail()"
-				 class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-6"
-				 x-transition>
-				<div class="bg-white rounded-3xl shadow-2xl w-full max-w-4xl overflow-hidden">
-					<div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
-						<div>
-							<p class="text-xs uppercase tracking-[0.2em] text-slate-400">Geräteübersicht</p>
-							<h3 class="text-xl font-semibold text-slate-900" x-text="selectedDevice?.name"></h3>
-						</div>
-						<button @click="closeDeviceDetail()" class="text-slate-400 hover:text-slate-600">
-							<i data-feather="x" class="w-6 h-6"></i>
-						</button>
-					</div>
-					<div class="grid gap-6 p-6 lg:grid-cols-3">
-						<div class="lg:col-span-2 space-y-6">
-							<div class="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-								<p class="text-sm font-semibold text-slate-700">Kurzprofil</p>
-								<div class="mt-3 grid gap-2 text-sm text-slate-600">
-										<div class="flex justify-between">
-											<span>Kategorie</span>
-											<span class="font-semibold text-slate-900" x-text="selectedDevice?.category_name"></span>
-										</div>
-										<div class="flex justify-between">
-											<span>Standort</span>
-											<span class="font-semibold text-slate-900" x-text="selectedDevice?.location_name || '-'"></span>
-										</div>
-									<div class="flex justify-between">
-										<span>Kategorie</span>
-										<span class="font-semibold text-slate-900" x-text="selectedDevice?.category_name"></span>
-									</div>
-									<div class="flex justify-between">
-										<span>Owner</span>
-										<span class="font-semibold text-slate-900" x-text="selectedDevice?.serial_number || '-'"></span>
-									</div>
-									<div class="flex justify-between">
-										<span>Erstellt</span>
-										<span class="font-semibold text-slate-900" x-text="selectedDevice?.created_at?.slice(0, 10) || '-'"></span>
-									</div>
-								</div>
-							</div>
-
-							<div class="rounded-2xl border border-slate-200 bg-white p-4">
-								<div class="flex items-center justify-between">
-									<div>
-										<p class="text-sm font-semibold text-slate-900">Notizen</p>
-										<p class="text-xs text-slate-500">Freigabe für alle Nutzer</p>
-									</div>
-									<i data-feather="file-text" class="w-4 h-4 text-slate-400"></i>
-								</div>
-								<div class="mt-3 flex gap-2">
-									<input type="text" placeholder="Neue Notiz hinzufügen" x-model="newNote"
-										   class="flex-1 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-blue-500 focus:ring-blue-500">
-									<button @click="addNote()" class="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">Speichern</button>
-								</div>
-								<div class="mt-4 space-y-3">
-									<template x-for="note in deviceNotes" :key="note.id">
-										<div class="flex items-start justify-between rounded-2xl border border-slate-100 bg-slate-50 px-3 py-2">
-											<div>
-												<p class="text-sm text-slate-700" x-text="note.note"></p>
-												<p class="text-xs text-slate-400" x-text="note.created_at.slice(0, 10)"></p>
-											</div>
-											<button @click="deleteNote(note.id)" class="text-slate-400 hover:text-rose-500">
-												<i data-feather="trash-2" class="w-4 h-4"></i>
-											</button>
-										</div>
-									</template>
-									<p x-show="deviceNotes.length === 0" class="text-xs text-slate-400">Noch keine Notizen.</p>
-								</div>
-							</div>
-						</div>
-
-						<div class="space-y-6">
-							<div class="rounded-2xl border border-slate-200 bg-white p-4">
-								<div class="flex items-center justify-between">
-									<div>
-										<p class="text-sm font-semibold text-slate-900">Tags</p>
-										<p class="text-xs text-slate-500">Freie Labels für Ordnung</p>
-									</div>
-									<i data-feather="tag" class="w-4 h-4 text-slate-400"></i>
-								</div>
-								<div class="mt-3 flex gap-2">
-									<input type="text" placeholder="Tag hinzufügen" x-model="newTag"
-										   class="flex-1 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-blue-500 focus:ring-blue-500">
-									<button @click="addTag()" class="rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50">Add</button>
-								</div>
-								<div class="mt-4 flex flex-wrap gap-2">
-									<template x-for="tag in deviceTags" :key="tag.id">
-										<span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
-											<span x-text="tag.tag"></span>
-											<button @click="removeTag(tag.id)" class="text-slate-400 hover:text-rose-500">
-												<i data-feather="x" class="w-3 h-3"></i>
-											</button>
-										</span>
-									</template>
-									<p x-show="deviceTags.length === 0" class="text-xs text-slate-400">Noch keine Tags.</p>
-								</div>
-							</div>
-
-							<div class="rounded-2xl border border-indigo-100 bg-indigo-50/60 p-4">
-								<div class="flex items-center justify-between">
-									<div>
-										<p class="text-sm font-semibold text-indigo-700">Wartungsplan (Pro)</p>
-										<p class="text-xs text-indigo-500">Erinnerungen &amp; Checklisten</p>
-									</div>
-									<i data-feather="shield" class="w-4 h-4 text-indigo-400"></i>
-								</div>
-								<div class="mt-3 space-y-3" :class="maintenanceSummary.pro_locked ? 'opacity-60' : ''">
-									<div class="flex gap-2">
-										<input type="text" placeholder="Wartungstitel" x-model="newMaintenance.title"
-											   class="flex-1 rounded-2xl border border-indigo-100 bg-white px-3 py-2 text-sm focus:border-indigo-400 focus:ring-indigo-400">
-									</div>
-									<div class="flex gap-2">
-										<input type="date" x-model="newMaintenance.due_date"
-											   class="flex-1 rounded-2xl border border-indigo-100 bg-white px-3 py-2 text-sm focus:border-indigo-400 focus:ring-indigo-400">
-										<button @click="addMaintenanceTask()" class="rounded-2xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500">
-											Planen
-										</button>
-									</div>
-								</div>
-								<div class="mt-4 space-y-3">
-									<template x-for="task in maintenanceTasks" :key="task.id">
-										<div class="flex items-start justify-between rounded-2xl border border-indigo-100 bg-white px-3 py-2 text-sm">
-											<div>
-												<p class="font-semibold text-slate-800" x-text="task.title"></p>
-												<p class="text-xs text-slate-400" x-text="task.due_date ? `Fällig: ${task.due_date}` : 'Kein Datum'"></p>
-											</div>
-											<button @click="updateMaintenanceStatus(task.id, task.status === 'open' ? 'done' : 'open')"
-													class="text-xs font-semibold text-indigo-600">
-												<span x-text="task.status === 'open' ? 'Erledigt' : 'Offen'"></span>
-											</button>
-										</div>
-									</template>
-									<p x-show="maintenanceSummary.pro_locked" class="text-xs text-indigo-500">Pro-Funktion aktivieren, um Wartungen zu planen.</p>
-									<p x-show="!maintenanceSummary.pro_locked && maintenanceTasks.length === 0" class="text-xs text-slate-400">Keine Wartungen geplant.</p>
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-			
-			<!-- Add/Edit Category Modal -->
-		<div x-show="isCategoryModalOpen" @click.away="closeCategoryModal()"
-			 class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-6"
-			 x-transition>
-			<div class="bg-white rounded-3xl shadow-2xl w-full max-w-lg">
-				<div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
-					<div>
-						<p class="text-xs uppercase tracking-[0.2em] text-slate-400">Kategorie</p>
-						<h3 class="text-lg font-semibold text-slate-900" x-text="editingCategory ? 'Kategorie bearbeiten' : 'Neue Kategorie'"></h3>
-					</div>
-					<button @click="closeCategoryModal()" class="text-slate-400 hover:text-slate-600">
-						<i data-feather="x" class="w-5 h-5"></i>
-					</button>
-				</div>
-				<form @submit.prevent="saveCategory()" class="space-y-4 p-6">
-					<div>
-						<label class="text-sm font-semibold text-slate-700">Name*</label>
-						<input type="text" x-model="currentCategory.name" required
-							   class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
-					</div>
-					<div>
-						<label class="text-sm font-semibold text-slate-700">Icon*</label>
-						<select x-model="currentCategory.icon" required
-								class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
-							<option value="cpu">CPU</option>
-							<option value="gpu">GPU</option>
-							<option value="memory">RAM</option>
-							<option value="hard-drive">Festplatte</option>
-							<option value="server">Server</option>
-							<option value="monitor">Monitor</option>
-							<option value="printer">Drucker</option>
-							<option value="wind">Kühlsystem</option>
-							<option value="grid">Mainboard</option>
-							<option value="zap">Netzteil</option>
-							<option value="sliders">RAM</option>
-							<option value="wifi">Netzwerk</option>
-							<option value="code">Raspberry Pi</option>
-						</select>
-					</div>
-					<div>
-						<label class="text-sm font-semibold text-slate-700">Felder (JSON)*</label>
-						<textarea x-model="currentCategory.fields" rows="4" required
-								  class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500 font-mono"
-								  placeholder='{"field1":"text","field2":"number"}'></textarea>
-						<p class="mt-2 text-xs text-slate-400">Beispiel: {"Modell":"text","Kernezahl":"number"}</p>
-					</div>
-					<div class="flex justify-end gap-3 pt-2">
-						<button type="button" @click="closeCategoryModal()"
-								class="rounded-2xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100">
-							Abbrechen
-						</button>
-						<button type="submit"
-								class="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">
-							Speichern
-						</button>
-					</div>
-				</form>
-			</div>
-		</div>
-		
-        <!-- Add/Edit Device Modal -->
-		<div x-show="isDeviceModalOpen" @click.away="closeDeviceModal()"
-			class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-6">
-			<div class="bg-white rounded-3xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
-				<div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
-					<div>
-						<p class="text-xs uppercase tracking-[0.2em] text-slate-400">Gerät</p>
-						<h3 class="text-lg font-semibold text-slate-900" x-text="editingDevice ? 'Gerät bearbeiten' : 'Neues Gerät'"></h3>
-					</div>
-					<button @click="closeDeviceModal()" class="text-slate-400 hover:text-slate-600">
-						<i data-feather="x" class="w-5 h-5"></i>
-					</button>
-				</div>
-				<form @submit.prevent="saveDevice()" class="space-y-4 p-6">
-					<input type="hidden" x-model="currentDevice.id">
-					<div class="grid gap-4 lg:grid-cols-2">
-						<div>
-							<label class="text-sm font-semibold text-slate-700">Name*</label>
-							<input type="text" x-model="currentDevice.name" required
-								class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
-						</div>
-						<div>
-							<label class="text-sm font-semibold text-slate-700">Kategorie</label>
-							<select x-model="currentDevice.category_id" required
-								class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
-								<option value="">-- Kategorie wählen --</option>
-								<template x-for="category in categories" :key="category.id">
-									<option :value="category.id" x-text="category.name"></option>
-								</template>
-							</select>
-						</div>
-						
-							<div class="form-group">
-								<label class="block text-sm font-medium text-gray-700 mb-1">Owner</label>
-								<input type="text" x-model="currentDevice.serial_number"
-									class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-							</div>
-
-							<div class="form-group">
-								<label class="block text-sm font-medium text-gray-700 mb-1">Standort</label>
-								<select x-model="currentDevice.location_id"
-									class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-									<option value="">-- Standort wählen --</option>
-									<template x-for="location in locations" :key="location.id">
-										<option :value="location.id" x-text="location.name"></option>
-									</template>
-								</select>
-							</div>
-						
-						<div class="form-group">
-							<label class="block text-sm font-medium text-gray-700 mb-1">Spezifikationen</label>
-							<div class="space-y-2">
-								<template x-for="(fieldType, fieldName) in getCategoryFields(currentDevice.category_id)" :key="fieldName">
-									<div>
-										<label class="block text-sm font-medium text-gray-700 mb-1" x-text="fieldName"></label>
-										<template x-if="fieldType === 'number'">
-											<input type="number" x-model="currentDevice.specs[fieldName]"
-												class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-										</template>
-										<template x-if="fieldType !== 'number'">
-											<input type="text" x-model="currentDevice.specs[fieldName]"
-												class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-										</template>
-									</div>
-								</template>
-							</select>
-						</div>
-					</div>
-					<div>
-						<label class="text-sm font-semibold text-slate-700">Spezifikationen</label>
-						<div class="mt-2 space-y-2">
-							<template x-for="(fieldType, fieldName) in getCategoryFields(currentDevice.category_id) || {}" :key="fieldName">
-								<div>
-									<label class="block text-xs font-semibold text-slate-500 mb-1" x-text="fieldName"></label>
-									<template x-if="fieldType === 'number'">
-										<input type="number" x-model="currentDevice.specs[fieldName]"
-											class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm focus:border-blue-500 focus:ring-blue-500">
-									</template>
-									<template x-if="fieldType !== 'number'">
-										<input type="text" x-model="currentDevice.specs[fieldName]"
-											class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm focus:border-blue-500 focus:ring-blue-500">
-									</template>
-								</div>
-							</template>
-							<p x-show="!getCategoryFields(currentDevice.category_id)" class="text-xs text-slate-400">Keine spezifischen Felder definiert.</p>
-						</div>
-					</div>
-					<div class="flex justify-end gap-3 pt-2">
-						<button type="button" @click="closeDeviceModal()"
-							class="rounded-2xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100">
-							Abbrechen
-						</button>
-						<button type="submit"
-							class="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">
-							Speichern
-						</button>
-					</div>
-				</form>
-			</div>
-		</div>
     </div>
-		<script src="/static/script.js"></script>
-		<script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+
+    <div x-show="deviceDetailOpen" @click.away="closeDeviceDetail()" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-6" x-transition>
+        <div class="bg-white rounded-3xl shadow-2xl w-full max-w-4xl overflow-hidden">
+            <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Geräteübersicht</p>
+                    <h3 class="text-xl font-semibold text-slate-900" x-text="selectedDevice?.name"></h3>
+                </div>
+                <button @click="closeDeviceDetail()" class="text-slate-400 hover:text-slate-600">
+                    <i data-feather="x" class="w-6 h-6"></i>
+                </button>
+            </div>
+            <div class="grid gap-6 p-6 lg:grid-cols-3">
+                <div class="lg:col-span-2 space-y-6">
+                    <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                        <p class="text-sm font-semibold text-slate-700">Kurzprofil</p>
+                        <div class="mt-3 grid gap-2 text-sm text-slate-600">
+                            <div class="flex justify-between">
+                                <span>Kategorie</span>
+                                <span class="font-semibold text-slate-900" x-text="selectedDevice?.category_name"></span>
+                            </div>
+                            <div class="flex justify-between">
+                                <span>Standort</span>
+                                <span class="font-semibold text-slate-900" x-text="selectedDevice?.location_name || '-' "></span>
+                            </div>
+                            <div class="flex justify-between">
+                                <span>Owner</span>
+                                <span class="font-semibold text-slate-900" x-text="selectedDevice?.serial_number || '-' "></span>
+                            </div>
+                            <div class="flex justify-between">
+                                <span>Erstellt</span>
+                                <span class="font-semibold text-slate-900" x-text="selectedDevice?.created_at?.slice(0, 10) || '-' "></span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-slate-900">Notizen</p>
+                                <p class="text-xs text-slate-500">Freigabe für alle Nutzer</p>
+                            </div>
+                            <i data-feather="file-text" class="w-4 h-4 text-slate-400"></i>
+                        </div>
+                        <div class="mt-3 flex gap-2">
+                            <input type="text" placeholder="Neue Notiz hinzufügen" x-model="newNote" class="flex-1 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-blue-500 focus:ring-blue-500">
+                            <button @click="addNote()" class="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">Speichern</button>
+                        </div>
+                        <div class="mt-4 space-y-3">
+                            <template x-for="note in deviceNotes" :key="note.id">
+                                <div class="flex items-start justify-between rounded-2xl border border-slate-100 bg-slate-50 px-3 py-2">
+                                    <div>
+                                        <p class="text-sm text-slate-700" x-text="note.note"></p>
+                                        <p class="text-xs text-slate-400" x-text="note.created_at.slice(0, 10)"></p>
+                                    </div>
+                                    <button @click="deleteNote(note.id)" class="text-slate-400 hover:text-rose-500">
+                                        <i data-feather="trash-2" class="w-4 h-4"></i>
+                                    </button>
+                                </div>
+                            </template>
+                            <p x-show="deviceNotes.length === 0" class="text-xs text-slate-400">Noch keine Notizen.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="space-y-6">
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-slate-900">Tags</p>
+                                <p class="text-xs text-slate-500">Freie Labels für Ordnung</p>
+                            </div>
+                            <i data-feather="tag" class="w-4 h-4 text-slate-400"></i>
+                        </div>
+                        <div class="mt-3 flex gap-2">
+                            <input type="text" placeholder="Tag hinzufügen" x-model="newTag" class="flex-1 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-blue-500 focus:ring-blue-500">
+                            <button @click="addTag()" class="rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50">Add</button>
+                        </div>
+                        <div class="mt-4 flex flex-wrap gap-2">
+                            <template x-for="tag in deviceTags" :key="tag.id">
+                                <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+                                    <span x-text="tag.tag"></span>
+                                    <button @click="removeTag(tag.id)" class="text-slate-400 hover:text-rose-500">
+                                        <i data-feather="x" class="w-3 h-3"></i>
+                                    </button>
+                                </span>
+                            </template>
+                            <p x-show="deviceTags.length === 0" class="text-xs text-slate-400">Noch keine Tags.</p>
+                        </div>
+                    </div>
+
+                    <div class="rounded-2xl border border-indigo-100 bg-indigo-50/60 p-4">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-indigo-700">Wartungsplan</p>
+                                <p class="text-xs text-indigo-500">Erinnerungen &amp; Checklisten</p>
+                            </div>
+                            <i data-feather="shield" class="w-4 h-4 text-indigo-400"></i>
+                        </div>
+                        <div class="mt-3 space-y-3">
+                            <div class="flex gap-2">
+                                <input type="text" placeholder="Wartungstitel" x-model="newMaintenance.title" class="flex-1 rounded-2xl border border-indigo-100 bg-white px-3 py-2 text-sm focus:border-indigo-400 focus:ring-indigo-400">
+                            </div>
+                            <div class="flex gap-2">
+                                <input type="date" x-model="newMaintenance.due_date" class="flex-1 rounded-2xl border border-indigo-100 bg-white px-3 py-2 text-sm focus:border-indigo-400 focus:ring-indigo-400">
+                                <button @click="addMaintenanceTask()" class="rounded-2xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500">Planen</button>
+                            </div>
+                        </div>
+                        <div class="mt-4 space-y-3">
+                            <template x-for="task in maintenanceTasks" :key="task.id">
+                                <div class="flex items-start justify-between rounded-2xl border border-indigo-100 bg-white px-3 py-2 text-sm">
+                                    <div>
+                                        <p class="font-semibold text-slate-800" x-text="task.title"></p>
+                                        <p class="text-xs text-slate-400" x-text="task.due_date ? `Fällig: ${task.due_date}` : 'Kein Datum'"></p>
+                                    </div>
+                                    <button @click="updateMaintenanceStatus(task.id, task.status === 'open' ? 'done' : 'open')" class="text-xs font-semibold text-indigo-600">
+                                        <span x-text="task.status === 'open' ? 'Erledigt' : 'Offen'"></span>
+                                    </button>
+                                </div>
+                            </template>
+                            <p x-show="maintenanceTasks.length === 0" class="text-xs text-indigo-500">Keine Wartungen geplant.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div x-show="isCategoryModalOpen" @click.away="closeCategoryModal()" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-6" x-transition>
+        <div class="bg-white rounded-3xl shadow-2xl w-full max-w-lg">
+            <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Kategorie</p>
+                    <h3 class="text-lg font-semibold text-slate-900" x-text="editingCategory ? 'Kategorie bearbeiten' : 'Neue Kategorie'"></h3>
+                </div>
+                <button @click="closeCategoryModal()" class="text-slate-400 hover:text-slate-600">
+                    <i data-feather="x" class="w-5 h-5"></i>
+                </button>
+            </div>
+            <form @submit.prevent="saveCategory()" class="space-y-4 p-6">
+                <div>
+                    <label class="text-sm font-semibold text-slate-700">Name*</label>
+                    <input type="text" x-model="currentCategory.name" required class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
+                </div>
+                <div>
+                    <label class="text-sm font-semibold text-slate-700">Icon*</label>
+                    <select x-model="currentCategory.icon" required class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
+                        <option value="cpu">CPU</option>
+                        <option value="gpu">GPU</option>
+                        <option value="memory">RAM</option>
+                        <option value="hard-drive">Festplatte</option>
+                        <option value="server">Server</option>
+                        <option value="monitor">Monitor</option>
+                        <option value="printer">Drucker</option>
+                        <option value="wind">Kühlsystem</option>
+                        <option value="grid">Mainboard</option>
+                        <option value="zap">Netzteil</option>
+                        <option value="sliders">RAM</option>
+                        <option value="wifi">Netzwerk</option>
+                        <option value="code">Raspberry Pi</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="text-sm font-semibold text-slate-700">Felder (JSON)*</label>
+                    <textarea x-model="currentCategory.fields" rows="4" required class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500 font-mono" placeholder='{"field1":"text","field2":"number"}'></textarea>
+                    <p class="mt-2 text-xs text-slate-400">Beispiel: {"Modell":"text","Kernezahl":"number"}</p>
+                </div>
+                <div class="flex justify-end gap-3 pt-2">
+                    <button type="button" @click="closeCategoryModal()" class="rounded-2xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100">Abbrechen</button>
+                    <button type="submit" class="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">Speichern</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div x-show="isDeviceModalOpen" @click.away="closeDeviceModal()" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-6">
+        <div class="bg-white rounded-3xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+            <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Gerät</p>
+                    <h3 class="text-lg font-semibold text-slate-900" x-text="editingDevice ? 'Gerät bearbeiten' : 'Neues Gerät'"></h3>
+                </div>
+                <button @click="closeDeviceModal()" class="text-slate-400 hover:text-slate-600">
+                    <i data-feather="x" class="w-5 h-5"></i>
+                </button>
+            </div>
+            <form @submit.prevent="saveDevice()" class="space-y-4 p-6">
+                <input type="hidden" x-model="currentDevice.id">
+                <div class="grid gap-4 lg:grid-cols-2">
+                    <div>
+                        <label class="text-sm font-semibold text-slate-700">Name*</label>
+                        <input type="text" x-model="currentDevice.name" required class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
+                    </div>
+                    <div>
+                        <label class="text-sm font-semibold text-slate-700">Kategorie*</label>
+                        <select x-model="currentDevice.category_id" required class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
+                            <option value="">-- Kategorie wählen --</option>
+                            <template x-for="category in categories" :key="category.id">
+                                <option :value="category.id" x-text="category.name"></option>
+                            </template>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="text-sm font-semibold text-slate-700">Owner</label>
+                        <input type="text" x-model="currentDevice.serial_number" class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
+                    </div>
+                    <div>
+                        <label class="text-sm font-semibold text-slate-700">Standort</label>
+                        <select x-model="currentDevice.location_id" class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
+                            <option value="">-- Standort wählen --</option>
+                            <template x-for="location in locations" :key="location.id">
+                                <option :value="location.id" x-text="location.name"></option>
+                            </template>
+                        </select>
+                    </div>
+                </div>
+                <div>
+                    <label class="text-sm font-semibold text-slate-700">Spezifikationen</label>
+                    <div class="mt-2 space-y-2">
+                        <template x-for="(fieldType, fieldName) in getCategoryFields(currentDevice.category_id) || {}" :key="fieldName">
+                            <div>
+                                <label class="block text-xs font-semibold text-slate-500 mb-1" x-text="fieldName"></label>
+                                <template x-if="fieldType === 'number'">
+                                    <input type="number" x-model="currentDevice.specs[fieldName]" class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm focus:border-blue-500 focus:ring-blue-500">
+                                </template>
+                                <template x-if="fieldType !== 'number'">
+                                    <input type="text" x-model="currentDevice.specs[fieldName]" class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm focus:border-blue-500 focus:ring-blue-500">
+                                </template>
+                            </div>
+                        </template>
+                        <p x-show="!getCategoryFields(currentDevice.category_id)" class="text-xs text-slate-400">Keine spezifischen Felder definiert.</p>
+                    </div>
+                </div>
+                <div class="flex justify-end gap-3 pt-2">
+                    <button type="button" @click="closeDeviceModal()" class="rounded-2xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100">Abbrechen</button>
+                    <button type="submit" class="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">Speichern</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <script src="https://unpkg.com/feather-icons"></script>
+    <script>
+        document.addEventListener("alpine:init", () => {
+            feather.replace();
+        });
+
+        async function logout() {
+            try {
+                const response = await fetch('/logout', {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: { 'Content-Type': 'application/json' }
+                });
+
+                if (response.ok) {
+                    window.location.href = '/login';
+                } else {
+                    const data = await response.json();
+                    alert('Logout failed: ' + (data.error || 'Unknown error'));
+                }
+            } catch (error) {
+                alert('Network error: ' + error.message);
+            }
+        }
+    </script>
+    <script src="/static/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation

- Users reported that clicking "add device" / "add category" did nothing and requested a full UI/UX redesign and removal of Pro gating so the app is fully functional.  
- The codebase contained defensive Pro-gating and a few frontend/backend edge cases which prevented CRUD flows from completing reliably.  
- The goal was to restore full functionality (create/edit/delete categories, devices, tags, notes, maintenance) and deliver a cleaner, more consistent dashboard layout.

### Description

- Unlocked Pro features by enabling `PRO_ENABLED` and making `@pro_required` a no-op so Pro endpoints are accessible (`app.py`).  
- Fixed CSV export response and removed an incorrect `BytesIO` double-wrap so `export_devices` returns a valid CSV payload (`app.py`).  
- Reworked the Alpine app logic to: always load maintenance data, add `location_id` defaults to device state, add defensive `response.ok` checks and consistent error handling, and simplify live-refresh hooks to avoid broken dashboard calls (`static/script.js`).  
- Rebuilt and cleaned up the main dashboard template and modal forms for better layout, fixed broken markup and duplicated sections, and adjusted base styling to match the refreshed UI (`templates/index.html`, `static/style.css`).

### Testing

- Launched the app locally with `python app.py`; a temporary admin user was created and the server responded to requests (login, categories, locations, devices, features, maintenance summary) as shown in the run logs, and the server stayed up.  
- Automated UI smoke test: a Playwright script opened `http://localhost:5000/login`, logged in as `admin`, navigated to `/`, and captured a full-page screenshot (`artifacts/inventory-dashboard.png`), proving the dashboard renders and endpoints returned 200 responses.  
- All changes were staged and committed (`git`); the automated checks performed during the run completed successfully (server start, UI login, screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697343244f34832d94404c8e46620170)