### PR TITLE
Quick‑Connect für Active Directory hinzufügen

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ import qrcode
 import qrcode.image.svg
 from io import BytesIO, StringIO
 import base64
-from ldap3 import Server, Connection
+from ldap3 import Server, Connection, BASE, ALL
 from ldap3.utils.conv import escape_filter_chars
 
 
@@ -345,6 +345,35 @@ def serialize_ad_settings(settings):
         "use_ssl": bool(settings["use_ssl"]),
         "has_bind_password": bool(settings["bind_password"])
     }
+
+def domain_to_base_dn(domain):
+    parts = [part for part in (domain or "").split('.') if part]
+    if not parts:
+        return ""
+    return ",".join(f"DC={part}" for part in parts)
+
+def discover_base_dn(server, connection, domain):
+    base_dn = ""
+    try:
+        naming_contexts = (
+            server.info.other.get("defaultNamingContext")
+            or server.info.other.get("defaultNamingContexts")
+            or []
+        )
+        if naming_contexts:
+            base_dn = naming_contexts[0]
+    except Exception:
+        base_dn = ""
+    if not base_dn:
+        try:
+            connection.search("", "(objectClass=*)", search_scope=BASE, attributes=["defaultNamingContext"])
+            if connection.entries:
+                base_dn = connection.entries[0].defaultNamingContext.value
+        except Exception:
+            base_dn = ""
+    if not base_dn:
+        base_dn = domain_to_base_dn(domain)
+    return base_dn
 
 def authenticate_ad_user(username, password, settings):
     if not settings or not settings["enabled"]:
@@ -885,6 +914,57 @@ def reset_user_password(user_id):
 @login_required
 def ad_settings():
     db = get_db()
+    settings = get_ad_settings(db)
+    return jsonify(serialize_ad_settings(settings))
+
+@app.route('/api/ad/quick-connect', methods=['POST'])
+@login_required
+def quick_connect_ad():
+    db = get_db()
+    data = request.get_json() or {}
+    server_url = (data.get('server_url') or '').strip()
+    domain = (data.get('domain') or '').strip()
+    username = (data.get('username') or '').strip()
+    password = data.get('password') or ''
+    use_ssl = bool(data.get('use_ssl'))
+
+    if not server_url:
+        return jsonify({"error": "Server-URL ist erforderlich"}), 400
+    if not username or not password:
+        return jsonify({"error": "AD-Benutzername und Passwort sind erforderlich"}), 400
+
+    user_principal = f"{username}@{domain}" if domain else username
+    server = Server(server_url, use_ssl=use_ssl, get_info=ALL)
+    try:
+        user_conn = Connection(server, user=user_principal, password=password, auto_bind=True)
+    except Exception:
+        return jsonify({"error": "Anmeldung am Active Directory fehlgeschlagen"}), 400
+
+    base_dn = discover_base_dn(server, user_conn, domain)
+    user_conn.unbind()
+    if not base_dn:
+        return jsonify({"error": "Base DN konnte nicht ermittelt werden. Bitte im Expertenmodus eintragen."}), 400
+
+    db.execute('''
+        UPDATE ad_settings
+        SET enabled = 1,
+            server_url = ?,
+            base_dn = ?,
+            bind_dn = '',
+            bind_password = '',
+            user_attribute = 'sAMAccountName',
+            domain = ?,
+            use_ssl = ?,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = 1
+    ''', (
+        server_url,
+        base_dn,
+        domain,
+        1 if use_ssl else 0
+    ))
+    log_activity(db, "update", "ad_settings", details={"enabled": True, "server_url": server_url, "mode": "quick"})
+    db.commit()
     settings = get_ad_settings(db)
     return jsonify(serialize_ad_settings(settings))
 

--- a/templates/users.html
+++ b/templates/users.html
@@ -202,7 +202,49 @@
                         </span>
                     </div>
 
