### PR TITLE
Prevent sidebar category overflow

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -240,6 +240,7 @@ footer {
 .app-sidebar .sidebar-scroll {
   max-height: calc(100vh - 8rem);
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .app-main--fixed {

--- a/templates/index.html
+++ b/templates/index.html
@@ -116,9 +116,9 @@
                     <div x-show="categoriesOpen" x-transition class="bg-slate-50 px-2 py-2 space-y-1 text-sm text-slate-800">
                         <template x-for="category in categories" :key="category.id">
                             <div class="group flex items-center justify-between px-3 py-2 rounded-xl hover:bg-white transition-colors">
-                                <button @click="loadDevices(category.id)" class="flex items-center gap-2 flex-1 text-left">
+                                <button @click="loadDevices(category.id)" class="flex items-center gap-2 flex-1 min-w-0 text-left">
                                     <div x-html="feather.icons[category.icon]?.toSvg({ class: 'w-4 h-4 text-slate-500' })"></div>
-                                    <span class="sidebar-text" x-text="category.name"></span>
+                                    <span class="sidebar-text truncate" x-text="category.name"></span>
                                 </button>
                                 <div class="flex items-center gap-2">
                                     <button @click="editCategoryModal(category)" class="text-slate-500 hover:text-slate-900">


### PR DESCRIPTION
### Motivation
- Prevent the horizontal scrollbar in the sidebar caused by long category names that expand the sidebar and force horizontal scrolling.

### Description
- Add `overflow-x: hidden` to `.app-sidebar .sidebar-scroll` in `static/style.css` to prevent horizontal overflow.
- Constrain the category list item by adding `min-w-0` to the button and `truncate` to the category name span in `templates/index.html` so long names are ellipsized instead of widening the layout.

### Testing
- Launched the development server with `python app.py` and ran a Playwright script that performed a login and captured a full-page screenshot of the sidebar, which loaded successfully and shows the category list without horizontal scrolling.
- No automated unit tests were required for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69739be87c1c832dadb1e8f58669cd88)