### PR TITLE
Tone down dark-mode sidebar button backgrounds

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -311,6 +311,10 @@ footer {
   background-color: rgba(17, 24, 39, 0.7);
 }
 
+.dark .bg-white\/50 {
+  background-color: rgba(17, 24, 39, 0.5);
+}
+
 .dark .bg-white\/80 {
   background-color: rgba(17, 24, 39, 0.8);
 }
@@ -349,6 +353,10 @@ footer {
 
 .dark .bg-emerald-50 {
   background-color: rgba(16, 185, 129, 0.15);
+}
+
+.dark .bg-emerald-50\/70 {
+  background-color: rgba(5, 46, 22, 0.6);
 }
 
 .dark .glass-card {
@@ -413,4 +421,36 @@ footer {
 
 .dark .border-emerald-100 {
   border-color: rgba(16, 185, 129, 0.35);
+}
+
+.dark .hover\:bg-white:hover {
+  background-color: #1e293b;
+}
+
+.dark .hover\:bg-slate-50:hover {
+  background-color: #1f2937;
+}
+
+.dark .hover\:bg-slate-100:hover {
+  background-color: #273449;
+}
+
+.dark .hover\:bg-slate-200:hover {
+  background-color: #334155;
+}
+
+.dark .hover\:bg-blue-50:hover {
+  background-color: rgba(59, 130, 246, 0.2);
+}
+
+.dark .hover\:bg-indigo-50:hover {
+  background-color: rgba(99, 102, 241, 0.2);
+}
+
+.dark .hover\:bg-rose-50:hover {
+  background-color: rgba(244, 63, 94, 0.2);
+}
+
+.dark .hover\:bg-emerald-50:hover {
+  background-color: rgba(16, 185, 129, 0.2);
 }


### PR DESCRIPTION
### Motivation
- Sidebar actions like the “2FA Einrichten” and “Passwort setzen” buttons were still too bright in dark mode and produced poor contrast on dark backgrounds.

### Description
- Added dark-mode override for `bg-white/50` to reduce the visual brightness of translucent white backgrounds in dark mode in `static/style.css`.
- Added a darker variant for `bg-emerald-50/70` to ensure the emerald 2FA action doesn’t look too luminous in dark mode.
- Added dark-mode hover overrides for common Tailwind-style utilities (`hover:bg-white`, `hover:bg-slate-50`, `hover:bg-slate-100`, `hover:bg-slate-200`, `hover:bg-blue-50`, `hover:bg-indigo-50`, `hover:bg-rose-50`, `hover:bg-emerald-50`) to provide lower-contrast hover backgrounds in dark mode.
- All changes are localized to `static/style.css`.

### Testing
- Launched the dev server with `python app.py` and confirmed the app served; the server started successfully.
- Ran a Playwright script that logs in, toggles dark mode, hovers the sidebar buttons and captured `artifacts/dark-mode-sidebar-buttons.png`, and the screenshot run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973bce553c4832d807655a0aa8261ae)