### PR TITLE
Expand stats dashboard with richer analytics

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from flask_cors import CORS
 from werkzeug.security import generate_password_hash, check_password_hash
 import sqlite3
 import json
+from datetime import datetime
 from functools import wraps
 import os
 import csv
@@ -825,6 +826,31 @@ def stats():
     # 1. Grundstatistiken mit Default-Werten
     total_devices = db.execute('SELECT COUNT(*) FROM devices').fetchone()[0] or 0
     total_categories = db.execute('SELECT COUNT(*) FROM categories').fetchone()[0] or 0
+    total_locations = db.execute('SELECT COUNT(*) FROM locations').fetchone()[0] or 0
+    total_tags = db.execute('SELECT COUNT(*) FROM device_tags').fetchone()[0] or 0
+    total_notes = db.execute('SELECT COUNT(*) FROM device_notes').fetchone()[0] or 0
+    total_maintenance = db.execute('SELECT COUNT(*) FROM maintenance_tasks').fetchone()[0] or 0
+    open_maintenance = db.execute(
+        "SELECT COUNT(*) FROM maintenance_tasks WHERE status = 'open'"
+    ).fetchone()[0] or 0
+    done_maintenance = db.execute(
+        "SELECT COUNT(*) FROM maintenance_tasks WHERE status = 'done'"
+    ).fetchone()[0] or 0
+    overdue_maintenance = db.execute('''
+        SELECT COUNT(*) FROM maintenance_tasks
+        WHERE status = 'open' AND due_date != '' AND date(due_date) < date('now')
+    ''').fetchone()[0] or 0
+    due_soon_maintenance = db.execute('''
+        SELECT COUNT(*) FROM maintenance_tasks
+        WHERE status = 'open' AND due_date != ''
+        AND date(due_date) >= date('now') AND date(due_date) <= date('now', '+7 days')
+    ''').fetchone()[0] or 0
+    devices_recent_7 = db.execute('''
+        SELECT COUNT(*) FROM devices WHERE date(created_at) >= date('now', '-7 days')
+    ''').fetchone()[0] or 0
+    devices_recent_30 = db.execute('''
+        SELECT COUNT(*) FROM devices WHERE date(created_at) >= date('now', '-30 days')
+    ''').fetchone()[0] or 0
     
     # 2. Kategorieverteilung mit sicherer Abfrage
     categories = db.execute('''
@@ -836,21 +862,95 @@ def stats():
     categories_data = [dict(c) for c in categories] if categories else []
     
     # 3. Verbesserte Statusverteilung mit Default-Werten
-    status_data = {'Verwendet': 0, 'Lager': 0, 'Defekt': 0}
+    status_data = {'Verwendet': 0, 'Lager': 0, 'Defekt': 0, 'Unbekannt': 0}
     devices = db.execute('SELECT specs FROM devices').fetchall()
     for device in devices:
         try:
             specs = json.loads(device['specs']) if device['specs'] else {}
-            status = specs.get('Status', 'Verwendet')
+            status = specs.get('Status') or specs.get('status') or 'Verwendet'
             # Normalisiere den Status (entferne Leerzeichen, mache erste Buchstabe groß)
             status = status.strip().capitalize()
             # Falls der Status nicht in unserer Liste ist, zählen wir als "Verwendet"
             if status in status_data:
                 status_data[status] += 1
             else:
-                status_data['Verwendet'] += 1
+                status_data['Unbekannt'] += 1
         except json.JSONDecodeError:
-            status_data['Verwendet'] += 1
+            status_data['Unbekannt'] += 1
+
+    # 3b. Standortverteilung
+    locations = db.execute('''
+        SELECT l.id, l.name, COUNT(d.id) as device_count
+        FROM locations l
+        LEFT JOIN devices d ON l.id = d.location_id
+        GROUP BY l.id
+    ''').fetchall()
+    locations_data = [dict(l) for l in locations] if locations else []
+    unknown_location_count = db.execute('''
+        SELECT COUNT(*) FROM devices WHERE location_id IS NULL
+    ''').fetchone()[0] or 0
+
+    # 3c. Gerätezugang letzte 6 Monate
+    monthly_rows = db.execute('''
+        SELECT strftime('%Y-%m', created_at) as month, COUNT(*) as device_count
+        FROM devices
+        WHERE date(created_at) >= date('now', '-5 months', 'start of month')
+        GROUP BY month
+        ORDER BY month
+    ''').fetchall()
+    monthly_counts = {row['month']: row['device_count'] for row in monthly_rows}
+    now = datetime.utcnow()
+    current_month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    months = []
+    for offset in range(-5, 1):
+        year = current_month_start.year + (current_month_start.month - 1 + offset) // 12
+        month = (current_month_start.month - 1 + offset) % 12 + 1
+        label = f"{year:04d}-{month:02d}"
+        months.append({'month': label, 'count': monthly_counts.get(label, 0)})
+
+    # 3d. Gerätealter-Buckets
+    age_buckets = {
+        '0-30 Tage': 0,
+        '31-90 Tage': 0,
+        '91-180 Tage': 0,
+        '181-365 Tage': 0,
+        '365+ Tage': 0
+    }
+    device_dates = db.execute('SELECT created_at FROM devices').fetchall()
+    for row in device_dates:
+        if not row['created_at']:
+            continue
+        try:
+            created_at = datetime.fromisoformat(row['created_at'])
+        except ValueError:
+            continue
+        age_days = (now - created_at).days
+        if age_days <= 30:
+            age_buckets['0-30 Tage'] += 1
+        elif age_days <= 90:
+            age_buckets['31-90 Tage'] += 1
+        elif age_days <= 180:
+            age_buckets['91-180 Tage'] += 1
+        elif age_days <= 365:
+            age_buckets['181-365 Tage'] += 1
+        else:
+            age_buckets['365+ Tage'] += 1
+
+    # 3e. Zusatz-KPIs
+    devices_with_tags = db.execute('SELECT COUNT(DISTINCT device_id) FROM device_tags').fetchone()[0] or 0
+    devices_with_notes = db.execute('SELECT COUNT(DISTINCT device_id) FROM device_notes').fetchone()[0] or 0
+    tag_coverage = round((devices_with_tags / total_devices) * 100) if total_devices else 0
+    note_coverage = round((devices_with_notes / total_devices) * 100) if total_devices else 0
+    activity_summary = db.execute('''
+        SELECT action, COUNT(*) as total
+        FROM activity_log
+        WHERE date(created_at) >= date('now', '-7 days')
+        GROUP BY action
+        ORDER BY total DESC
+        LIMIT 5
+    ''').fetchall()
+    activity_summary_data = [dict(row) for row in activity_summary] if activity_summary else []
+    top_categories = sorted(categories_data, key=lambda x: x['device_count'], reverse=True)[:5]
     
     # 4. Letzte Geräte mit sicherer Abfrage
     recent_devices = db.execute('''
@@ -865,8 +965,28 @@ def stats():
     context = {
         'total_devices': total_devices,
         'total_categories': total_categories,
+        'total_locations': total_locations,
+        'total_tags': total_tags,
+        'total_notes': total_notes,
+        'total_maintenance': total_maintenance,
+        'open_maintenance': open_maintenance,
+        'done_maintenance': done_maintenance,
+        'overdue_maintenance': overdue_maintenance,
+        'due_soon_maintenance': due_soon_maintenance,
+        'devices_recent_7': devices_recent_7,
+        'devices_recent_30': devices_recent_30,
         'categories': categories_data,
         'status_data': status_data,
+        'locations': locations_data,
+        'unknown_location_count': unknown_location_count,
+        'devices_by_month': months,
+        'age_buckets': age_buckets,
+        'devices_with_tags': devices_with_tags,
+        'devices_with_notes': devices_with_notes,
+        'tag_coverage': tag_coverage,
+        'note_coverage': note_coverage,
+        'activity_summary': activity_summary_data,
+        'top_categories': top_categories,
         'recent_devices': recent_devices_data,
         'username': session.get('username', '')
     }

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
-<html lang="de" x-data="inventoryStats()">
+<html lang="de">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Inventory Pro - Statistiken</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
     <link rel="stylesheet" href="/static/style.css">
     <style>
         .stat-card:hover {
@@ -16,6 +15,10 @@
         .progress-bar {
             height: 6px;
             border-radius: 999px;
+        }
+        .glass-card {
+            background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.65));
+            backdrop-filter: blur(12px);
         }
     </style>
 </head>
