### PR TITLE
Add searchable Feather icon catalog for category picker

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -45,6 +45,8 @@ document.addEventListener('alpine:init', () => {
         editingAsset: null,
         categoryMenuOpen: null,  // Geändert von openCategoryId zu categoryMenuOpen für Konsistenz
         openDeviceId: null,
+        iconSearch: '',
+        iconCatalog: [],
         
         // Current Items
         currentCategory: {
@@ -80,6 +82,7 @@ document.addEventListener('alpine:init', () => {
             await this.loadFeatureFlags();
             await this.loadMaintenanceSummary();
             await this.loadActivityFeed();
+            this.loadIconCatalog();
             this.$watch('searchQuery', () => this.searchDevices());
             feather.replace();
             this.startLiveRefresh();
@@ -173,6 +176,14 @@ document.addEventListener('alpine:init', () => {
             }
         },
 
+        loadIconCatalog() {
+            if (!window.feather || !feather.icons) {
+                this.iconCatalog = [];
+                return;
+            }
+            this.iconCatalog = Object.keys(feather.icons).sort();
+        },
+
         // Search and Sort
         searchDevices() {
             if (!this.searchQuery) {
@@ -229,6 +240,7 @@ document.addEventListener('alpine:init', () => {
                 icon: 'cpu',
                 fields: []
             };
+            this.iconSearch = '';
             this.isCategoryModalOpen = true;
             this.categoryMenuOpen = null; // Menü schließen beim Öffnen des Modals
         },
@@ -261,6 +273,7 @@ document.addEventListener('alpine:init', () => {
                     };
                 })
 			};
+            this.iconSearch = '';
 			this.isCategoryModalOpen = true;
 			this.categoryMenuOpen = null; // Menü schließen beim Öffnen des Modals
 		},
@@ -281,6 +294,18 @@ document.addEventListener('alpine:init', () => {
 
         removeCategoryField(fieldId) {
             this.currentCategory.fields = this.currentCategory.fields.filter(field => field.id !== fieldId);
+        },
+
+        filteredIconCatalog() {
+            const query = this.iconSearch.trim().toLowerCase();
+            if (!query) {
+                return this.iconCatalog;
+            }
+            return this.iconCatalog.filter(iconName => iconName.includes(query));
+        },
+
+        selectIcon(iconName) {
+            this.currentCategory.icon = iconName;
         },
 
         async saveCategory() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -887,21 +887,30 @@
                 </div>
                 <div>
                     <label class="text-sm font-semibold text-slate-700">Icon*</label>
-                    <select x-model="currentCategory.icon" required class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
-                        <option value="cpu">CPU</option>
-                        <option value="gpu">GPU</option>
-                        <option value="memory">RAM</option>
-                        <option value="hard-drive">Festplatte</option>
-                        <option value="server">Server</option>
-                        <option value="monitor">Monitor</option>
-                        <option value="printer">Drucker</option>
-                        <option value="wind">Kühlsystem</option>
-                        <option value="grid">Mainboard</option>
-                        <option value="zap">Netzteil</option>
-                        <option value="sliders">RAM</option>
-                        <option value="wifi">Netzwerk</option>
-                        <option value="code">Raspberry Pi</option>
-                    </select>
+                    <div class="mt-2 space-y-3">
+                        <div class="flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2">
+                            <div class="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200 bg-white">
+                                <div x-html="feather.icons[currentCategory.icon]?.toSvg({ class: 'w-5 h-5 text-slate-600' })"></div>
+                            </div>
+                            <div class="flex-1">
+                                <input type="text" x-model="iconSearch" placeholder="Icon suchen (z. B. box, camera, tool)" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:ring-blue-500">
+                                <p class="mt-1 text-xs text-slate-400">Aktuell: <span class="font-semibold text-slate-600" x-text="currentCategory.icon"></span></p>
+                            </div>
+                        </div>
+                        <div class="max-h-56 overflow-y-auto rounded-2xl border border-slate-200 bg-white p-2">
+                            <div class="grid grid-cols-4 gap-2 sm:grid-cols-6">
+                                <template x-for="iconName in filteredIconCatalog()" :key="iconName">
+                                    <button type="button" @click="selectIcon(iconName)" class="flex flex-col items-center gap-1 rounded-xl border px-2 py-2 text-[10px] font-semibold uppercase tracking-wide transition"
+                                        :class="currentCategory.icon === iconName ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-slate-200 text-slate-500 hover:border-slate-300 hover:bg-slate-50'">
+                                        <div x-html="feather.icons[iconName]?.toSvg({ class: 'w-4 h-4' })"></div>
+                                        <span class="w-full truncate" x-text="iconName"></span>
+                                    </button>
+                                </template>
+                            </div>
+                            <p x-show="filteredIconCatalog().length === 0" class="p-4 text-center text-xs text-slate-400">Keine Icons gefunden.</p>
+                        </div>
+                        <p class="text-xs text-slate-500">Tipp: Nutze die Suche für eine große Auswahl an passenden Symbolen.</p>
+                    </div>
                 </div>
                 <div>
                     <div class="flex items-center justify-between">


### PR DESCRIPTION
### Motivation
- Provide a much larger, searchable icon selection for categories so users can pick more appropriate symbols when creating or editing a category.
- Replace the small fixed dropdown with a visual catalog and preview to make icon selection faster and more intuitive.

### Description
- Replaced the single `<select>` icon control in `templates/index.html` with a preview, search input and a searchable grid of icons using `feather.icons` for rendering. 
- Added Alpine state properties `iconSearch` and `iconCatalog`, and a `loadIconCatalog` initializer to populate available Feather icon names in `static/script.js`.
- Implemented `filteredIconCatalog()` and `selectIcon(iconName)` helpers and wired `iconSearch` reset into `openAddCategoryModal` and `editCategoryModal` to support searching and picking icons. 
- The UI now shows a live preview of the currently selected icon and highlights the chosen icon in the grid.

### Testing
- Launched the development server with `python app.py` and verified the app started and returned `200` for core API endpoints as seen in the server logs, which succeeded. 
- Executed a Playwright-based UI smoke script that logs in, opens the category modal, types into the icon search and captured a screenshot (`artifacts/icon-picker.png`), which ran successfully and produced the artifact. 
- No automated unit tests were added or run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973a7a0f5cc832db0340d8a1a0da023)