### PR TITLE
Add migration for assets notes/specs columns

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,6 +134,16 @@ def init_db():
             )
         ''')
 
+        try:
+            c.execute('ALTER TABLE assets ADD COLUMN notes TEXT')
+        except sqlite3.OperationalError:
+            pass
+
+        try:
+            c.execute('ALTER TABLE assets ADD COLUMN specs TEXT')
+        except sqlite3.OperationalError:
+            pass
+
         c.execute('''
             CREATE TABLE IF NOT EXISTS asset_devices (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
### Motivation
- Beim Anlegen eines Assets trat der Fehler `Datenbankfehler: table assets has no column named notes` auf, weil ältere Datenbanken die Spalten `notes` und `specs` in der Tabelle `assets` nicht haben; das sollte beim Start automatisch korrigiert werden.

### Description
- In `init_db()` (`app.py`) wurden zwei idempotente Migrationen ergänzt, die mit `ALTER TABLE assets ADD COLUMN notes TEXT` und `ALTER TABLE assets ADD COLUMN specs TEXT` die fehlenden Spalten hinzufügen und jede Anweisung in einem `try/except sqlite3.OperationalError` abfangen.

### Testing
- Es wurden keine automatisierten Tests ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973a4203c4c832db9e72e3e5b4b21ea)