@@ -146,13 +149,14 @@
                 </div>
             </section>
 
-            <!-- Statistik-Karten -->
+            <!-- KPI Überblick -->
 			<div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
 				<div class="stat-card bg-white p-6 rounded-2xl border border-slate-200 shadow-sm transition">
                     <div class="flex items-center justify-between">
                         <div>
                             <h3 class="text-sm font-semibold text-slate-500">Gesamtgeräte</h3>
                             <p class="mt-2 text-3xl font-semibold text-slate-900">{{ total_devices }}</p>
+                            <p class="text-xs text-slate-500">{{ devices_recent_30 }} neu in 30 Tagen</p>
                         </div>
                         <span class="inline-flex items-center justify-center rounded-2xl bg-blue-50 p-3 text-blue-600">
                             <i data-feather="box" class="h-5 w-5"></i>
@@ -165,6 +169,7 @@
                         <div>
                             <h3 class="text-sm font-semibold text-slate-500">Kategorien</h3>
                             <p class="mt-2 text-3xl font-semibold text-slate-900">{{ total_categories }}</p>
+                            <p class="text-xs text-slate-500">{{ total_locations }} Standorte aktiv</p>
                         </div>
                         <span class="inline-flex items-center justify-center rounded-2xl bg-indigo-50 p-3 text-indigo-600">
                             <i data-feather="layers" class="h-5 w-5"></i>