-                    <form class="mt-6 grid gap-4 lg:grid-cols-2" @submit.prevent="connectAd()">
+                    <form class="mt-6 grid gap-4 lg:grid-cols-3" @submit.prevent="quickConnectAd()">
+                        <div class="lg:col-span-3">
+                            <p class="text-sm font-semibold text-slate-700">Schnell verbinden (empfohlen)</p>
+                            <p class="text-xs text-slate-500">Melde dich einmalig mit einem AD-Benutzer an. Base DN wird automatisch erkannt.</p>
+                        </div>
+                        <div>
+                            <label class="text-sm font-semibold text-slate-700">Server-URL</label>
+                            <input type="text" x-model="adQuick.server_url" placeholder="ldap://ad.firma.local"
+                                   class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500" required>
+                        </div>
+                        <div>
+                            <label class="text-sm font-semibold text-slate-700">Domain (optional)</label>
+                            <input type="text" x-model="adQuick.domain" placeholder="firma.local"
+                                   class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500">
+                        </div>
+                        <div>
+                            <label class="text-sm font-semibold text-slate-700">AD-Benutzername</label>
+                            <input type="text" x-model="adQuick.username" placeholder="Supporter"
+                                   class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500" required>
+                        </div>
+                        <div>
+                            <label class="text-sm font-semibold text-slate-700">AD-Passwort</label>
+                            <input type="password" x-model="adQuick.password" placeholder="Passwort"
+                                   class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500" required>
+                        </div>
+                        <div class="flex items-center gap-3 lg:col-span-2">
+                            <input id="ad-quick-ssl" type="checkbox" x-model="adQuick.use_ssl"
+                                   class="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500">
+                            <label for="ad-quick-ssl" class="text-sm text-slate-600">SSL/TLS verwenden</label>
+                        </div>
+                        <div class="flex flex-wrap items-center gap-3 justify-end lg:justify-start">
+                            <button type="submit" class="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500">
+                                Schnell verbinden
+                            </button>
+                        </div>
+                    </form>
+
+                    <div class="mt-6 border-t border-slate-200 pt-6">
+                        <p class="text-sm font-semibold text-slate-700">Expertenmodus</p>
+                        <p class="text-xs text-slate-500">Nutze diese Felder nur, wenn die automatische Erkennung nicht klappt.</p>
+                    </div>
+
+                    <form class="mt-4 grid gap-4 lg:grid-cols-2" @submit.prevent="connectAd()">
                         <div>
                             <label class="text-sm font-semibold text-slate-700">Server-URL</label>
                             <input type="text" x-model="adSettings.server_url" placeholder="ldap://ad.firma.local"
@@ -299,6 +341,13 @@
                     use_ssl: false,
                     has_bind_password: false
                 },
+                adQuick: {
+                    server_url: '',
+                    domain: '',
+                    username: '',
+                    password: '',
+                    use_ssl: false
+                },
                 adMessage: '',
                 adError: '',
 
@@ -372,6 +421,9 @@
                     if (response.ok) {
                         const data = await response.json();
                         this.adSettings = { ...this.adSettings, ...data, bind_password: '' };
+                        this.adQuick.server_url = data.server_url || this.adQuick.server_url;
+                        this.adQuick.domain = data.domain || this.adQuick.domain;
+                        this.adQuick.use_ssl = !!data.use_ssl;
                     }
                     this.$nextTick(() => feather.replace());
                 },
@@ -388,6 +440,27 @@
                     if (response.ok) {
                         const data = await response.json();
                         this.adSettings = { ...this.adSettings, ...data, bind_password: '' };
+                        this.adMessage = 'Active Directory verbunden.';
+                    } else {
+                        const error = await response.json();
+                        this.adError = error.error || 'Verbindung fehlgeschlagen.';
+                    }
+                    this.$nextTick(() => feather.replace());
+                },
+
+                async quickConnectAd() {
+                    this.adMessage = '';
+                    this.adError = '';
+                    const payload = { ...this.adQuick };
+                    const response = await fetch('/api/ad/quick-connect', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(payload)
+                    });
+                    if (response.ok) {
+                        const data = await response.json();
+                        this.adSettings = { ...this.adSettings, ...data, bind_password: '' };
+                        this.adQuick.password = '';
                         this.adMessage = 'Active Directory verbunden.';
                     } else {
                         const error = await response.json();


### PR DESCRIPTION
### Motivation
- Die AD‑Verbindung ist für Anwender zu kompliziert; es soll eine einfache, „one‑click“ Möglichkeit geben, sich kurz mit einem AD‑User zu authentifizieren und das System automatisch zu verbinden.

### Description
- Neue Schnellverbindungs‑Endpoint `POST /api/ad/quick-connect` hinzugefügt, der mit Benutzeranmeldeinformationen am AD bindet, die Base DN automatisch ermittelt und die `ad_settings` speichert.  
- Implementiert `discover_base_dn` und `domain_to_base_dn` zur automatischen Erkennung der Base DN und ergänzt `ldap3`-Import mit `BASE` und `ALL`.  
- UI: In `templates/users.html` eine „Schnell verbinden (empfohlen)“ Sektion samt Feldern `server_url`, `domain`, `username`, `password`, `use_ssl` ergänzt und clientseitige Logik `quickConnectAd()` implementiert; der vorhandene Expertenmodus bleibt erhalten.  
- Änderungen sind in `app.py` (AD‑Discovery + neuer Endpoint) und `templates/users.html` (Form + Alpine.js state & Aktionen) enthalten.

### Testing
- `pip install -r requirements.txt` ausgeführt und Abhängigkeit `ldap3` installiert, Ergebnis: erfolgreich.  
- Entwicklungsserver mit `python app.py` gestartet, Ergebnis: Server lief und lieferte HTTP‑Requests (siehe HTTP 200/302 Logs).  
- Automatisiertes UI‑Skript mit Playwright ausgeführt, das Login, Navigation zu `/users` und einen Screenshot erstellte; Playwright‑Durchlauf war nach Installation von `ldap3` erfolgreich und lieferte das Artefakt `artifacts/ad-quick-connect.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b3ba3b28832d9f5f9be049749960)