### PR TITLE
Add dark/light theme toggle and consistent dark-mode styles

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -295,3 +295,122 @@ footer {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 }
+
+/* Dark mode overrides */
+.dark body,
+.dark .app-body {
+  background-color: #0b1120;
+  color: #e2e8f0;
+}
+
+.dark .bg-white {
+  background-color: #111827;
+}
+
+.dark .bg-white\/70 {
+  background-color: rgba(17, 24, 39, 0.7);
+}
+
+.dark .bg-white\/80 {
+  background-color: rgba(17, 24, 39, 0.8);
+}
+
+.dark .bg-white\/90 {
+  background-color: rgba(17, 24, 39, 0.9);
+}
+
+.dark .bg-slate-50 {
+  background-color: #0f172a;
+}
+
+.dark .bg-slate-100 {
+  background-color: #111827;
+}
+
+.dark .bg-slate-200 {
+  background-color: #1f2937;
+}
+
+.dark .bg-slate-950\/5 {
+  background-color: #0b1120;
+}
+
+.dark .bg-indigo-50 {
+  background-color: rgba(99, 102, 241, 0.15);
+}
+
+.dark .bg-indigo-100 {
+  background-color: rgba(99, 102, 241, 0.25);
+}
+
+.dark .bg-rose-50 {
+  background-color: rgba(225, 29, 72, 0.15);
+}
+
+.dark .bg-emerald-50 {
+  background-color: rgba(16, 185, 129, 0.15);
+}
+
+.dark .glass-card {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.75));
+}
+
+.dark .text-slate-900 {
+  color: #f8fafc;
+}
+
+.dark .text-slate-800 {
+  color: #e2e8f0;
+}
+
+.dark .text-slate-700 {
+  color: #cbd5e1;
+}
+
+.dark .text-slate-600 {
+  color: #cbd5e1;
+}
+
+.dark .text-slate-500 {
+  color: #94a3b8;
+}
+
+.dark .text-slate-400 {
+  color: #94a3b8;
+}
+
+.dark .text-indigo-700 {
+  color: #c7d2fe;
+}
+
+.dark .text-indigo-600 {
+  color: #a5b4fc;
+}
+
+.dark .text-rose-600 {
+  color: #fb7185;
+}
+
+.dark .text-emerald-700 {
+  color: #6ee7b7;
+}
+
+.dark .border-slate-200 {
+  border-color: #1f2937;
+}
+
+.dark .border-slate-100 {
+  border-color: #1f2937;
+}
+
+.dark .border-indigo-100 {
+  border-color: rgba(99, 102, 241, 0.4);
+}
+
+.dark .border-rose-100 {
+  border-color: rgba(225, 29, 72, 0.35);
+}
+
+.dark .border-emerald-100 {
+  border-color: rgba(16, 185, 129, 0.35);
+}