@@ -175,11 +180,12 @@
 				<div class="stat-card bg-white p-6 rounded-2xl border border-slate-200 shadow-sm transition">
                     <div class="flex items-center justify-between">
                         <div>
-                            <h3 class="text-sm font-semibold text-slate-500">Verwendet</h3>
-                            <p class="mt-2 text-3xl font-semibold text-slate-900">{{ status_data['Verwendet'] }}</p>
+                            <h3 class="text-sm font-semibold text-slate-500">Wartung offen</h3>
+                            <p class="mt-2 text-3xl font-semibold text-slate-900">{{ open_maintenance }}</p>
+                            <p class="text-xs text-slate-500">{{ overdue_maintenance }} überfällig</p>
                         </div>
-                        <span class="inline-flex items-center justify-center rounded-2xl bg-emerald-50 p-3 text-emerald-600">
-                            <i data-feather="check-circle" class="h-5 w-5"></i>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-rose-50 p-3 text-rose-600">
+                            <i data-feather="tool" class="h-5 w-5"></i>
                         </span>
                     </div>
 				</div>
@@ -187,62 +193,208 @@
 				<div class="stat-card bg-white p-6 rounded-2xl border border-slate-200 shadow-sm transition">
                     <div class="flex items-center justify-between">
                         <div>
-                            <h3 class="text-sm font-semibold text-slate-500">Lager</h3>
-                            <p class="mt-2 text-3xl font-semibold text-slate-900">{{ status_data['Lager'] }}</p>
+                            <h3 class="text-sm font-semibold text-slate-500">Letzte 7 Tage</h3>
+                            <p class="mt-2 text-3xl font-semibold text-slate-900">{{ devices_recent_7 }}</p>
+                            <p class="text-xs text-slate-500">Neue Geräte</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-emerald-50 p-3 text-emerald-600">
+                            <i data-feather="trending-up" class="h-5 w-5"></i>
+                        </span>
+                    </div>
+				</div>
+
+                <div class="stat-card bg-white p-6 rounded-2xl border border-slate-200 shadow-sm transition">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <h3 class="text-sm font-semibold text-slate-500">Gerätestatus</h3>
+                            <p class="mt-2 text-3xl font-semibold text-slate-900">{{ status_data['Verwendet'] }}</p>
+                            <p class="text-xs text-slate-500">{{ status_data['Lager'] }} im Lager</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-emerald-50 p-3 text-emerald-600">
+                            <i data-feather="check-circle" class="h-5 w-5"></i>
+                        </span>
+                    </div>
+				</div>
+
+                <div class="stat-card bg-white p-6 rounded-2xl border border-slate-200 shadow-sm transition">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <h3 class="text-sm font-semibold text-slate-500">Dokumentation</h3>
+                            <p class="mt-2 text-3xl font-semibold text-slate-900">{{ tag_coverage }}%</p>
+                            <p class="text-xs text-slate-500">{{ note_coverage }}% mit Notizen</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-sky-50 p-3 text-sky-600">
+                            <i data-feather="file-text" class="h-5 w-5"></i>
+                        </span>
+                    </div>
+				</div>
+
+                <div class="stat-card bg-white p-6 rounded-2xl border border-slate-200 shadow-sm transition">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <h3 class="text-sm font-semibold text-slate-500">Wartung gesamt</h3>
+                            <p class="mt-2 text-3xl font-semibold text-slate-900">{{ total_maintenance }}</p>
+                            <p class="text-xs text-slate-500">{{ done_maintenance }} erledigt</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-purple-50 p-3 text-purple-600">
+                            <i data-feather="clipboard" class="h-5 w-5"></i>
+                        </span>
+                    </div>
+				</div>
+
+                <div class="stat-card bg-white p-6 rounded-2xl border border-slate-200 shadow-sm transition">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <h3 class="text-sm font-semibold text-slate-500">Fällige Wartung</h3>
+                            <p class="mt-2 text-3xl font-semibold text-slate-900">{{ due_soon_maintenance }}</p>
+                            <p class="text-xs text-slate-500">Nächste 7 Tage</p>
                         </div>
                         <span class="inline-flex items-center justify-center rounded-2xl bg-amber-50 p-3 text-amber-600">
