### PR TITLE
Fix missing AD principal builder in login flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -375,6 +375,34 @@ def discover_base_dn(server, connection, domain):
         base_dn = domain_to_base_dn(domain)
     return base_dn
 
+def build_ad_principals(username, domain):
+    principals = []
+    if not username:
+        return principals
+    username = username.strip()
+    if not username:
+        return principals
+
+    principals.append(username)
+
+    if "\\" in username:
+        if domain:
+            account_name = username.split("\\", 1)[1]
+            principals.append(f"{account_name}@{domain}")
+        return list(dict.fromkeys(principals))
+
+    if "@" in username:
+        if domain:
+            account_name = username.split("@", 1)[0]
+            principals.append(f"{domain}\\{account_name}")
+        return list(dict.fromkeys(principals))
+
+    if domain:
+        principals.append(f"{username}@{domain}")
+        principals.append(f"{domain}\\{username}")
+
+    return list(dict.fromkeys(principals))
+
 def authenticate_ad_user(username, password, settings):
     if not settings or not settings["enabled"]:
         return False


### PR DESCRIPTION
### Motivation
- Fix a `NameError` that occurred during AD authentication by adding the missing helper that generates AD principal variants so the login flow can try common account formats when `authenticate_ad_user` attempts bindings.

### Description
- Add a new helper function `build_ad_principals` in `app.py` which produces a deduplicated list of candidate principals from the supplied username and configured domain, handling `domain\user`, `user@domain`, and plain usernames.
- The new helper is placed just before `authenticate_ad_user` and is used by the existing fallback loop that attempts binds with different user principal formats.
- No other authentication logic was changed and the function returns an empty list for empty input to avoid raising exceptions.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b8271044832da644b52ecc1a46de)