### PR TITLE
Add asset grouping and UI for composing devices into Assets

### DIFF
--- a/app.py
+++ b/app.py
@@ -125,6 +125,27 @@ def init_db():
         ''')
 
         c.execute('''
+            CREATE TABLE IF NOT EXISTS assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                notes TEXT,
+                specs TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS asset_devices (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_id INTEGER NOT NULL,
+                device_id INTEGER NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (asset_id) REFERENCES assets(id),
+                FOREIGN KEY (device_id) REFERENCES devices(id)
+            )
+        ''')
+
+        c.execute('''
             CREATE TABLE IF NOT EXISTS activity_log (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 username TEXT,
@@ -496,6 +517,107 @@ def get_devices():
     
     devices = db.execute(query, params).fetchall()
     return jsonify([dict(row) for row in devices])
+
+@app.route('/api/assets', methods=['GET', 'POST'])
+@login_required
+def manage_assets():
+    db = get_db()
+    if request.method == 'POST':
+        data = request.get_json()
+        name = (data.get('name') or '').strip()
+        notes = (data.get('notes') or '').strip()
+        specs = json.dumps(data.get('specs', {}))
+        device_ids = data.get('device_ids') or []
+        if not name:
+            return jsonify({"error": "Name ist erforderlich"}), 400
+        try:
+            cursor = db.execute('''
+                INSERT INTO assets (name, notes, specs)
+                VALUES (?, ?, ?)
+            ''', (name, notes, specs))
+            asset_id = cursor.lastrowid
+            for device_id in device_ids:
+                db.execute('''
+                    INSERT INTO asset_devices (asset_id, device_id)
+                    VALUES (?, ?)
+                ''', (asset_id, device_id))
+            log_activity(db, "create", "asset", asset_id, {"name": name})
+            db.commit()
+            return jsonify({"status": "created", "id": asset_id}), 201
+        except sqlite3.Error as e:
+            return jsonify({"error": f"Datenbankfehler: {str(e)}"}), 500
+
+    assets = db.execute('''
+        SELECT a.*, COUNT(ad.device_id) as device_count
+        FROM assets a
+        LEFT JOIN asset_devices ad ON a.id = ad.asset_id
+        GROUP BY a.id
+        ORDER BY a.created_at DESC
+    ''').fetchall()
+    result = []
+    for row in assets:
+        asset = dict(row)
+        try:
+            asset['specs'] = json.loads(asset.get('specs') or '{}')
+        except json.JSONDecodeError:
+            asset['specs'] = {}
+        result.append(asset)
+    return jsonify(result)
+
+@app.route('/api/assets/<int:asset_id>', methods=['GET', 'PUT', 'DELETE'])
+@login_required
+def asset_detail(asset_id):
+    db = get_db()
+    asset_row = db.execute('SELECT * FROM assets WHERE id = ?', (asset_id,)).fetchone()
+    if not asset_row:
+        return jsonify({"error": "Asset nicht gefunden"}), 404
+
+    if request.method == 'GET':
+        device_rows = db.execute('''
+            SELECT d.*, c.name as category_name, c.icon as category_icon, l.name as location_name
+            FROM devices d
+            JOIN asset_devices ad ON ad.device_id = d.id
+            JOIN categories c ON d.category_id = c.id
+            LEFT JOIN locations l ON d.location_id = l.id
+            WHERE ad.asset_id = ?
+            ORDER BY d.created_at DESC
+        ''', (asset_id,)).fetchall()
+        asset = dict(asset_row)
+        try:
+            asset['specs'] = json.loads(asset.get('specs') or '{}')
+        except json.JSONDecodeError:
+            asset['specs'] = {}
+        asset['devices'] = [dict(row) for row in device_rows]
+        return jsonify(asset)
+
+    if request.method == 'PUT':
+        data = request.get_json()
+        name = (data.get('name') or '').strip()
+        notes = (data.get('notes') or '').strip()
+        specs = json.dumps(data.get('specs', {}))
+        device_ids = data.get('device_ids') or []
+        if not name:
+            return jsonify({"error": "Name ist erforderlich"}), 400
+        db.execute('''
+            UPDATE assets
+            SET name = ?, notes = ?, specs = ?
+            WHERE id = ?
+        ''', (name, notes, specs, asset_id))
+        db.execute('DELETE FROM asset_devices WHERE asset_id = ?', (asset_id,))
+        for device_id in device_ids:
+            db.execute('''
+                INSERT INTO asset_devices (asset_id, device_id)
+                VALUES (?, ?)
+            ''', (asset_id, device_id))
+        log_activity(db, "update", "asset", asset_id, {"name": name})
+        db.commit()
+        return jsonify({"status": "updated"}), 200
+
+    db.execute('DELETE FROM asset_devices WHERE asset_id = ?', (asset_id,))
+    db.execute('DELETE FROM assets WHERE id = ?', (asset_id,))
+    log_activity(db, "delete", "asset", asset_id)
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
 
 @app.route('/api/locations', methods=['GET', 'POST'])
 @login_required

--- a/static/script.js
+++ b/static/script.js
@@ -5,6 +5,8 @@ document.addEventListener('alpine:init', () => {
         locations: [],
         devices: [],
         filteredDevices: [],
+        allDevices: [],
+        assets: [],
         activeCategory: null,
         searchQuery: '',
         sortDropdownOpen: false,
@@ -21,6 +23,8 @@ document.addEventListener('alpine:init', () => {
         activityFeed: [],
         selectedDevice: null,
         deviceDetailOpen: false,
+        selectedAsset: null,
+        assetDetailOpen: false,
         deviceTags: [],
         deviceNotes: [],
         maintenanceTasks: [],
@@ -35,8 +39,10 @@ document.addEventListener('alpine:init', () => {
         // Modals
         isCategoryModalOpen: false,
         isDeviceModalOpen: false,
+        isAssetModalOpen: false,
         editingCategory: null,
         editingDevice: null,
+        editingAsset: null,
         categoryMenuOpen: null,  // Geändert von openCategoryId zu categoryMenuOpen für Konsistenz
         openDeviceId: null,
         
@@ -56,12 +62,21 @@ document.addEventListener('alpine:init', () => {
             specs: {},
             extraSpecs: []
         },
+        currentAsset: {
+            id: null,
+            name: '',
+            notes: '',
+            specs: [],
+            device_ids: []
+        },
 
         // Initialization
         async init() {
             await this.loadCategories();
             await this.loadLocations();
+            await this.loadAllDevices();
             await this.loadDevices();
+            await this.loadAssets();
             await this.loadFeatureFlags();
             await this.loadMaintenanceSummary();
             await this.loadActivityFeed();
@@ -130,6 +145,20 @@ document.addEventListener('alpine:init', () => {
                 if (updated) {
                     this.selectedDevice = updated;
                 }
+            }
+        },
+		
+        async loadAllDevices() {
+            const response = await fetch('/api/devices');
+            if (response.ok) {
+                this.allDevices = await response.json();
+            }
+        },
+
+        async loadAssets() {
+            const response = await fetch('/api/assets');
+            if (response.ok) {
+                this.assets = await response.json();
             }
         },
 
@@ -434,6 +463,7 @@ document.addEventListener('alpine:init', () => {
                 }
 
                 await this.loadDevices(this.activeCategory);
+                await this.loadAllDevices();
                 this.closeDeviceModal();
                 await this.loadActivityFeed();
             } catch (error) {
@@ -449,6 +479,7 @@ document.addEventListener('alpine:init', () => {
                 });
                 if (response.ok) {
                     await this.loadDevices(this.activeCategory);
+                    await this.loadAllDevices();
                     await this.loadActivityFeed();
                 } else {
                     const error = await response.json();
@@ -627,6 +658,144 @@ document.addEventListener('alpine:init', () => {
             return `${label}${name ? ` • ${name}` : ''}`;
         },
 
+        // Asset Methods
+        async openAddAssetModal() {
+            this.editingAsset = false;
+            this.currentAsset = {
+                id: null,
+                name: '',
+                notes: '',
+                specs: [],
+                device_ids: []
+            };
+            if (this.allDevices.length === 0) {
+                await this.loadAllDevices();
+            }
+            this.isAssetModalOpen = true;
+        },
+
+        async openEditAssetModal(asset) {
+            try {
+                const response = await fetch(`/api/assets/${asset.id}`);
+                if (!response.ok) {
+                    throw new Error('Asset konnte nicht geladen werden');
+                }
+                const data = await response.json();
+                this.editingAsset = true;
+                this.currentAsset = {
+                    id: data.id,
+                    name: data.name,
+                    notes: data.notes || '',
+                    specs: Object.entries(data.specs || {}).map(([key, value]) => ({
+                        id: crypto.randomUUID(),
+                        name: key,
+                        value
+                    })),
+                    device_ids: (data.devices || []).map(device => device.id)
+                };
+                this.isAssetModalOpen = true;
+            } catch (error) {
+                console.error('Error loading asset:', error);
+                alert(error.message);
+            }
+        },
+
+        closeAssetModal() {
+            this.isAssetModalOpen = false;
+        },
+
+        addAssetSpec() {
+            this.currentAsset.specs.push({
+                id: crypto.randomUUID(),
+                name: '',
+                value: ''
+            });
+        },
+
+        removeAssetSpec(specId) {
+            this.currentAsset.specs = this.currentAsset.specs.filter(spec => spec.id !== specId);
+        },
+
+        async saveAsset() {
+            try {
+                const specs = {};
+                this.currentAsset.specs.forEach((spec) => {
+                    const trimmedName = spec.name.trim();
+                    if (!trimmedName) return;
+                    specs[trimmedName] = spec.value;
+                });
+
+                const payload = {
+                    name: this.currentAsset.name,
+                    notes: this.currentAsset.notes,
+                    specs,
+                    device_ids: this.currentAsset.device_ids
+                };
+
+                let response;
+                if (this.editingAsset) {
+                    response = await fetch(`/api/assets/${this.currentAsset.id}`, {
+                        method: 'PUT',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(payload)
+                    });
+                } else {
+                    response = await fetch('/api/assets', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(payload)
+                    });
+                }
+
+                if (!response.ok) {
+                    const error = await response.json();
+                    throw new Error(error.error || 'Asset konnte nicht gespeichert werden');
+                }
+
+                await this.loadAssets();
+                this.closeAssetModal();
+                await this.loadActivityFeed();
+            } catch (error) {
+                console.error('Error saving asset:', error);
+                alert('Error saving asset: ' + error.message);
+            }
+        },
+
+        async deleteAsset(assetId) {
+            if (!confirm('Möchten Sie dieses Asset wirklich löschen?')) {
+                return;
+            }
+            const response = await fetch(`/api/assets/${assetId}`, {
+                method: 'DELETE'
+            });
+            if (response.ok) {
+                await this.loadAssets();
+                await this.loadActivityFeed();
+            } else {
+                const error = await response.json();
+                alert(error.error || 'Asset konnte nicht gelöscht werden');
+            }
+        },
+
+        async openAssetDetail(asset) {
+            try {
+                const response = await fetch(`/api/assets/${asset.id}`);
+                if (!response.ok) {
+                    throw new Error('Asset konnte nicht geladen werden');
+                }
+                this.selectedAsset = await response.json();
+                this.assetDetailOpen = true;
+            } catch (error) {
+                console.error('Error loading asset detail:', error);
+                alert(error.message);
+            }
+        },
+
+        closeAssetDetail() {
+            this.assetDetailOpen = false;
+            this.selectedAsset = null;
+        },
+
         // Helper Methods
         getCategoryById(categoryId) {
             return this.categories.find(c => c.id === categoryId) || null;
@@ -687,6 +856,10 @@ document.addEventListener('alpine:init', () => {
                 key,
                 value: this.formatSpecValue(value)
             }));
+        },
+
+        getDevicesForCategory(categoryId) {
+            return this.allDevices.filter(device => device.category_id === categoryId);
         },
 
 		getCategoryColor(categoryName) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,6 +26,7 @@
 
             <nav x-data="{
                 categoriesOpen: true,
+                assetsOpen: true,
                 otpModalOpen: false,
                 otpSecret: '',
                 otpQrCode: '',
@@ -133,6 +134,44 @@
                         <button @click="openAddCategoryModal()" class="flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium text-blue-600 hover:text-blue-800 w-full rounded-xl hover:bg-white transition-colors sidebar-text">
                             <i data-feather="plus-circle" class="w-4 h-4"></i>
                             Kategorie hinzufügen
+                        </button>
+                    </div>
+                </div>
+
+                <div class="border border-slate-200 rounded-2xl overflow-hidden shadow-sm bg-white sidebar-compact-hidden">
+                    <button @click="assetsOpen = !assetsOpen"
+                            class="w-full flex items-center justify-between px-4 py-3 bg-white hover:bg-slate-50 transition-colors">
+                        <span class="flex items-center gap-3">
+                            <span class="flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-600">
+                                <i data-feather="package" class="w-4 h-4"></i>
+                            </span>
+                            <span class="text-sm font-semibold text-slate-800 sidebar-text">Assets</span>
+                        </span>
+                        <svg :class="{ 'rotate-180': assetsOpen }" class="w-4 h-4 text-slate-500 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                        </svg>
+                    </button>
+
+                    <div x-show="assetsOpen" x-transition class="bg-slate-50 px-2 py-2 space-y-1 text-sm text-slate-800">
+                        <template x-for="asset in assets" :key="asset.id">
+                            <div class="group flex items-center justify-between px-3 py-2 rounded-xl hover:bg-white transition-colors">
+                                <button @click="openAssetDetail(asset)" class="flex items-center gap-2 flex-1 min-w-0 text-left">
+                                    <span class="inline-flex items-center justify-center w-7 h-7 rounded-lg bg-indigo-50 text-indigo-600 text-xs font-semibold" x-text="asset.device_count || 0"></span>
+                                    <span class="sidebar-text truncate" x-text="asset.name"></span>
+                                </button>
+                                <div class="flex items-center gap-2">
+                                    <button @click="openEditAssetModal(asset)" class="text-slate-500 hover:text-slate-900">
+                                        <i data-feather="edit" class="w-4 h-4"></i>
+                                    </button>
+                                    <button @click="deleteAsset(asset.id)" class="text-rose-500 hover:text-rose-700">
+                                        <i data-feather="trash-2" class="w-4 h-4"></i>
+                                    </button>
+                                </div>
+                            </div>
+                        </template>
+                        <button @click="openAddAssetModal()" class="flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium text-indigo-600 hover:text-indigo-800 w-full rounded-xl hover:bg-white transition-colors sidebar-text">
+                            <i data-feather="plus-circle" class="w-4 h-4"></i>
+                            Asset hinzufügen
                         </button>
                     </div>
                 </div>
@@ -253,6 +292,10 @@
                                     <i data-feather="folder-plus" class="w-4 h-4"></i>
                                     Kategorie anlegen
                                 </button>
+                                <button @click="openAddAssetModal()" class="inline-flex items-center gap-2 rounded-full border border-white/30 px-4 py-2 text-sm font-semibold text-white/90 hover:bg-white/10">
+                                    <i data-feather="package" class="w-4 h-4"></i>
+                                    Asset anlegen
+                                </button>
                                 <button x-show="activeCategory && getCategoryById(activeCategory)" @click="editCategoryModal(getCategoryById(activeCategory))" class="inline-flex items-center gap-2 rounded-full border border-white/30 px-4 py-2 text-sm font-semibold text-white/90 hover:bg-white/10">
                                     <i data-feather="edit" class="w-4 h-4"></i>
                                     Kategorie bearbeiten
@@ -369,6 +412,7 @@
                         <div class="mt-4 space-y-3">
                             <button @click="openAddDeviceModal()" class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">Gerät hinzufügen</button>
                             <button @click="openAddCategoryModal()" class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">Kategorie erstellen</button>
+                            <button @click="openAddAssetModal()" class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">Asset erstellen</button>
                             <a href="/stats" class="block w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">Statistiken ansehen</a>
                             <a href="/api/export/devices" class="block w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left text-sm font-semibold text-slate-700 hover:bg-slate-100">CSV Export</a>
                         </div>
@@ -395,6 +439,55 @@
                         </div>
                     </div>
                 </section>
+
+                <div class="rounded-3xl border border-slate-200 bg-white shadow-sm">
+                    <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+                        <div>
+                            <h3 class="text-lg font-semibold text-slate-900">Assets</h3>
+                            <p class="text-sm text-slate-500">Kombiniere Geräte zu einem vollständigen Asset.</p>
+                        </div>
+                        <button @click="openAddAssetModal()" class="inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-xs font-semibold text-white hover:bg-indigo-500">
+                            <i data-feather="plus" class="w-4 h-4"></i>
+                            Asset hinzufügen
+                        </button>
+                    </div>
+                    <div class="overflow-x-hidden">
+                        <table class="w-full table-fixed text-sm">
+                            <thead class="text-left text-slate-500">
+                                <tr class="border-b border-slate-200">
+                                    <th class="py-3 px-4 sm:px-6 font-semibold">Asset</th>
+                                    <th class="py-3 px-4 sm:px-6 font-semibold">Komponenten</th>
+                                    <th class="hidden md:table-cell py-3 px-4 sm:px-6 font-semibold">Notizen</th>
+                                    <th class="py-3 px-4 sm:px-6 font-semibold text-right">Aktionen</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100">
+                                <template x-for="asset in assets" :key="asset.id">
+                                    <tr class="hover:bg-slate-50">
+                                        <td class="py-4 px-4 sm:px-6">
+                                            <p class="max-w-[14rem] truncate font-semibold text-slate-900 sm:max-w-none" x-text="asset.name"></p>
+                                            <p class="text-xs text-slate-500" x-text="asset.created_at?.slice(0, 10) || ''"></p>
+                                        </td>
+                                        <td class="py-4 px-4 sm:px-6 text-slate-700">
+                                            <span class="inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700" x-text="`${asset.device_count || 0} Geräte`"></span>
+                                        </td>
+                                        <td class="hidden md:table-cell py-4 px-4 sm:px-6 text-slate-600">
+                                            <span class="line-clamp-2" x-text="asset.notes || '-'"></span>
+                                        </td>
+                                        <td class="py-4 px-4 sm:px-6 text-right">
+                                            <div class="flex flex-wrap items-center justify-end gap-2">
+                                                <button @click="openAssetDetail(asset)" class="rounded-full border border-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-600 hover:bg-indigo-50">Details</button>
+                                                <button @click="openEditAssetModal(asset)" class="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-100">Bearbeiten</button>
+                                                <button @click="deleteAsset(asset.id)" class="rounded-full border border-rose-200 px-3 py-1 text-xs font-semibold text-rose-600 hover:bg-rose-50">Löschen</button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </template>
+                            </tbody>
+                        </table>
+                        <p x-show="assets.length === 0" class="px-6 py-6 text-sm text-slate-400">Noch keine Assets angelegt.</p>
+                    </div>
+                </div>
 
                 <div class="rounded-3xl border border-slate-200 bg-white shadow-sm">
                     <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
@@ -627,6 +720,152 @@
                     </div>
                 </div>
             </div>
+        </div>
+    </div>
+
+    <div x-show="assetDetailOpen" @click.away="closeAssetDetail()" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-6" x-transition>
+        <div class="bg-white rounded-3xl shadow-2xl w-full max-w-4xl max-h-[90vh] overflow-y-auto">
+            <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Assetübersicht</p>
+                    <h3 class="text-xl font-semibold text-slate-900" x-text="selectedAsset?.name"></h3>
+                </div>
+                <button @click="closeAssetDetail()" class="text-slate-400 hover:text-slate-600">
+                    <i data-feather="x" class="w-6 h-6"></i>
+                </button>
+            </div>
+            <div class="grid gap-6 p-6 lg:grid-cols-3">
+                <div class="lg:col-span-2 space-y-6">
+                    <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                        <p class="text-sm font-semibold text-slate-700">Kurzprofil</p>
+                        <div class="mt-3 grid gap-2 text-sm text-slate-600">
+                            <div class="flex justify-between">
+                                <span>Komponenten</span>
+                                <span class="font-semibold text-slate-900" x-text="selectedAsset?.devices?.length || 0"></span>
+                            </div>
+                            <div class="flex justify-between">
+                                <span>Erstellt</span>
+                                <span class="font-semibold text-slate-900" x-text="selectedAsset?.created_at?.slice(0, 10) || '-' "></span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4">
+                        <p class="text-sm font-semibold text-slate-900">Spezifikationen</p>
+                        <div class="mt-3 space-y-2 text-sm text-slate-600">
+                            <template x-for="spec in Object.entries(selectedAsset?.specs || {})" :key="spec[0]">
+                                <div class="flex justify-between gap-4">
+                                    <span x-text="spec[0]"></span>
+                                    <span class="font-semibold text-slate-900 text-right" x-text="spec[1]"></span>
+                                </div>
+                            </template>
+                            <p x-show="Object.keys(selectedAsset?.specs || {}).length === 0" class="text-xs text-slate-400">Keine Spezifikationen hinterlegt.</p>
+                        </div>
+                    </div>
+
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4">
+                        <p class="text-sm font-semibold text-slate-900">Notizen</p>
+                        <p class="mt-2 text-sm text-slate-600 whitespace-pre-line" x-text="selectedAsset?.notes || 'Keine Notizen hinterlegt.'"></p>
+                    </div>
+                </div>
+
+                <div class="space-y-6">
+                    <div class="rounded-2xl border border-indigo-100 bg-indigo-50/60 p-4">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-indigo-700">Asset-Komponenten</p>
+                                <p class="text-xs text-indigo-500">Zugeordnete Geräte</p>
+                            </div>
+                            <i data-feather="layers" class="w-4 h-4 text-indigo-400"></i>
+                        </div>
+                        <div class="mt-4 space-y-3 text-sm">
+                            <template x-for="device in selectedAsset?.devices || []" :key="device.id">
+                                <div class="rounded-2xl border border-indigo-100 bg-white px-3 py-2">
+                                    <p class="font-semibold text-slate-800" x-text="device.name"></p>
+                                    <p class="text-xs text-slate-500" x-text="device.category_name"></p>
+                                </div>
+                            </template>
+                            <p x-show="(selectedAsset?.devices || []).length === 0" class="text-xs text-indigo-500">Keine Geräte zugeordnet.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div x-show="isAssetModalOpen" @click.away="closeAssetModal()" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-6">
+        <div class="bg-white rounded-3xl shadow-2xl w-full max-w-3xl max-h-[90vh] overflow-y-auto">
+            <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Asset</p>
+                    <h3 class="text-lg font-semibold text-slate-900" x-text="editingAsset ? 'Asset bearbeiten' : 'Neues Asset'"></h3>
+                </div>
+                <button @click="closeAssetModal()" class="text-slate-400 hover:text-slate-600">
+                    <i data-feather="x" class="w-5 h-5"></i>
+                </button>
+            </div>
+            <form @submit.prevent="saveAsset()" class="space-y-4 p-6">
+                <input type="hidden" x-model="currentAsset.id">
+                <div>
+                    <label class="text-sm font-semibold text-slate-700">Name*</label>
+                    <input type="text" x-model="currentAsset.name" required class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-indigo-500 focus:ring-indigo-500">
+                </div>
+                <div>
+                    <label class="text-sm font-semibold text-slate-700">Notizen</label>
+                    <textarea x-model="currentAsset.notes" rows="3" class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Zusätzliche Infos, z. B. Einsatzzweck"></textarea>
+                </div>
+                <div>
+                    <div class="flex items-center justify-between">
+                        <label class="text-sm font-semibold text-slate-700">Spezifikationen</label>
+                        <button type="button" @click="addAssetSpec()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-100">
+                            <i data-feather="plus" class="w-3 h-3"></i>
+                            Spezifikation hinzufügen
+                        </button>
+                    </div>
+                    <div class="mt-3 space-y-3">
+                        <template x-for="spec in currentAsset.specs" :key="spec.id">
+                            <div class="flex flex-col gap-2 rounded-2xl border border-slate-200 bg-slate-50 p-3 sm:flex-row sm:items-center">
+                                <div class="flex-1">
+                                    <label class="text-xs font-semibold text-slate-500">Bezeichnung</label>
+                                    <input type="text" x-model="spec.name" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="z. B. Build">
+                                </div>
+                                <div class="flex-1">
+                                    <label class="text-xs font-semibold text-slate-500">Wert</label>
+                                    <input type="text" x-model="spec.value" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="z. B. Gaming PC">
+                                </div>
+                                <button type="button" @click="removeAssetSpec(spec.id)" class="self-start rounded-full border border-rose-200 px-3 py-2 text-xs font-semibold text-rose-600 hover:bg-rose-50 sm:self-center">
+                                    Entfernen
+                                </button>
+                            </div>
+                        </template>
+                        <p x-show="currentAsset.specs.length === 0" class="text-xs text-slate-400">Keine Spezifikationen angelegt.</p>
+                    </div>
+                </div>
+                <div>
+                    <label class="text-sm font-semibold text-slate-700">Geräte zuordnen</label>
+                    <div class="mt-3 space-y-4">
+                        <template x-for="category in categories" :key="category.id">
+                            <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                                <p class="text-sm font-semibold text-slate-700" x-text="category.name"></p>
+                                <div class="mt-3 grid gap-2 sm:grid-cols-2">
+                                    <template x-for="device in getDevicesForCategory(category.id)" :key="device.id">
+                                        <label class="flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
+                                            <input type="checkbox" :value="device.id" x-model="currentAsset.device_ids" class="rounded border-slate-300 text-indigo-600 focus:ring-indigo-500">
+                                            <span class="truncate" x-text="device.name"></span>
+                                        </label>
+                                    </template>
+                                    <p x-show="getDevicesForCategory(category.id).length === 0" class="text-xs text-slate-400">Keine Geräte in dieser Kategorie.</p>
+                                </div>
+                            </div>
+                        </template>
+                        <p x-show="categories.length === 0" class="text-xs text-slate-400">Bitte zuerst Kategorien und Geräte anlegen.</p>
+                    </div>
+                </div>
+                <div class="flex justify-end gap-3 pt-2">
+                    <button type="button" @click="closeAssetModal()" class="rounded-2xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100">Abbrechen</button>
+                    <button type="submit" class="rounded-2xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500">Speichern</button>
+                </div>
+            </form>
         </div>
     </div>
 


### PR DESCRIPTION
### Motivation
- Provide a way to group individual category entries/devices into higher-level Assets (e.g. combine CPU, RAM, GPU entries into a single “Gaming PC” asset). 
- Let users name an asset, add specs/notes and select devices from categories to form that asset.

### Description
- Added two new tables in `init_db()`: `assets` and `asset_devices` to persist assets and their device memberships (`app.py`).
- Implemented REST endpoints `GET/POST /api/assets` and `GET/PUT/DELETE /api/assets/<id>` to create, read, update and delete assets and their relations (`app.py`).
- Extended client state and logic in `static/script.js` to load assets and all devices, and added methods for asset CRUD, device selection per category, spec handling and detail views (`loadAllDevices`, `loadAssets`, `openAddAssetModal`, `openEditAssetModal`, `saveAsset`, `deleteAsset`, `openAssetDetail`, `getDevicesForCategory`).
- Updated `templates/index.html` to add an Assets section in the sidebar, an Assets list on the dashboard, an Asset detail modal and an Asset creation/edit modal with device assignment UI and spec/notes fields.

### Testing
- Launched the app locally with `python app.py` and confirmed the server started and API endpoints responded (server run logged successfully). — succeeded.
- Ran an automated Playwright script that logged in as the temporary admin (`admin`/`admin`) and captured a screenshot of the dashboard showing the new Assets section, with HTTP requests to `/api/assets` observed in the server log — succeeded (screenshot saved at the test artifact path).
- Committed the changes to the repository; no unit tests were added or run beyond the integration smoke test above. — succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69739f66d0fc832d8ae9db7b3b3aad5d)