-                            <i data-feather="archive" class="h-5 w-5"></i>
+                            <i data-feather="calendar" class="h-5 w-5"></i>
                         </span>
                     </div>
 				</div>
 			</div>
 
-			<!-- Kategorieverteilung Chart -->
-			<div class="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm">
-				<div class="flex items-center justify-between mb-4">
-                    <div>
-                        <h2 class="text-xl font-semibold text-slate-900">Verteilung nach Kategorien</h2>
-                        <p class="text-sm text-slate-500">Welche Bereiche aktuell dominieren.</p>
-                    </div>
-                    <span class="inline-flex items-center justify-center rounded-2xl bg-slate-100 p-2 text-slate-500">
-                        <i data-feather="pie-chart" class="h-4 w-4"></i>
-                    </span>
-                </div>
-				<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-					{% for category in categories %}
-					<div class="flex items-center rounded-2xl border border-slate-100 bg-slate-50 px-4 py-3">
-						<div class="w-3 h-3 rounded-full mr-3" 
-							 style="background-color: {{ loop.cycle('#3B82F6', '#10B981', '#6366F1', '#F59E0B') }}"></div>
-						<span class="text-sm text-slate-700">{{ category['name'] }}</span>
-						<span class="ml-auto text-sm font-semibold text-slate-900">{{ category['device_count'] }}</span>
-					</div>
-					{% endfor %}
-				</div>
-			</div>
-			
-			<!-- Charts Section -->
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <!-- Kategorieverteilung -->
-                <div class="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm">
-                    <div class="flex justify-between items-center mb-4">
+                <div class="glass-card p-6 rounded-2xl border border-slate-200 shadow-sm">
+                    <div class="flex items-center justify-between mb-4">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-900">Gerätezugang (6 Monate)</h2>
+                            <p class="text-sm text-slate-500">Neu angelegte Geräte im Zeitverlauf.</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-slate-100 p-2 text-slate-500">
+                            <i data-feather="activity" class="h-4 w-4"></i>
+                        </span>
+                    </div>
+                    <canvas id="growthChart" height="280"></canvas>
+                </div>
+
+                <div class="glass-card p-6 rounded-2xl border border-slate-200 shadow-sm">
+                    <div class="flex items-center justify-between mb-4">
                         <div>
                             <h2 class="text-xl font-semibold text-slate-900">Verteilung nach Kategorien</h2>
-                            <p class="text-sm text-slate-500">Auswertung nach Zeitraum filtern.</p>
+                            <p class="text-sm text-slate-500">Welche Bereiche aktuell dominieren.</p>
                         </div>
-                        <select x-model="chartTimeRange" class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">
-                            <option value="all">Alle</option>
-                            <option value="month">Letzter Monat</option>
-                            <option value="week">Letzte Woche</option>
-                        </select>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-slate-100 p-2 text-slate-500">
+                            <i data-feather="pie-chart" class="h-4 w-4"></i>
+                        </span>
                     </div>
-                    <canvas id="categoryChart" height="300"></canvas>
+                    <canvas id="categoryChart" height="280"></canvas>
                 </div>
-                
-                <!-- Statusverteilung -->
+
                 <div class="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm">