--- a/static/theme.js
+++ b/static/theme.js
@@ -1,43 +1,45 @@
-const themeStorageKey = 'inventorypro.theme';
-const themeToggleButtons = document.querySelectorAll('[data-theme-toggle]');
-const themeLabelSelector = '[data-theme-label]';
+(() => {
+  const root = document.documentElement;
+  const stored = localStorage.getItem('theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const initial = stored || (prefersDark ? 'dark' : 'light');
 
-const getSystemTheme = () => {
-  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-    return 'dark';
-  }
-  return 'light';
-};
-
-const applyTheme = (theme, persist = true) => {
-  document.body.dataset.theme = theme;
-  if (persist) {
-    localStorage.setItem(themeStorageKey, theme);
+  if (initial === 'dark') {
+    root.classList.add('dark');
   }
 
-  themeToggleButtons.forEach((button) => {
-    button.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
-    const label = button.querySelector(themeLabelSelector);
-    if (label) {
-      label.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+  const updateButtons = () => {
+    const isDark = root.classList.contains('dark');
+    document.querySelectorAll('[data-theme-toggle]').forEach((button) => {
+      button.setAttribute('aria-pressed', String(isDark));
+      const label = button.querySelector('[data-theme-label]');
+      const icon = button.querySelector('[data-theme-icon]');
+      if (label) {
+        label.textContent = isDark ? 'Light Mode' : 'Dark Mode';
+      }
+      if (icon) {
+        icon.textContent = isDark ? '☀️' : '🌙';
+      }
+    });
+  };
+
+  const setTheme = (mode) => {
+    if (mode === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
     }
-  });
-};
+    localStorage.setItem('theme', mode);
+    updateButtons();
+  };
 
-const storedTheme = localStorage.getItem(themeStorageKey);
-applyTheme(storedTheme || getSystemTheme(), false);
+  window.InventoryTheme = {
+    toggle() {
+      const next = root.classList.contains('dark') ? 'light' : 'dark';
+      setTheme(next);
+    },
+    set: setTheme,
+  };
 
-if (!storedTheme && window.matchMedia) {
-  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-  mediaQuery.addEventListener('change', (event) => {
-    applyTheme(event.matches ? 'dark' : 'light', false);
-  });
-}
-
-themeToggleButtons.forEach((button) => {
-  button.addEventListener('click', () => {
-    const currentTheme = document.body.dataset.theme === 'dark' ? 'dark' : 'light';
-    const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
-    applyTheme(nextTheme);
-  });
-});
+  document.addEventListener('DOMContentLoaded', updateButtons);
+})();

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Inventory Pro</title>
+    <script src="/static/theme.js"></script>
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"/>
     <link rel="stylesheet" href="/static/style.css">
@@ -268,6 +272,10 @@
                     <button @click="openAddDeviceModal()" class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-blue-200 hover:from-blue-500 hover:to-indigo-500">
                         <i data-feather="plus" class="w-4 h-4"></i>
                         <span>Neues Gerät</span>
+                    </button>
+                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+                        <span data-theme-icon aria-hidden="true">🌙</span>
+                        <span data-theme-label>Dark Mode</span>
                     </button>
                     <button onclick="logout()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
                         <i data-feather="log-out" class="w-4 h-4"></i>

--- a/templates/locations.html
+++ b/templates/locations.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Inventory Pro - Standorte</title>
+    <script src="/static/theme.js"></script>
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
     <link rel="stylesheet" href="/static/style.css">
@@ -77,6 +81,10 @@
                 </div>
                 <div class="flex items-center space-x-4">
                     <span class="text-sm text-slate-500">Angemeldet als {{ username }}</span>
+                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+                        <span data-theme-icon aria-hidden="true">🌙</span>
+                        <span data-theme-label>Dark Mode</span>
+                    </button>
                     <button onclick="logout()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
                         <i data-feather="log-out" class="w-4 h-4"></i>
                         Abmelden

--- a/templates/login.html
+++ b/templates/login.html
@@ -4,9 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Login | Inventory Pro</title>
+    <script src="/static/theme.js"></script>
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="/static/style.css">
 </head>
 <body class="min-h-screen bg-slate-950/5 text-slate-900 flex items-center justify-center px-6">
+    <div class="absolute right-6 top-6">
+        <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+            <span data-theme-icon aria-hidden="true">🌙</span>
+            <span data-theme-label>Dark Mode</span>
+        </button>
+    </div>
     <div class="w-full max-w-md rounded-3xl bg-white shadow-2xl shadow-slate-200/60 border border-slate-200 p-8">
         <div class="flex items-center gap-3 mb-6">
             <span class="inline-flex items-center justify-center w-12 h-12 rounded-2xl bg-gradient-to-br from-blue-500 via-indigo-500 to-purple-500 text-white shadow-lg">

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -4,9 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Passwort zurücksetzen | Inventory Pro</title>
+    <script src="/static/theme.js"></script>
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="/static/style.css">
 </head>
 <body class="min-h-screen bg-slate-950/5 text-slate-900 flex items-center justify-center px-6">
+    <div class="absolute right-6 top-6">
+        <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+            <span data-theme-icon aria-hidden="true">🌙</span>
+            <span data-theme-label>Dark Mode</span>
+        </button>
+    </div>
     <div class="w-full max-w-md rounded-3xl bg-white shadow-2xl shadow-slate-200/60 border border-slate-200 p-8">
         <div class="mb-6">
             <p class="text-xs uppercase tracking-[0.3em] text-slate-400">Security</p>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Inventory Pro - Statistiken</title>
+    <script src="/static/theme.js"></script>
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="stylesheet" href="/static/style.css">
@@ -94,7 +98,10 @@
 
 			<!-- Rechte Seite: Button-Gruppe -->
 			<div class="flex items-center space-x-4">
-
+			  <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+				<span data-theme-icon aria-hidden="true">🌙</span>
+				<span data-theme-label>Dark Mode</span>
+			  </button>
 			  <!-- Logout Button -->
 			  <button onclick="logout()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
 				<i data-feather="log-out" class="w-4 h-4"></i>

--- a/templates/users.html
+++ b/templates/users.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Inventory Pro - Benutzerverwaltung</title>
+    <script src="/static/theme.js"></script>
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
     <link rel="stylesheet" href="/static/style.css">
@@ -78,6 +82,10 @@
                 </div>
                 <div class="flex items-center space-x-4">
                     <span class="text-sm text-slate-500">Angemeldet als {{ username }}</span>
+                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+                        <span data-theme-icon aria-hidden="true">🌙</span>
+                        <span data-theme-label>Dark Mode</span>
+                    </button>
                     <button onclick="logout()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
                         <i data-feather="log-out" class="w-4 h-4"></i>
                         Abmelden

--- a/templates/verify_otp.html
+++ b/templates/verify_otp.html
@@ -4,9 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OTP Verifizierung | Inventory Pro</title>
+    <script src="/static/theme.js"></script>
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="/static/style.css">
 </head>
 <body class="min-h-screen bg-slate-950/5 text-slate-900 flex items-center justify-center px-6">
+    <div class="absolute right-6 top-6">
+        <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+            <span data-theme-icon aria-hidden="true">🌙</span>
+            <span data-theme-label>Dark Mode</span>
+        </button>
+    </div>
     <div class="w-full max-w-md rounded-3xl bg-white shadow-2xl shadow-slate-200/60 border border-slate-200 p-8">
         <div class="mb-6">
             <p class="text-xs uppercase tracking-[0.3em] text-slate-400">Security</p>


### PR DESCRIPTION
### Motivation
- Provide a user-controllable light/dark theme both on the login pages and inside the authenticated UI so the app is always shown in a single consistent mode. 
- Persist the chosen mode across pages and sessions while respecting the system preference as a sensible default.

### Description
- Add a small client-side theme controller at `static/theme.js` that reads/writes the theme to `localStorage`, applies the `dark` class to `document.documentElement`, and exposes `InventoryTheme.toggle()` and `InventoryTheme.set()` for UI toggles. 
- Enable Tailwind `darkMode: 'class'` in pages by injecting a small `tailwind.config` snippet and include the shared `static/style.css` where needed. 
- Extend `static/style.css` with `.dark` overrides for background, text, border and card tokens so components render consistently in dark mode (including `glass-card`, `bg-*`, `text-*` and `border-*` variants). 
- Add accessible theme toggle buttons (`data-theme-toggle`, `data-theme-icon`, `data-theme-label`) to the login and auth layouts (`templates/login.html`, `templates/reset_password.html`, `templates/verify_otp.html`, `templates/index.html`, `templates/users.html`, `templates/locations.html`, `templates/stats.html`) so users can switch modes before and after login.

### Testing
- Started the development server with `python app.py` and the server booted and served pages successfully (logs show requests to `/login`, `/static/style.css`, `/static/theme.js`).
- Ran a Playwright script which loaded `http://127.0.0.1:5000/login`, set `localStorage.theme='dark'`, reloaded and captured a screenshot (`artifacts/login-dark.png`) to verify the dark UI rendering, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973ba3eeed8832d8c81f59779fbe07f)