### PR TITLE
Expand device detail information and specs display

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -664,6 +664,31 @@ document.addEventListener('alpine:init', () => {
             );
         },
 
+        formatSpecValue(value) {
+            if (value === null || value === undefined || value === '') {
+                return '-';
+            }
+            if (typeof value === 'boolean') {
+                return value ? 'Ja' : 'Nein';
+            }
+            return value;
+        },
+
+        getDeviceSpecEntries(device) {
+            if (!device) return [];
+            let parsed;
+            try {
+                parsed = JSON.parse(device.specs || '{}');
+            } catch (error) {
+                console.error('Error parsing device specs:', error);
+                return [];
+            }
+            return Object.entries(parsed).map(([key, value]) => ({
+                key,
+                value: this.formatSpecValue(value)
+            }));
+        },
+
 		getCategoryColor(categoryName) {
 			// 1. Definiere die festen Farben für bekannte Kategorien
 			const predefinedColors = {

--- a/templates/index.html
+++ b/templates/index.html
@@ -517,6 +517,48 @@
                     </div>
 
                     <div class="rounded-2xl border border-slate-200 bg-white p-4">
+                        <p class="text-sm font-semibold text-slate-900">Vollständige Gerätedaten</p>
+                        <div class="mt-3 space-y-2 text-sm text-slate-600">
+                            <div class="flex justify-between gap-4">
+                                <span>ID</span>
+                                <span class="font-semibold text-slate-900" x-text="selectedDevice?.id || '-' "></span>
+                            </div>
+                            <div class="flex justify-between gap-4">
+                                <span>Name</span>
+                                <span class="font-semibold text-slate-900 text-right" x-text="selectedDevice?.name || '-' "></span>
+                            </div>
+                            <div class="flex justify-between gap-4">
+                                <span>Kategorie</span>
+                                <span class="font-semibold text-slate-900 text-right" x-text="selectedDevice?.category_name || '-' "></span>
+                            </div>
+                            <div class="flex justify-between gap-4">
+                                <span>Standort</span>
+                                <span class="font-semibold text-slate-900 text-right" x-text="selectedDevice?.location_name || '-' "></span>
+                            </div>
+                            <div class="flex justify-between gap-4">
+                                <span>Owner</span>
+                                <span class="font-semibold text-slate-900 text-right" x-text="selectedDevice?.serial_number || '-' "></span>
+                            </div>
+                            <div class="flex justify-between gap-4">
+                                <span>Erstellt am</span>
+                                <span class="font-semibold text-slate-900 text-right" x-text="selectedDevice?.created_at?.slice(0, 10) || '-' "></span>
+                            </div>
+                        </div>
+                        <div class="mt-4 border-t border-slate-100 pt-4">
+                            <p class="text-sm font-semibold text-slate-900">Spezifikationen</p>
+                            <div class="mt-2 space-y-2 text-sm text-slate-600">
+                                <template x-for="spec in getDeviceSpecEntries(selectedDevice)" :key="spec.key">
+                                    <div class="flex justify-between gap-4">
+                                        <span x-text="spec.key"></span>
+                                        <span class="font-semibold text-slate-900 text-right" x-text="spec.value"></span>
+                                    </div>
+                                </template>
+                                <p x-show="getDeviceSpecEntries(selectedDevice).length === 0" class="text-xs text-slate-400">Keine Spezifikationen hinterlegt.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4">
                         <div class="flex items-center justify-between">
                             <div>
                                 <p class="text-sm font-semibold text-slate-900">Notizen</p>


### PR DESCRIPTION
### Motivation
- The device detail view should show every stored data point and list all specifications so users can inspect devices fully without switching screens.
- Provide a readable, consistent presentation for spec values (including booleans and empty values) in the UI.

### Description
- Added a new “Vollständige Gerätedaten” panel inside the device detail modal in `templates/index.html` that lists ID, name, category, location, owner, creation date and a full list of specifications.
- Implemented client-side helpers `formatSpecValue` and `getDeviceSpecEntries` in `static/script.js` to parse `device.specs` JSON and format values (show `-` for empty and `Ja`/`Nein` for booleans).
- Wired the template to render spec entries via `getDeviceSpecEntries(selectedDevice)` and fall back to a message when no specs exist.
- No backend changes were required; this is purely a UI enhancement to present existing persisted data.

### Testing
- Started the development server with `python app.py` and observed successful startup and API requests for login and device/category/location endpoints. (server run succeeded)
- Attempted an automated UI flow with Playwright to add a device and capture a details screenshot, but the Playwright run timed out in this environment (UI test failed due to timeout).
- Changes were staged and committed with `git commit` (commit message: "Expand device detail specifications").

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697369ac76fc832da1544e26377b055e)