### PR TITLE
Adjust dark mode hover colors for buttons

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -414,3 +414,35 @@ footer {
 .dark .border-emerald-100 {
   border-color: rgba(16, 185, 129, 0.35);
 }
+
+.dark .hover\:bg-white:hover {
+  background-color: #1e293b;
+}
+
+.dark .hover\:bg-slate-50:hover {
+  background-color: #1f2937;
+}
+
+.dark .hover\:bg-slate-100:hover {
+  background-color: #273449;
+}
+
+.dark .hover\:bg-slate-200:hover {
+  background-color: #334155;
+}
+
+.dark .hover\:bg-blue-50:hover {
+  background-color: rgba(59, 130, 246, 0.2);
+}
+
+.dark .hover\:bg-indigo-50:hover {
+  background-color: rgba(99, 102, 241, 0.2);
+}
+
+.dark .hover\:bg-rose-50:hover {
+  background-color: rgba(244, 63, 94, 0.2);
+}
+
+.dark .hover\:bg-emerald-50:hover {
+  background-color: rgba(16, 185, 129, 0.2);
+}


### PR DESCRIPTION
### Motivation
- Dark-mode hover states and some button hover backgrounds were too bright and caused poor contrast on dark backgrounds.

### Description
- Added dark-mode overrides in `static/style.css` for common Tailwind-style hover utilities to provide darker, lower-contrast hover backgrounds (e.g. `.dark .hover\:bg-white:hover`, `.dark .hover\:bg-slate-50:hover`, `.dark .hover\:bg-slate-100:hover`, `.dark .hover\:bg-slate-200:hover`).
- Tuned accent hover backgrounds for blue/indigo/rose/emerald to use subtler RGBA values in dark mode.
- Changes are localized to `static/style.css` (inserted new rules around the dark-mode section).

### Testing
- Installed Python dependencies with `pip install -r requirements.txt` to run the dev server and the test script, which completed successfully. 
- Launched the development server with `python app.py` and ran a Playwright script that toggled dark mode and captured `artifacts/dark-mode-hover.png`, and the screenshot run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973bce553c4832d807655a0aa8261ae)