### PR TITLE
Add Active Directory integration (ldap3) with UI and AD-backed login

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,8 @@ import qrcode
 import qrcode.image.svg
 from io import BytesIO, StringIO
 import base64
+from ldap3 import Server, Connection
+from ldap3.utils.conv import escape_filter_chars
 
 
 app = Flask(__name__)
@@ -168,6 +170,22 @@ def init_db():
         ''')
 
         c.execute('''
+            CREATE TABLE IF NOT EXISTS ad_settings (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                enabled INTEGER DEFAULT 0,
+                server_url TEXT,
+                base_dn TEXT,
+                bind_dn TEXT,
+                bind_password TEXT,
+                user_attribute TEXT DEFAULT 'sAMAccountName',
+                domain TEXT,
+                use_ssl INTEGER DEFAULT 0,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+        c.execute('INSERT OR IGNORE INTO ad_settings (id) VALUES (1)')
+
+        c.execute('''
             CREATE TABLE IF NOT EXISTS device_tags (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 device_id INTEGER NOT NULL,
@@ -297,6 +315,81 @@ def pro_required(f):
         return f(*args, **kwargs)
     return wrapped
 
+def get_ad_settings(db):
+    settings = db.execute('SELECT * FROM ad_settings WHERE id = 1').fetchone()
+    if not settings:
+        db.execute('INSERT INTO ad_settings (id) VALUES (1)')
+        db.commit()
+        settings = db.execute('SELECT * FROM ad_settings WHERE id = 1').fetchone()
+    return settings
+
+def serialize_ad_settings(settings):
+    if not settings:
+        return {
+            "enabled": False,
+            "server_url": "",
+            "base_dn": "",
+            "bind_dn": "",
+            "user_attribute": "sAMAccountName",
+            "domain": "",
+            "use_ssl": False,
+            "has_bind_password": False
+        }
+    return {
+        "enabled": bool(settings["enabled"]),
+        "server_url": settings["server_url"] or "",
+        "base_dn": settings["base_dn"] or "",
+        "bind_dn": settings["bind_dn"] or "",
+        "user_attribute": settings["user_attribute"] or "sAMAccountName",
+        "domain": settings["domain"] or "",
+        "use_ssl": bool(settings["use_ssl"]),
+        "has_bind_password": bool(settings["bind_password"])
+    }
+
+def authenticate_ad_user(username, password, settings):
+    if not settings or not settings["enabled"]:
+        return False
+    server_url = settings["server_url"] or ""
+    base_dn = settings["base_dn"] or ""
+    if not server_url or not base_dn:
+        return False
+    if not password:
+        return False
+
+    server = Server(server_url, use_ssl=bool(settings["use_ssl"]))
+    bind_dn = settings["bind_dn"] or ""
+    bind_password = settings["bind_password"] or ""
+    user_attribute = settings["user_attribute"] or "sAMAccountName"
+    domain = settings["domain"] or ""
+
+    if bind_dn:
+        try:
+            admin_conn = Connection(server, user=bind_dn, password=bind_password, auto_bind=True)
+        except Exception:
+            return False
+        safe_username = escape_filter_chars(username)
+        search_filter = f"({user_attribute}={safe_username})"
+        admin_conn.search(base_dn, search_filter, attributes=["distinguishedName"])
+        if not admin_conn.entries:
+            admin_conn.unbind()
+            return False
+        user_dn = admin_conn.entries[0].entry_dn
+        admin_conn.unbind()
+        try:
+            user_conn = Connection(server, user=user_dn, password=password, auto_bind=True)
+            user_conn.unbind()
+            return True
+        except Exception:
+            return False
+
+    user_principal = f"{username}@{domain}" if domain else username
+    try:
+        user_conn = Connection(server, user=user_principal, password=password, auto_bind=True)
+        user_conn.unbind()
+        return True
+    except Exception:
+        return False
+
 @app.route('/login', methods=['GET', 'POST'])
 def login():
     if request.method == 'POST':
@@ -310,6 +403,19 @@ def login():
             session['logged_in'] = True
             session['username'] = username
             log_activity(db, "login", "user", user['id'], {"username": username})
+            db.commit()
+            return redirect(url_for('index'))
+
+        ad_settings = get_ad_settings(db)
+        if authenticate_ad_user(username, password, ad_settings):
+            existing_user = db.execute('SELECT id FROM users WHERE username = ?', (username,)).fetchone()
+            if not existing_user:
+                placeholder_password = generate_password_hash(os.urandom(24).hex())
+                db.execute('INSERT INTO users (username, password_hash) VALUES (?, ?)', (username, placeholder_password))
+                existing_user = db.execute('SELECT id FROM users WHERE username = ?', (username,)).fetchone()
+            session['logged_in'] = True
+            session['username'] = username
+            log_activity(db, "login", "user", existing_user['id'], {"username": username, "source": "ad"})
             db.commit()
             return redirect(url_for('index'))
 
@@ -774,6 +880,82 @@ def reset_user_password(user_id):
     log_activity(db, "update", "user_password", user_id)
     db.commit()
     return jsonify({"status": "updated"}), 200
+
+@app.route('/api/ad/settings', methods=['GET'])
+@login_required
+def ad_settings():
+    db = get_db()
+    settings = get_ad_settings(db)
+    return jsonify(serialize_ad_settings(settings))
+
+@app.route('/api/ad/connect', methods=['POST'])
+@login_required
+def connect_ad():
+    db = get_db()
+    data = request.get_json() or {}
+    server_url = (data.get('server_url') or '').strip()
+    base_dn = (data.get('base_dn') or '').strip()
+    bind_dn = (data.get('bind_dn') or '').strip()
+    bind_password = data.get('bind_password') or ''
+    user_attribute = (data.get('user_attribute') or 'sAMAccountName').strip()
+    domain = (data.get('domain') or '').strip()
+    use_ssl = bool(data.get('use_ssl'))
+
+    if not server_url or not base_dn:
+        return jsonify({"error": "Server-URL und Base DN sind erforderlich"}), 400
+
+    existing = get_ad_settings(db)
+    if not bind_password and existing:
+        bind_password = existing["bind_password"] or ''
+
+    server = Server(server_url, use_ssl=use_ssl)
+    if bind_dn:
+        try:
+            test_conn = Connection(server, user=bind_dn, password=bind_password, auto_bind=True)
+            test_conn.unbind()
+        except Exception:
+            return jsonify({"error": "Bind zum Active Directory fehlgeschlagen"}), 400
+
+    db.execute('''
+        UPDATE ad_settings
+        SET enabled = 1,
+            server_url = ?,
+            base_dn = ?,
+            bind_dn = ?,
+            bind_password = ?,
+            user_attribute = ?,
+            domain = ?,
+            use_ssl = ?,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = 1
+    ''', (
+        server_url,
+        base_dn,
+        bind_dn,
+        bind_password,
+        user_attribute,
+        domain,
+        1 if use_ssl else 0
+    ))
+    log_activity(db, "update", "ad_settings", details={"enabled": True, "server_url": server_url})
+    db.commit()
+    settings = get_ad_settings(db)
+    return jsonify(serialize_ad_settings(settings))
+
+@app.route('/api/ad/disconnect', methods=['POST'])
+@login_required
+def disconnect_ad():
+    db = get_db()
+    db.execute('''
+        UPDATE ad_settings
+        SET enabled = 0,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = 1
+    ''')
+    log_activity(db, "update", "ad_settings", details={"enabled": False})
+    db.commit()
+    settings = get_ad_settings(db)
+    return jsonify(serialize_ad_settings(settings))
 
 @app.route('/api/devices/<int:device_id>/tags', methods=['GET', 'POST'])
 @login_required

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ werkzeug
 pyotp
 qrcode
 pillow
+ldap3

--- a/templates/users.html
+++ b/templates/users.html
@@ -186,6 +186,74 @@
                     </div>
                 </div>
             </section>
+
+            <section class="grid gap-6 lg:grid-cols-3">
+                <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm lg:col-span-3">
+                    <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                        <div>
+                            <h3 class="text-lg font-semibold text-slate-900">Active Directory</h3>
+                            <p class="text-sm text-slate-500">Verbinde ein AD, um Benutzer zentral anzumelden.</p>
+                        </div>
+                        <span class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold"
+                              :class="adSettings.enabled ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-500'">
+                            <i data-feather="link" x-show="adSettings.enabled" class="w-3 h-3"></i>
+                            <i data-feather="unlink" x-show="!adSettings.enabled" class="w-3 h-3"></i>
+                            <span x-text="adSettings.enabled ? 'Verbunden' : 'Getrennt'"></span>
+                        </span>
+                    </div>
+
+                    <form class="mt-6 grid gap-4 lg:grid-cols-2" @submit.prevent="connectAd()">
+                        <div>
+                            <label class="text-sm font-semibold text-slate-700">Server-URL</label>
+                            <input type="text" x-model="adSettings.server_url" placeholder="ldap://ad.firma.local"
+                                   class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500" required>
+                        </div>
+                        <div>
+                            <label class="text-sm font-semibold text-slate-700">Base DN</label>
+                            <input type="text" x-model="adSettings.base_dn" placeholder="DC=firma,DC=local"
+                                   class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500" required>
+                        </div>
+                        <div>
+                            <label class="text-sm font-semibold text-slate-700">Bind DN (optional)</label>
+                            <input type="text" x-model="adSettings.bind_dn" placeholder="CN=ldap-bind,OU=Service,DC=firma,DC=local"
+                                   class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
+                        </div>
+                        <div>
+                            <label class="text-sm font-semibold text-slate-700">Bind Passwort (optional)</label>
+                            <input type="password" x-model="adSettings.bind_password" placeholder="Nur bei Änderung neu eingeben"
+                                   class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
+                            <p class="mt-1 text-xs text-slate-400" x-show="adSettings.has_bind_password && !adSettings.bind_password">
+                                Gespeichertes Passwort bleibt erhalten.
+                            </p>
+                        </div>
+                        <div>
+                            <label class="text-sm font-semibold text-slate-700">Benutzer-Attribut</label>
+                            <input type="text" x-model="adSettings.user_attribute" placeholder="sAMAccountName"
+                                   class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
+                        </div>
+                        <div>
+                            <label class="text-sm font-semibold text-slate-700">Domain (optional)</label>
+                            <input type="text" x-model="adSettings.domain" placeholder="firma.local"
+                                   class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
+                        </div>
+                        <div class="flex items-center gap-3">
+                            <input id="ad-ssl" type="checkbox" x-model="adSettings.use_ssl"
+                                   class="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500">
+                            <label for="ad-ssl" class="text-sm text-slate-600">SSL/TLS verwenden</label>
+                        </div>
+                        <div class="flex flex-wrap items-center gap-3 justify-end lg:justify-start">
+                            <button type="submit" class="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">
+                                Verbinden &amp; speichern
+                            </button>
+                            <button type="button" @click="disconnectAd()" class="rounded-2xl border border-rose-200 px-4 py-2 text-sm font-semibold text-rose-600 hover:bg-rose-50">
+                                Trennen
+                            </button>
+                        </div>
+                    </form>
+                    <p class="mt-3 text-xs text-rose-500" x-text="adError" x-show="adError"></p>
+                    <p class="mt-3 text-xs text-emerald-600" x-text="adMessage" x-show="adMessage"></p>
+                </div>
+            </section>
             </main>
         </div>
     </div>
@@ -220,9 +288,23 @@
                 resetPassword: '',
                 errorMessage: '',
                 successMessage: '',
+                adSettings: {
+                    enabled: false,
+                    server_url: '',
+                    base_dn: '',
+                    bind_dn: '',
+                    bind_password: '',
+                    user_attribute: 'sAMAccountName',
+                    domain: '',
+                    use_ssl: false,
+                    has_bind_password: false
+                },
+                adMessage: '',
+                adError: '',
 
                 async init() {
                     await this.loadUsers();
+                    await this.loadAdSettings();
                     feather.replace();
                 },
 
@@ -283,6 +365,50 @@
                         const error = await response.json();
                         alert(error.error || 'Fehler beim Löschen');
                     }
+                },
+
+                async loadAdSettings() {
+                    const response = await fetch('/api/ad/settings');
+                    if (response.ok) {
+                        const data = await response.json();
+                        this.adSettings = { ...this.adSettings, ...data, bind_password: '' };
+                    }
+                    this.$nextTick(() => feather.replace());
+                },
+
+                async connectAd() {
+                    this.adMessage = '';
+                    this.adError = '';
+                    const payload = { ...this.adSettings };
+                    const response = await fetch('/api/ad/connect', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(payload)
+                    });
+                    if (response.ok) {
+                        const data = await response.json();
+                        this.adSettings = { ...this.adSettings, ...data, bind_password: '' };
+                        this.adMessage = 'Active Directory verbunden.';
+                    } else {
+                        const error = await response.json();
+                        this.adError = error.error || 'Verbindung fehlgeschlagen.';
+                    }
+                    this.$nextTick(() => feather.replace());
+                },
+
+                async disconnectAd() {
+                    this.adMessage = '';
+                    this.adError = '';
+                    const response = await fetch('/api/ad/disconnect', { method: 'POST' });
+                    if (response.ok) {
+                        const data = await response.json();
+                        this.adSettings = { ...this.adSettings, ...data, bind_password: '' };
+                        this.adMessage = 'Active Directory getrennt.';
+                    } else {
+                        const error = await response.json();
+                        this.adError = error.error || 'Trennen fehlgeschlagen.';
+                    }
+                    this.$nextTick(() => feather.replace());
                 }
             }));
         });


### PR DESCRIPTION
### Motivation
- Enable optional Active Directory authentication so admins can connect/disconnect an AD and allow AD users to sign in without managing their passwords locally.
- Provide UI controls for connecting/disconnecting AD and storing connection settings in the app database for easy administration.

### Description
- Added an `ad_settings` table and helper functions `get_ad_settings`, `serialize_ad_settings` and `authenticate_ad_user` to manage and use AD configuration stored in SQLite.
- Integrated `ldap3` and implemented AD login fallback in the `/login` route which will auto-provision a local placeholder account for AD users on first successful AD authentication.
- Added API endpoints `GET /api/ad/settings`, `POST /api/ad/connect` and `POST /api/ad/disconnect` to manage AD configuration and validate bind credentials.
- Extended the user administration UI (`templates/users.html`) with an Active Directory panel, AlpineJS bindings and client methods to load, connect and disconnect AD settings, and added `ldap3` to `requirements.txt`.

### Testing
- Installed dependencies with `pip install -r requirements.txt`, which successfully installed `ldap3` and related packages. (succeeded)
- Launched the application with `python app.py` and verified the temporary admin login flow; the server started and served pages. (succeeded)
- Ran an automated Playwright smoke script that logged in as the temporary `admin`, navigated to `/users`, and captured a screenshot showing the new AD settings panel; requests including `GET /api/ad/settings` returned HTTP 200. (succeeded)
- No unit tests were added as part of this change; only smoke/integration checks described above were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973aafdef20832dba9a75a1b693786d)