-                    <h2 class="text-xl font-semibold text-slate-900 mb-2">Gerätestatus</h2>
-                    <p class="text-sm text-slate-500 mb-4">Live-Überblick über den Status deiner Geräte.</p>
-                    <canvas id="statusChart" height="300"></canvas>
+                    <div class="flex items-center justify-between mb-4">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-900">Gerätestatus</h2>
+                            <p class="text-sm text-slate-500">Aktueller Status aller Geräte.</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-slate-100 p-2 text-slate-500">
+                            <i data-feather="check-square" class="h-4 w-4"></i>
+                        </span>
+                    </div>
+                    <canvas id="statusChart" height="280"></canvas>
+                </div>
+
+                <div class="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm">
+                    <div class="flex items-center justify-between mb-4">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-900">Standorte</h2>
+                            <p class="text-sm text-slate-500">Verteilung der Geräte nach Standort.</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-slate-100 p-2 text-slate-500">
+                            <i data-feather="map-pin" class="h-4 w-4"></i>
+                        </span>
+                    </div>
+                    <canvas id="locationChart" height="280"></canvas>
+                </div>
+
+                <div class="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm">
+                    <div class="flex items-center justify-between mb-4">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-900">Gerätealter</h2>
+                            <p class="text-sm text-slate-500">Wie lange Geräte schon im Bestand sind.</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-slate-100 p-2 text-slate-500">
+                            <i data-feather="clock" class="h-4 w-4"></i>
+                        </span>
+                    </div>
+                    <canvas id="ageChart" height="280"></canvas>
+                </div>
+
+                <div class="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm">
+                    <div class="flex items-center justify-between mb-4">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-900">Standortlücken</h2>
+                            <p class="text-sm text-slate-500">Geräte ohne Standortzuordnung.</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-slate-100 p-2 text-slate-500">
+                            <i data-feather="alert-circle" class="h-4 w-4"></i>
+                        </span>
+                    </div>
+                    <div class="flex items-center gap-4">
+                        <div class="rounded-2xl bg-rose-50 px-4 py-3">
+                            <p class="text-xs uppercase tracking-widest text-rose-400">Ohne Standort</p>
+                            <p class="mt-2 text-3xl font-semibold text-rose-600">{{ unknown_location_count }}</p>
+                        </div>
+                        <div class="flex-1">
+                            <div class="flex items-center justify-between text-xs text-slate-500">
+                                <span>Abdeckung</span>
+                                <span>{{ (100 - (unknown_location_count * 100 // (total_devices or 1))) }}%</span>
+                            </div>
+                            <div class="mt-2 h-2 rounded-full bg-slate-100">
+                                <div class="h-2 rounded-full bg-rose-400" style="width: {{ (unknown_location_count * 100 // (total_devices or 1)) }}%"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <div class="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm">
+                    <div class="flex items-center justify-between mb-4">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-900">Top Kategorien</h2>
+                            <p class="text-sm text-slate-500">Kategorien mit dem größten Bestand.</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-slate-100 p-2 text-slate-500">
+                            <i data-feather="award" class="h-4 w-4"></i>
+                        </span>
+                    </div>
+                    <div class="space-y-3">
+                        {% for category in top_categories %}
+                        <div class="flex items-center rounded-2xl border border-slate-100 bg-slate-50 px-4 py-3">
+                            <span class="text-sm font-semibold text-slate-700">{{ category['name'] }}</span>
+                            <span class="ml-auto text-sm font-semibold text-slate-900">{{ category['device_count'] }}</span>
+                        </div>
+                        {% endfor %}
+                        {% if top_categories|length == 0 %}
+                        <p class="text-sm text-slate-500">Noch keine Kategorien vorhanden.</p>
+                        {% endif %}
+                    </div>
+                </div>
+
+                <div class="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm">
+                    <div class="flex items-center justify-between mb-4">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-900">Aktivität (7 Tage)</h2>
+                            <p class="text-sm text-slate-500">Meistgenutzte Aktionen im System.</p>
+                        </div>
+                        <span class="inline-flex items-center justify-center rounded-2xl bg-slate-100 p-2 text-slate-500">
+                            <i data-feather="zap" class="h-4 w-4"></i>
+                        </span>
+                    </div>
+                    <div class="space-y-3">
+                        {% for item in activity_summary %}
+                        <div class="flex items-center rounded-2xl border border-slate-100 bg-slate-50 px-4 py-3">
+                            <span class="text-sm font-semibold text-slate-700">{{ item['action'] }}</span>
+                            <span class="ml-auto text-sm font-semibold text-slate-900">{{ item['total'] }}</span>
+                        </div>
+                        {% endfor %}
+                        {% if activity_summary|length == 0 %}
+                        <p class="text-sm text-slate-500">Keine Aktivitäten in den letzten 7 Tagen.</p>
+                        {% endif %}
+                    </div>
                 </div>
             </div>
 
@@ -285,301 +437,113 @@
     </div>
 
     <script>
-        document.addEventListener('alpine:init', () => {
-            Alpine.data('inventoryStats', () => ({
-                // Daten aus dem Haupt-App-State
-                categories: [],
-                devices: [],
-                filteredDevices: [],
-                recentDevices: [],
-                chartTimeRange: 'all',
-                
-                // Statistikwerte
-                totalDevices: 0,
-                activePercentage: 0,
-                topCategory: '',
-                avgSpecs: 0,
-                mostCommonSpec: '',
-                newestDevice: '',
-                newestDeviceCategory: '',
-                
-                // Initialisierung
-                async init() {
-                    await this.loadData();
-                    this.calculateStats();
-                    this.initCharts();
-                    feather.replace();
-                    
-                    // Aktualisiere Daten alle 30 Sekunden
-                    setInterval(async () => {
-                        await this.loadData();
-                        this.calculateStats();
-                        this.updateCharts();
-                    }, 30000);
+        document.addEventListener('DOMContentLoaded', function() {
+            const statsData = {
+                categories: {{ categories|tojson|default([]) }},
+                statusData: {{ status_data|tojson|default({}) }},
+                locations: {{ locations|tojson|default([]) }},
+                unknownLocationCount: {{ unknown_location_count|default(0) }},
+                devicesByMonth: {{ devices_by_month|tojson|default([]) }},
+                ageBuckets: {{ age_buckets|tojson|default({}) }}
+            };
+
+            const palette = [
+                '#3B82F6', '#10B981', '#6366F1', '#F59E0B',
+                '#EF4444', '#8B5CF6', '#EC4899', '#14B8A6',
+                '#0EA5E9', '#22C55E'
+            ];
+
+            new Chart(document.getElementById('growthChart'), {
+                type: 'line',
+                data: {
+                    labels: statsData.devicesByMonth.map(item => item.month),
+                    datasets: [{
+                        label: 'Neue Geräte',
+                        data: statsData.devicesByMonth.map(item => item.count),
+                        borderColor: '#6366F1',
+                        backgroundColor: 'rgba(99, 102, 241, 0.2)',
+                        tension: 0.35,
+                        fill: true
+                    }]
                 },
-                
-                // Daten laden
-                async loadData() {
-                    const [catRes, devRes] = await Promise.all([
-                        fetch('/api/categories'),
-                        fetch('/api/devices')
-                    ]);
-                    
-                    this.categories = await catRes.json();
-                    this.devices = await devRes.json();
-                    this.filteredDevices = [...this.devices];
-                    this.recentDevices = [...this.devices]
-                        .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
-                        .slice(0, 5);
-                },
-                
-                // Statistiken berechnen
-                calculateStats() {
-                    this.totalDevices = this.devices.length;
-                    
-                    // Aktive Geräte berechnen
-                    const activeCount = this.devices.filter(d => 
-                        (d.specs && JSON.parse(d.specs).status === 'Verwendet') || 
-                        !d.specs
-                    ).length;
-                    this.activePercentage = Math.round((activeCount / this.totalDevices) * 100);
-                    
-                    // Top Kategorie finden
-                    const categoryCounts = {};
-                    this.devices.forEach(device => {
-                        const catName = this.categories.find(c => c.id === device.category_id)?.name || 'Unknown';
-                        categoryCounts[catName] = (categoryCounts[catName] || 0) + 1;
-                    });
-                    this.topCategory = Object.entries(categoryCounts).sort((a, b) => b[1] - a[1])[0]?.[0] || 'N/A';
-                    
-                    // Durchschnittliche Specs
-                    const specCounts = {};
-                    this.devices.forEach(device => {
-                        if (device.specs) {
-                            const specs = JSON.parse(device.specs);
-                            Object.entries(specs).forEach(([key, val]) => {
-                                if (key !== 'status') {
-                                    const specKey = `${key}:${val}`;
-                                    specCounts[specKey] = (specCounts[specKey] || 0) + 1;
-                                }
-                            });
-                        }
-                    });
-                    this.avgSpecs = Object.keys(specCounts).length > 0 
-                        ? (Object.values(specCounts).reduce((a, b) => a + b, 0) / Object.keys(specCounts).length
-                        : 0;
-                    this.mostCommonSpec = Object.entries(specCounts).sort((a, b) => b[1] - a[1])[0]?.[0] || 'N/A';
-                    
-                    // Neuestes Gerät
-                    const newest = [...this.devices].sort((a, b) => 
-                        new Date(b.created_at) - new Date(a.created_at))[0];
-                    if (newest) {
-                        this.newestDevice = newest.name;
-                        this.newestDeviceCategory = this.categories.find(c => c.id === newest.category_id)?.name || 'Unknown';
+                options: {
+                    plugins: {
+                        legend: { display: false }
+                    },
+                    scales: {
+                        y: { beginAtZero: true }
                     }
-                },
-                
-                // Charts initialisieren
-                initCharts() {
-                    // Kategorie-Chart
-                    this.categoryChart = new Chart(
-                        document.getElementById('categoryChart'),
-                        this.getCategoryChartConfig()
-                    );
-                    
-                    // Status-Chart
-                    this.statusChart = new Chart(
-                        document.getElementById('statusChart'),
-                        this.getStatusChartConfig()
-                    );
-                },
-                
-                // Charts aktualisieren
-                updateCharts() {
-                    this.categoryChart.data = this.getCategoryChartData();
-                    this.statusChart.data = this.getStatusChartData();
-                    this.categoryChart.update();
-                    this.statusChart.update();
-                },
-                
-                // Kategorie-Chart Konfiguration
-                getCategoryChartConfig() {
-                    return {
-                        type: 'doughnut',
-                        data: this.getCategoryChartData(),
-                        options: {
-                            responsive: true,
-                            plugins: {
-                                legend: {
-                                    position: 'right',
-                                },
-                                tooltip: {
-                                    callbacks: {
-                                        label: function(context) {
-                                            return `${context.label}: ${context.raw} (${context.parsed}%)`;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    };
-                },
-                
-                getCategoryChartData() {
-                    const categoryCounts = {};
-                    this.categories.forEach(cat => {
-                        categoryCounts[cat.name] = this.devices.filter(d => d.category_id === cat.id).length;
-                    });
-                    
-                    return {
-                        labels: Object.keys(categoryCounts),
-                        datasets: [{
-                            data: Object.values(categoryCounts),
-                            backgroundColor: [
-                                '#3B82F6', '#10B981', '#6366F1', '#F59E0B', 
-                                '#EF4444', '#8B5CF6', '#EC4899', '#14B8A6'
-                            ],
-                            borderWidth: 1
-                        }]
-                    };
-                },
-                
-                // Status-Chart Konfiguration
-                getStatusChartConfig() {
-                    return {
-                        type: 'bar',
-                        data: this.getStatusChartData(),
-                        options: {
-                            responsive: true,
-                            scales: {
-                                y: {
-                                    beginAtZero: true
-                                }
-                            }
-                        }
-                    };
-                },
-                
-                getStatusChartData() {
-                    const statusCounts = {
-                        'Verwendet': 0,
-                        'Lager': 0,
-                        'Defekt': 0
-                    };
-                    
-                    this.devices.forEach(device => {
-                        let status = 'Verwendet';
-                        if (device.specs) {
-                            const specs = JSON.parse(device.specs);
-                            if (specs.status && statusCounts.hasOwnProperty(specs.status)) {
-                                status = specs.status;
-                            }
-                        }
-                        statusCounts[status]++;
-                    });
-                    
-                    return {
-                        labels: Object.keys(statusCounts),
-                        datasets: [{
-                            label: 'Geräte nach Status',
-                            data: Object.values(statusCounts),
-                            backgroundColor: [
-                                '#10B981',
-                                '#F59E0B',
-                                '#EF4444'
-                            ]
-                        }]
-                    };
-                },
-                
-                // Hilfsfunktion aus dem Haupt-App-State
-                getCategoryColor(categoryName) {
-                    const predefinedColors = {
-                        'CPU': 'bg-blue-100 text-blue-800',
-                        'GPU': 'bg-purple-100 text-purple-800',
-                        'RAM': 'bg-green-100 text-green-800',
-                        'Storage': 'bg-yellow-100 text-yellow-800'
-                    };
-                    
-                    if (predefinedColors[categoryName]) {
-                        return predefinedColors[categoryName];
-                    }
-                    
-                    const dynamicColors = [
-                        'bg-blue-100 text-blue-800',
-                        'bg-red-100 text-red-800',
-                        'bg-green-100 text-green-800',
-                        'bg-yellow-100 text-yellow-800',
-                        'bg-purple-100 text-purple-800',
-                        'bg-pink-100 text-pink-800',
-                        'bg-rose-100 text-rose-800',
-                        'bg-fuchsia-100 text-fuchsia-800',
-                        'bg-indigo-100 text-indigo-800',
-                        'bg-cyan-100 text-cyan-800',
-                        'bg-sky-100 text-sky-800',
-                        'bg-amber-100 text-amber-800',
-                        'bg-orange-100 text-orange-800',
-                        'bg-lime-100 text-lime-800',
-                        'bg-emerald-100 text-emerald-800',
-                        'bg-teal-100 text-teal-800',
-                        'bg-violet-100 text-violet-800',
-                    ];
-                    
-                    const hash = Array.from(categoryName).reduce(
-                        (hash, char) => (hash << 5) - hash + char.charCodeAt(0),
-                        0
-                    );
-                    const colorIndex = Math.abs(hash) % dynamicColors.length;
-                    
-                    return dynamicColors[colorIndex];
                 }
-            }));
+            });
+
+            new Chart(document.getElementById('categoryChart'), {
+                type: 'doughnut',
+                data: {
+                    labels: statsData.categories.map(item => item.name),
+                    datasets: [{
+                        data: statsData.categories.map(item => item.device_count),
+                        backgroundColor: palette,
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    plugins: { legend: { position: 'right' } }
+                }
+            });
+
+            new Chart(document.getElementById('statusChart'), {
+                type: 'bar',
+                data: {
+                    labels: Object.keys(statsData.statusData),
+                    datasets: [{
+                        label: 'Geräte',
+                        data: Object.values(statsData.statusData),
+                        backgroundColor: ['#10B981', '#F59E0B', '#EF4444', '#94A3B8']
+                    }]
+                },
+                options: {
+                    plugins: { legend: { display: false } },
+                    scales: { y: { beginAtZero: true } }
+                }
+            });
+
+            const locationLabels = statsData.locations.map(item => item.name);
+            const locationCounts = statsData.locations.map(item => item.device_count);
+            if (statsData.unknownLocationCount > 0) {
+                locationLabels.push('Unbekannt');
+                locationCounts.push(statsData.unknownLocationCount);
+            }
+            new Chart(document.getElementById('locationChart'), {
+                type: 'bar',
+                data: {
+                    labels: locationLabels,
+                    datasets: [{
+                        label: 'Geräte',
+                        data: locationCounts,
+                        backgroundColor: '#38BDF8'
+                    }]
+                },
+                options: {
+                    plugins: { legend: { display: false } },
+                    scales: { y: { beginAtZero: true } }
+                }
+            });
+
+            new Chart(document.getElementById('ageChart'), {
+                type: 'doughnut',
+                data: {
+                    labels: Object.keys(statsData.ageBuckets),
+                    datasets: [{
+                        data: Object.values(statsData.ageBuckets),
+                        backgroundColor: ['#22C55E', '#38BDF8', '#A855F7', '#F59E0B', '#EF4444']
+                    }]
+                },
+                options: {
+                    plugins: { legend: { position: 'bottom' } }
+                }
+            });
         });
     </script>
-	
-	<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-	<!-- Chart.js Integration mit Null-Checks -->
-	<script>
-	document.addEventListener('DOMContentLoaded', function() {
-		// Sicherstellen, dass Daten vorhanden sind
-		const categories = {{ categories|tojson|default([]) }};
-		const statusData = {{ status_data|tojson|default({}) }};
-		
-		// Kategorie-Chart nur rendern wenn Daten vorhanden
-		if (categories.length > 0) {
-			const ctx1 = document.getElementById('categoryChart');
-			new Chart(ctx1, {
-				type: 'pie',
-				data: {
-					labels: categories.map(c => c.name),
-					datasets: [{
-						data: categories.map(c => c.device_count),
-						backgroundColor: [
-							'#3B82F6', '#10B981', '#6366F1', '#F59E0B',
-							'#EF4444', '#8B5CF6', '#EC4899', '#14B8A6'
-						]
-					}]
-				}
-			});
-		}
-		
-		// Status-Chart
-		const ctx2 = document.getElementById('statusChart');
-		new Chart(ctx2, {
-			type: 'bar',
-			data: {
-				labels: Object.keys(statusData),
-				datasets: [{
-					label: 'Geräte',
-					data: Object.values(statusData),
-					backgroundColor: [
-						'#EF4444', '#F59E0B', '#10B981'
-					]
-				}]
-			}
-		});
-	});
-	</script>
 	
 	<script src="https://unpkg.com/feather-icons"></script>
 		<script>


### PR DESCRIPTION
### Motivation
- Provide much more comprehensive and visually improved statistics for inventory insights by adding maintenance, growth, location, age and coverage KPIs and nicer presentation on the stats page.

### Description
- Extend `stats()` in `app.py` to compute additional aggregates including locations, tags, notes, maintenance counts (`open`, `done`, `overdue`, `due_soon`), recent device counts, monthly growth for the last 6 months, device age buckets, tag/note coverage, activity summary and top categories, and add `datetime` import for time calculations.
- Normalize device status parsing and add an `Unbekannt` bucket for unknown/malformed `specs` values to make status counts more robust.
- Update `templates/stats.html` to redesign the dashboard: add KPI cards, a `glass-card` style, new charts (`growthChart`, `categoryChart`, `statusChart`, `locationChart`, `ageChart`), top-categories and activity widgets, and remove the previous Alpine-based interactive code in favor of a consolidated Chart.js rendering script that consumes the server-provided JSON context.
- Pass all new data into the template context (e.g. `devices_by_month`, `age_buckets`, `locations`, `tag_coverage`, `note_coverage`, `activity_summary`, `top_categories`, etc.) so charts and KPIs render from server-side aggregates.

### Testing
- Launched the development server with `python app.py` and confirmed it started successfully in debug mode. (success)
- Executed an automated Playwright script that logs in as the temporary admin and navigates to `/stats`, capturing a full-page screenshot to `artifacts/stats.png` to validate the new UI rendering and that `GET /stats` returned `200` (screenshot created and requests succeeded). (success)
- Committed the changes locally after verification with `git` as part of the rollout. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973714693c8832d923fffd910d84fbe)