### PR TITLE
Add helpdesk ticket system with notifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,8 @@ from io import BytesIO, StringIO
 import base64
 from ldap3 import Server, Connection, BASE, ALL
 from ldap3.utils.conv import escape_filter_chars
+from email.message import EmailMessage
+import smtplib
 
 
 app = Flask(__name__)
@@ -170,6 +172,93 @@ def init_db():
         ''')
 
         c.execute('''
+            CREATE TABLE IF NOT EXISTS ticket_categories (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT,
+                color TEXT DEFAULT '#2563eb',
+                sla_hours INTEGER DEFAULT 72,
+                is_default INTEGER DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS tickets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                description TEXT NOT NULL,
+                category_id INTEGER,
+                priority TEXT DEFAULT 'normal',
+                status TEXT DEFAULT 'open',
+                requester_name TEXT,
+                requester_email TEXT,
+                created_by TEXT,
+                assignee TEXT,
+                assignee_email TEXT,
+                due_date TEXT,
+                tags TEXT,
+                custom_fields TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (category_id) REFERENCES ticket_categories(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS ticket_comments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ticket_id INTEGER NOT NULL,
+                author TEXT,
+                body TEXT NOT NULL,
+                is_internal INTEGER DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (ticket_id) REFERENCES tickets(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS ticket_watchers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ticket_id INTEGER NOT NULL,
+                email TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (ticket_id) REFERENCES tickets(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS ticket_alerts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                status_match TEXT,
+                priority_match TEXT,
+                category_id INTEGER,
+                recipient_emails TEXT NOT NULL,
+                is_enabled INTEGER DEFAULT 1,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (category_id) REFERENCES ticket_categories(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS notification_settings (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                enabled INTEGER DEFAULT 0,
+                smtp_host TEXT,
+                smtp_port INTEGER DEFAULT 587,
+                smtp_username TEXT,
+                smtp_password TEXT,
+                smtp_from TEXT,
+                use_tls INTEGER DEFAULT 1,
+                default_recipients TEXT,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+        c.execute('INSERT OR IGNORE INTO notification_settings (id) VALUES (1)')
+
+        c.execute('''
             CREATE TABLE IF NOT EXISTS ad_settings (
                 id INTEGER PRIMARY KEY CHECK (id = 1),
                 enabled INTEGER DEFAULT 0,
@@ -249,6 +338,17 @@ def init_db():
             VALUES (?, ?)
         ''', default_locations)
 
+        default_ticket_categories = [
+            ("Allgemein", "Allgemeine Anfragen und Rückfragen", "#2563eb", 72, 1),
+            ("Incident", "Störungen und dringende Ausfälle", "#dc2626", 24, 0),
+            ("Service Request", "Bestellungen und Service-Anfragen", "#0f766e", 120, 0),
+            ("Change", "Geplante Änderungen und Wartungen", "#7c3aed", 168, 0)
+        ]
+        c.executemany('''
+            INSERT OR IGNORE INTO ticket_categories (name, description, color, sla_hours, is_default)
+            VALUES (?, ?, ?, ?, ?)
+        ''', default_ticket_categories)
+
         try:
             c.execute('ALTER TABLE devices ADD COLUMN location_id INTEGER')
         except sqlite3.OperationalError:
@@ -314,6 +414,163 @@ def pro_required(f):
     def wrapped(*args, **kwargs):
         return f(*args, **kwargs)
     return wrapped
+
+def parse_email_list(value):
+    if not value:
+        return []
+    if isinstance(value, list):
+        emails = value
+    else:
+        emails = value.split(',')
+    return [email.strip() for email in emails if email and email.strip()]
+
+def get_notification_settings(db):
+    settings = db.execute('SELECT * FROM notification_settings WHERE id = 1').fetchone()
+    if not settings:
+        db.execute('INSERT INTO notification_settings (id) VALUES (1)')
+        db.commit()
+        settings = db.execute('SELECT * FROM notification_settings WHERE id = 1').fetchone()
+    return settings
+
+def serialize_notification_settings(settings):
+    if not settings:
+        return {
+            "enabled": False,
+            "smtp_host": "",
+            "smtp_port": 587,
+            "smtp_username": "",
+            "smtp_from": "",
+            "use_tls": True,
+            "default_recipients": "",
+            "has_password": False
+        }
+    return {
+        "enabled": bool(settings["enabled"]),
+        "smtp_host": settings["smtp_host"] or "",
+        "smtp_port": settings["smtp_port"] or 587,
+        "smtp_username": settings["smtp_username"] or "",
+        "smtp_from": settings["smtp_from"] or "",
+        "use_tls": bool(settings["use_tls"]),
+        "default_recipients": settings["default_recipients"] or "",
+        "has_password": bool(settings["smtp_password"])
+    }
+
+def send_notification_email(settings, recipients, subject, body):
+    if not settings or not settings["enabled"]:
+        return False
+    recipients = parse_email_list(recipients)
+    if not recipients:
+        return False
+    smtp_host = settings["smtp_host"]
+    smtp_port = settings["smtp_port"] or 587
+    smtp_from = settings["smtp_from"] or settings["smtp_username"]
+    if not smtp_host or not smtp_from:
+        return False
+
+    message = EmailMessage()
+    message["Subject"] = subject
+    message["From"] = smtp_from
+    message["To"] = ", ".join(recipients)
+    message.set_content(body)
+
+    try:
+        with smtplib.SMTP(smtp_host, smtp_port, timeout=10) as server:
+            if settings["use_tls"]:
+                server.starttls()
+            if settings["smtp_username"] and settings["smtp_password"]:
+                server.login(settings["smtp_username"], settings["smtp_password"])
+            server.send_message(message)
+        return True
+    except Exception:
+        return False
+
+def format_ticket_subject(ticket, prefix):
+    return f"{prefix} #{ticket['id']} - {ticket['title']}"
+
+def build_ticket_email_body(ticket, header, comment=None):
+    lines = [
+        header,
+        "",
+        f"Ticket: #{ticket['id']} - {ticket['title']}",
+        f"Status: {ticket.get('status')}",
+        f"Priorität: {ticket.get('priority')}",
+        f"Kategorie: {ticket.get('category_name') or 'Unbekannt'}",
+        f"Zuständig: {ticket.get('assignee') or '-'}",
+        f"Fällig: {ticket.get('due_date') or '-'}",
+        "",
+        "Beschreibung:",
+        ticket.get('description') or "-"
+    ]
+    if comment:
+        lines.extend(["", "Neuer Kommentar:", comment])
+    return "\n".join(lines)
+
+def trigger_ticket_notifications(db, event_type, ticket, comment=None):
+    settings = get_notification_settings(db)
+    if not settings or not settings["enabled"]:
+        return
+
+    recipients = []
+    recipients.extend(parse_email_list(settings["default_recipients"]))
+    recipients.extend(parse_email_list(ticket.get("requester_email")))
+    recipients.extend(parse_email_list(ticket.get("assignee_email")))
+
+    watcher_rows = db.execute('SELECT email FROM ticket_watchers WHERE ticket_id = ?', (ticket["id"],)).fetchall()
+    recipients.extend([row["email"] for row in watcher_rows])
+
+    alerts = db.execute('''
+        SELECT * FROM ticket_alerts
+        WHERE is_enabled = 1 AND event_type = ?
+    ''', (event_type,)).fetchall()
+
+    for alert in alerts:
+        if alert["status_match"] and alert["status_match"] != ticket.get("status"):
+            continue
+        if alert["priority_match"] and alert["priority_match"] != ticket.get("priority"):
+            continue
+        if alert["category_id"] and alert["category_id"] != ticket.get("category_id"):
+            continue
+        recipients.extend(parse_email_list(alert["recipient_emails"]))
+
+    unique_recipients = list(dict.fromkeys([email for email in recipients if email]))
+    if not unique_recipients:
+        return
+
+    subject = format_ticket_subject(ticket, "Ticket Update")
+    header = f"Es gibt ein Update zum Ticket {ticket['id']}."
+    if event_type == "created":
+        header = f"Ein neues Ticket wurde erstellt."
+        subject = format_ticket_subject(ticket, "Neues Ticket")
+    elif event_type == "commented":
+        header = "Es gibt einen neuen Kommentar."
+        subject = format_ticket_subject(ticket, "Kommentar erhalten")
+    elif event_type == "status_changed":
+        header = f"Der Status wurde auf '{ticket.get('status')}' geändert."
+        subject = format_ticket_subject(ticket, "Status geändert")
+
+    body = build_ticket_email_body(ticket, header, comment=comment)
+    send_notification_email(settings, unique_recipients, subject, body)
+
+def fetch_ticket(db, ticket_id):
+    ticket = db.execute('''
+        SELECT t.*, c.name as category_name, c.color as category_color
+        FROM tickets t
+        LEFT JOIN ticket_categories c ON t.category_id = c.id
+        WHERE t.id = ?
+    ''', (ticket_id,)).fetchone()
+    return dict(ticket) if ticket else None
+
+def normalize_ticket_row(row):
+    ticket = dict(row)
+    try:
+        ticket['tags'] = json.loads(ticket.get('tags') or '[]')
+    except json.JSONDecodeError:
+        ticket['tags'] = []
+    try:
+        ticket['custom_fields'] = json.loads(ticket.get('custom_fields') or '[]')
+    except json.JSONDecodeError:
+        ticket['custom_fields'] = []
+    return ticket
 
 def get_ad_settings(db):
     settings = db.execute('SELECT * FROM ad_settings WHERE id = 1').fetchone()
@@ -523,6 +780,11 @@ def users_page():
 @login_required
 def locations_page():
     return render_template('locations.html', username=session.get('username'))
+
+@app.route('/tickets')
+@login_required
+def tickets_page():
+    return render_template('tickets.html', username=session.get('username'))
 
 @app.route('/api/categories/<int:category_id>', methods=['PUT', 'DELETE'])
 @login_required
@@ -844,6 +1106,396 @@ def update_location(location_id):
     log_activity(db, "delete", "location", location_id)
     db.commit()
     return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/ticket-categories', methods=['GET', 'POST'])
+@login_required
+def ticket_categories():
+    db = get_db()
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        name = (data.get('name') or '').strip()
+        description = (data.get('description') or '').strip()
+        color = (data.get('color') or '#2563eb').strip()
+        sla_hours = int(data.get('sla_hours') or 72)
+        is_default = 1 if data.get('is_default') else 0
+        if not name:
+            return jsonify({"error": "Name ist erforderlich"}), 400
+        try:
+            db.execute('''
+                INSERT INTO ticket_categories (name, description, color, sla_hours, is_default)
+                VALUES (?, ?, ?, ?, ?)
+            ''', (name, description, color, sla_hours, is_default))
+            log_activity(db, "create", "ticket_category", details={"name": name})
+            db.commit()
+            return jsonify({"status": "created"}), 201
+        except sqlite3.IntegrityError:
+            return jsonify({"error": "Kategorie existiert bereits"}), 400
+
+    categories = db.execute('SELECT * FROM ticket_categories ORDER BY name').fetchall()
+    return jsonify([dict(row) for row in categories])
+
+@app.route('/api/ticket-categories/<int:category_id>', methods=['PUT', 'DELETE'])
+@login_required
+def ticket_category_detail(category_id):
+    db = get_db()
+    if request.method == 'PUT':
+        data = request.get_json() or {}
+        name = (data.get('name') or '').strip()
+        description = (data.get('description') or '').strip()
+        color = (data.get('color') or '#2563eb').strip()
+        sla_hours = int(data.get('sla_hours') or 72)
+        is_default = 1 if data.get('is_default') else 0
+        if not name:
+            return jsonify({"error": "Name ist erforderlich"}), 400
+        result = db.execute('''
+            UPDATE ticket_categories
+            SET name = ?, description = ?, color = ?, sla_hours = ?, is_default = ?
+            WHERE id = ?
+        ''', (name, description, color, sla_hours, is_default, category_id))
+        if result.rowcount == 0:
+            return jsonify({"error": "Kategorie nicht gefunden"}), 404
+        log_activity(db, "update", "ticket_category", category_id, {"name": name})
+        db.commit()
+        return jsonify({"status": "updated"}), 200
+
+    result = db.execute('DELETE FROM ticket_categories WHERE id = ?', (category_id,))
+    if result.rowcount == 0:
+        return jsonify({"error": "Kategorie nicht gefunden"}), 404
+    log_activity(db, "delete", "ticket_category", category_id)
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/tickets', methods=['GET', 'POST'])
+@login_required
+def tickets():
+    db = get_db()
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        title = (data.get('title') or '').strip()
+        description = (data.get('description') or '').strip()
+        category_id = data.get('category_id')
+        priority = (data.get('priority') or 'normal').strip()
+        status = (data.get('status') or 'open').strip()
+        requester_name = (data.get('requester_name') or session.get('username') or '').strip()
+        requester_email = (data.get('requester_email') or '').strip()
+        assignee = (data.get('assignee') or '').strip()
+        assignee_email = (data.get('assignee_email') or '').strip()
+        due_date = (data.get('due_date') or '').strip()
+        tags = json.dumps(data.get('tags') or [])
+        custom_fields = json.dumps(data.get('custom_fields') or [])
+        if not title or not description:
+            return jsonify({"error": "Titel und Beschreibung sind erforderlich"}), 400
+        cursor = db.execute('''
+            INSERT INTO tickets (
+                title, description, category_id, priority, status, requester_name,
+                requester_email, created_by, assignee, assignee_email, due_date, tags, custom_fields
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ''', (
+            title, description, category_id, priority, status, requester_name, requester_email,
+            session.get('username'), assignee, assignee_email, due_date, tags, custom_fields
+        ))
+        ticket_id = cursor.lastrowid
+        log_activity(db, "create", "ticket", ticket_id, {"title": title})
+        db.commit()
+        ticket = fetch_ticket(db, ticket_id)
+        if ticket:
+            ticket = normalize_ticket_row(ticket)
+            trigger_ticket_notifications(db, "created", ticket)
+        return jsonify({"status": "created", "id": ticket_id}), 201
+
+    filters = []
+    params = []
+    status = request.args.get('status')
+    priority = request.args.get('priority')
+    category_id = request.args.get('category_id')
+    assignee = request.args.get('assignee')
+    mine = request.args.get('mine')
+    search = (request.args.get('search') or '').strip()
+
+    if status:
+        filters.append('t.status = ?')
+        params.append(status)
+    if priority:
+        filters.append('t.priority = ?')
+        params.append(priority)
+    if category_id:
+        filters.append('t.category_id = ?')
+        params.append(category_id)
+    if assignee:
+        filters.append('t.assignee = ?')
+        params.append(assignee)
+    if mine:
+        filters.append('t.created_by = ?')
+        params.append(session.get('username'))
+    if search:
+        filters.append('(t.title LIKE ? OR t.description LIKE ? OR t.requester_name LIKE ?)')
+        params.extend([f'%{search}%', f'%{search}%', f'%{search}%'])
+
+    query = '''
+        SELECT t.*, c.name as category_name, c.color as category_color
+        FROM tickets t
+        LEFT JOIN ticket_categories c ON t.category_id = c.id
+    '''
+    if filters:
+        query += ' WHERE ' + ' AND '.join(filters)
+    query += ' ORDER BY t.updated_at DESC, t.created_at DESC'
+
+    rows = db.execute(query, params).fetchall()
+    tickets = [normalize_ticket_row(row) for row in rows]
+    return jsonify(tickets)
+
+@app.route('/api/tickets/<int:ticket_id>', methods=['GET', 'PUT', 'DELETE'])
+@login_required
+def ticket_detail(ticket_id):
+    db = get_db()
+    ticket = fetch_ticket(db, ticket_id)
+    if not ticket:
+        return jsonify({"error": "Ticket nicht gefunden"}), 404
+
+    if request.method == 'GET':
+        ticket = normalize_ticket_row(ticket)
+        comments = db.execute('''
+            SELECT id, author, body, is_internal, created_at
+            FROM ticket_comments
+            WHERE ticket_id = ?
+            ORDER BY created_at ASC
+        ''', (ticket_id,)).fetchall()
+        watchers = db.execute('''
+            SELECT id, email
+            FROM ticket_watchers
+            WHERE ticket_id = ?
+            ORDER BY created_at DESC
+        ''', (ticket_id,)).fetchall()
+        ticket['comments'] = [dict(row) for row in comments]
+        ticket['watchers'] = [dict(row) for row in watchers]
+        return jsonify(ticket)
+
+    if request.method == 'PUT':
+        data = request.get_json() or {}
+        title = (data.get('title') or ticket['title']).strip()
+        description = (data.get('description') or ticket['description']).strip()
+        category_id = data.get('category_id')
+        priority = (data.get('priority') or ticket['priority']).strip()
+        status = (data.get('status') or ticket['status']).strip()
+        requester_name = (data.get('requester_name') or ticket.get('requester_name') or '').strip()
+        requester_email = (data.get('requester_email') or ticket.get('requester_email') or '').strip()
+        assignee = (data.get('assignee') or ticket.get('assignee') or '').strip()
+        assignee_email = (data.get('assignee_email') or ticket.get('assignee_email') or '').strip()
+        due_date = (data.get('due_date') or ticket.get('due_date') or '').strip()
+        tags = json.dumps(data.get('tags') or json.loads(ticket.get('tags') or '[]'))
+        custom_fields = json.dumps(data.get('custom_fields') or json.loads(ticket.get('custom_fields') or '[]'))
+        status_changed = status != ticket.get('status')
+
+        db.execute('''
+            UPDATE tickets
+            SET title = ?, description = ?, category_id = ?, priority = ?, status = ?,
+                requester_name = ?, requester_email = ?, assignee = ?, assignee_email = ?,
+                due_date = ?, tags = ?, custom_fields = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+        ''', (
+            title, description, category_id, priority, status, requester_name, requester_email,
+            assignee, assignee_email, due_date, tags, custom_fields, ticket_id
+        ))
+        log_activity(db, "update", "ticket", ticket_id, {"title": title})
+        db.commit()
+        updated_ticket = fetch_ticket(db, ticket_id)
+        if updated_ticket:
+            normalized = normalize_ticket_row(updated_ticket)
+            trigger_ticket_notifications(db, "updated", normalized)
+            if status_changed:
+                trigger_ticket_notifications(db, "status_changed", normalized)
+        return jsonify({"status": "updated"}), 200
+
+    db.execute('DELETE FROM ticket_comments WHERE ticket_id = ?', (ticket_id,))
+    db.execute('DELETE FROM ticket_watchers WHERE ticket_id = ?', (ticket_id,))
+    db.execute('DELETE FROM tickets WHERE id = ?', (ticket_id,))
+    log_activity(db, "delete", "ticket", ticket_id)
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/tickets/<int:ticket_id>/comments', methods=['GET', 'POST'])
+@login_required
+def ticket_comments(ticket_id):
+    db = get_db()
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        body = (data.get('body') or '').strip()
+        is_internal = 1 if data.get('is_internal') else 0
+        if not body:
+            return jsonify({"error": "Kommentar darf nicht leer sein"}), 400
+        db.execute('''
+            INSERT INTO ticket_comments (ticket_id, author, body, is_internal)
+            VALUES (?, ?, ?, ?)
+        ''', (ticket_id, session.get('username'), body, is_internal))
+        db.execute('UPDATE tickets SET updated_at = CURRENT_TIMESTAMP WHERE id = ?', (ticket_id,))
+        log_activity(db, "comment", "ticket", ticket_id)
+        db.commit()
+        ticket = fetch_ticket(db, ticket_id)
+        if ticket:
+            ticket = normalize_ticket_row(ticket)
+            trigger_ticket_notifications(db, "commented", ticket, comment=body)
+        return jsonify({"status": "created"}), 201
+
+    comments = db.execute('''
+        SELECT id, author, body, is_internal, created_at
+        FROM ticket_comments
+        WHERE ticket_id = ?
+        ORDER BY created_at ASC
+    ''', (ticket_id,)).fetchall()
+    return jsonify([dict(row) for row in comments])
+
+@app.route('/api/tickets/<int:ticket_id>/watchers', methods=['GET', 'POST'])
+@login_required
+def ticket_watchers(ticket_id):
+    db = get_db()
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        email = (data.get('email') or '').strip()
+        if not email:
+            return jsonify({"error": "E-Mail ist erforderlich"}), 400
+        db.execute('''
+            INSERT INTO ticket_watchers (ticket_id, email)
+            VALUES (?, ?)
+        ''', (ticket_id, email))
+        log_activity(db, "watch", "ticket", ticket_id, {"email": email})
+        db.commit()
+        return jsonify({"status": "created"}), 201
+
+    watchers = db.execute('''
+        SELECT id, email, created_at
+        FROM ticket_watchers
+        WHERE ticket_id = ?
+        ORDER BY created_at DESC
+    ''', (ticket_id,)).fetchall()
+    return jsonify([dict(row) for row in watchers])
+
+@app.route('/api/tickets/<int:ticket_id>/watchers/<int:watcher_id>', methods=['DELETE'])
+@login_required
+def delete_ticket_watcher(ticket_id, watcher_id):
+    db = get_db()
+    result = db.execute('''
+        DELETE FROM ticket_watchers
+        WHERE id = ? AND ticket_id = ?
+    ''', (watcher_id, ticket_id))
+    if result.rowcount == 0:
+        return jsonify({"error": "Watcher nicht gefunden"}), 404
+    log_activity(db, "unwatch", "ticket", ticket_id, {"watcher_id": watcher_id})
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/ticket-alerts', methods=['GET', 'POST'])
+@login_required
+def ticket_alerts():
+    db = get_db()
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        name = (data.get('name') or '').strip()
+        event_type = (data.get('event_type') or '').strip()
+        status_match = (data.get('status_match') or '').strip() or None
+        priority_match = (data.get('priority_match') or '').strip() or None
+        category_id = data.get('category_id') or None
+        recipient_emails = (data.get('recipient_emails') or '').strip()
+        is_enabled = 1 if data.get('is_enabled', True) else 0
+        if not name or not event_type or not recipient_emails:
+            return jsonify({"error": "Name, Event und Empfänger sind erforderlich"}), 400
+        db.execute('''
+            INSERT INTO ticket_alerts (name, event_type, status_match, priority_match, category_id, recipient_emails, is_enabled)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        ''', (name, event_type, status_match, priority_match, category_id, recipient_emails, is_enabled))
+        log_activity(db, "create", "ticket_alert", details={"name": name})
+        db.commit()
+        return jsonify({"status": "created"}), 201
+
+    alerts = db.execute('SELECT * FROM ticket_alerts ORDER BY created_at DESC').fetchall()
+    return jsonify([dict(row) for row in alerts])
+
+@app.route('/api/ticket-alerts/<int:alert_id>', methods=['PUT', 'DELETE'])
+@login_required
+def ticket_alert_detail(alert_id):
+    db = get_db()
+    if request.method == 'PUT':
+        data = request.get_json() or {}
+        name = (data.get('name') or '').strip()
+        event_type = (data.get('event_type') or '').strip()
+        status_match = (data.get('status_match') or '').strip() or None
+        priority_match = (data.get('priority_match') or '').strip() or None
+        category_id = data.get('category_id') or None
+        recipient_emails = (data.get('recipient_emails') or '').strip()
+        is_enabled = 1 if data.get('is_enabled', True) else 0
+        if not name or not event_type or not recipient_emails:
+            return jsonify({"error": "Name, Event und Empfänger sind erforderlich"}), 400
+        result = db.execute('''
+            UPDATE ticket_alerts
+            SET name = ?, event_type = ?, status_match = ?, priority_match = ?, category_id = ?, recipient_emails = ?, is_enabled = ?
+            WHERE id = ?
+        ''', (name, event_type, status_match, priority_match, category_id, recipient_emails, is_enabled, alert_id))
+        if result.rowcount == 0:
+            return jsonify({"error": "Alert nicht gefunden"}), 404
+        log_activity(db, "update", "ticket_alert", alert_id, {"name": name})
+        db.commit()
+        return jsonify({"status": "updated"}), 200
+
+    result = db.execute('DELETE FROM ticket_alerts WHERE id = ?', (alert_id,))
+    if result.rowcount == 0:
+        return jsonify({"error": "Alert nicht gefunden"}), 404
+    log_activity(db, "delete", "ticket_alert", alert_id)
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/notifications/settings', methods=['GET', 'POST'])
+@login_required
+def notification_settings():
+    db = get_db()
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        enabled = 1 if data.get('enabled') else 0
+        smtp_host = (data.get('smtp_host') or '').strip()
+        smtp_port = int(data.get('smtp_port') or 587)
+        smtp_username = (data.get('smtp_username') or '').strip()
+        smtp_password = data.get('smtp_password') or ''
+        smtp_from = (data.get('smtp_from') or '').strip()
+        use_tls = 1 if data.get('use_tls', True) else 0
+        default_recipients = (data.get('default_recipients') or '').strip()
+
+        existing = get_notification_settings(db)
+        if existing and not smtp_password:
+            smtp_password = existing["smtp_password"] or ''
+
+        db.execute('''
+            UPDATE notification_settings
+            SET enabled = ?, smtp_host = ?, smtp_port = ?, smtp_username = ?, smtp_password = ?,
+                smtp_from = ?, use_tls = ?, default_recipients = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE id = 1
+        ''', (
+            enabled, smtp_host, smtp_port, smtp_username, smtp_password, smtp_from,
+            use_tls, default_recipients
+        ))
+        log_activity(db, "update", "notification_settings", details={"enabled": bool(enabled)})
+        db.commit()
+        settings = get_notification_settings(db)
+        return jsonify(serialize_notification_settings(settings))
+
+    settings = get_notification_settings(db)
+    return jsonify(serialize_notification_settings(settings))
+
+@app.route('/api/notifications/test', methods=['POST'])
+@login_required
+def notification_test():
+    db = get_db()
+    data = request.get_json() or {}
+    recipients = data.get('recipients')
+    settings = get_notification_settings(db)
+    if not settings or not settings["enabled"]:
+        return jsonify({"error": "Benachrichtigungen sind deaktiviert"}), 400
+    if not recipients:
+        return jsonify({"error": "Empfänger fehlt"}), 400
+    subject = "Inventory Pro Ticket-System Test"
+    body = "Dies ist eine Test-E-Mail aus dem Inventory Pro Helpdesk."
+    success = send_notification_email(settings, recipients, subject, body)
+    if not success:
+        return jsonify({"error": "E-Mail konnte nicht versendet werden"}), 400
+    return jsonify({"status": "sent"}), 200
 
 @app.route('/api/features', methods=['GET'])
 @login_required

--- a/static/tickets.js
+++ b/static/tickets.js
@@ -1,0 +1,348 @@
+document.addEventListener('alpine:init', () => {
+    Alpine.data('ticketsApp', () => ({
+        tickets: [],
+        categories: [],
+        alerts: [],
+        selectedTicket: null,
+        filters: {
+            status: '',
+            priority: '',
+            category_id: '',
+            mine: false,
+            search: ''
+        },
+        statusOptions: ['open', 'in_progress', 'pending', 'resolved', 'closed'],
+        statusLabels: {
+            open: 'Offen',
+            in_progress: 'In Bearbeitung',
+            pending: 'Wartet',
+            resolved: 'Gelöst',
+            closed: 'Geschlossen'
+        },
+        priorityOptions: ['low', 'normal', 'high', 'urgent'],
+        stats: {
+            open: 0,
+            in_progress: 0,
+            pending: 0,
+            resolved: 0
+        },
+        ticketModalOpen: false,
+        ticketError: '',
+        newTicket: {
+            title: '',
+            description: '',
+            category_id: '',
+            priority: 'normal',
+            requester_name: '',
+            requester_email: '',
+            assignee: '',
+            assignee_email: '',
+            due_date: '',
+            tags: '',
+            custom_fields: []
+        },
+        newComment: '',
+        internalComment: false,
+        newWatcher: '',
+        activeAdminTab: 'categories',
+        newCategory: {
+            name: '',
+            description: '',
+            color: '#2563eb',
+            sla_hours: 72,
+            is_default: false
+        },
+        newAlert: {
+            name: '',
+            event_type: 'created',
+            status_match: '',
+            priority_match: '',
+            category_id: '',
+            recipient_emails: '',
+            is_enabled: true
+        },
+        notificationSettings: {
+            enabled: false,
+            smtp_host: '',
+            smtp_port: 587,
+            smtp_username: '',
+            smtp_password: '',
+            smtp_from: '',
+            use_tls: true,
+            default_recipients: ''
+        },
+        notificationMessage: '',
+        testRecipients: '',
+
+        async init() {
+            await this.loadCategories();
+            await this.loadTickets();
+            await this.loadAlerts();
+            await this.loadNotificationSettings();
+            await this.loadStats();
+            this.$nextTick(() => feather.replace());
+        },
+
+        openNewTicket() {
+            this.ticketError = '';
+            this.ticketModalOpen = true;
+        },
+
+        addCustomField() {
+            this.newTicket.custom_fields.push({ key: '', value: '' });
+        },
+
+        removeCustomField(index) {
+            this.newTicket.custom_fields.splice(index, 1);
+        },
+
+        async loadCategories() {
+            const response = await fetch('/api/ticket-categories');
+            if (response.ok) {
+                this.categories = await response.json();
+            }
+        },
+
+        async loadTickets() {
+            const params = new URLSearchParams();
+            if (this.filters.status) params.append('status', this.filters.status);
+            if (this.filters.priority) params.append('priority', this.filters.priority);
+            if (this.filters.category_id) params.append('category_id', this.filters.category_id);
+            if (this.filters.mine) params.append('mine', '1');
+            if (this.filters.search) params.append('search', this.filters.search);
+
+            const response = await fetch(`/api/tickets?${params.toString()}`);
+            if (response.ok) {
+                this.tickets = await response.json();
+            }
+            this.$nextTick(() => feather.replace());
+        },
+
+        async loadStats() {
+            const response = await fetch('/api/tickets');
+            if (!response.ok) return;
+            const allTickets = await response.json();
+            const counts = { open: 0, in_progress: 0, pending: 0, resolved: 0 };
+            allTickets.forEach((ticket) => {
+                if (counts[ticket.status] !== undefined) {
+                    counts[ticket.status] += 1;
+                }
+            });
+            this.stats = counts;
+        },
+
+        async selectTicket(ticket) {
+            const response = await fetch(`/api/tickets/${ticket.id}`);
+            if (response.ok) {
+                this.selectedTicket = await response.json();
+                this.newComment = '';
+                this.internalComment = false;
+                this.newWatcher = '';
+                this.$nextTick(() => feather.replace());
+            }
+        },
+
+        closeTicket() {
+            this.selectedTicket = null;
+        },
+
+        async updateTicket() {
+            if (!this.selectedTicket) return;
+            const payload = {
+                title: this.selectedTicket.title,
+                description: this.selectedTicket.description,
+                category_id: this.selectedTicket.category_id,
+                priority: this.selectedTicket.priority,
+                status: this.selectedTicket.status,
+                requester_name: this.selectedTicket.requester_name,
+                requester_email: this.selectedTicket.requester_email,
+                assignee: this.selectedTicket.assignee,
+                assignee_email: this.selectedTicket.assignee_email,
+                due_date: this.selectedTicket.due_date,
+                tags: this.selectedTicket.tags,
+                custom_fields: this.selectedTicket.custom_fields
+            };
+            const response = await fetch(`/api/tickets/${this.selectedTicket.id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            if (response.ok) {
+                await this.loadTickets();
+                await this.loadStats();
+            }
+        },
+
+        async createTicket() {
+            this.ticketError = '';
+            const tags = this.newTicket.tags
+                ? this.newTicket.tags.split(',').map((tag) => tag.trim()).filter(Boolean)
+                : [];
+            const customFields = (this.newTicket.custom_fields || []).filter((field) => field.key || field.value);
+
+            const payload = {
+                title: this.newTicket.title,
+                description: this.newTicket.description,
+                category_id: this.newTicket.category_id || null,
+                priority: this.newTicket.priority,
+                requester_name: this.newTicket.requester_name,
+                requester_email: this.newTicket.requester_email,
+                assignee: this.newTicket.assignee,
+                assignee_email: this.newTicket.assignee_email,
+                due_date: this.newTicket.due_date,
+                tags,
+                custom_fields: customFields
+            };
+
+            const response = await fetch('/api/tickets', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+
+            if (response.ok) {
+                this.ticketModalOpen = false;
+                this.newTicket = {
+                    title: '',
+                    description: '',
+                    category_id: '',
+                    priority: 'normal',
+                    requester_name: '',
+                    requester_email: '',
+                    assignee: '',
+                    assignee_email: '',
+                    due_date: '',
+                    tags: '',
+                    custom_fields: []
+                };
+                await this.loadTickets();
+                await this.loadStats();
+            } else {
+                const error = await response.json();
+                this.ticketError = error.error || 'Ticket konnte nicht erstellt werden.';
+            }
+        },
+
+        async addComment() {
+            if (!this.newComment || !this.selectedTicket) return;
+            const response = await fetch(`/api/tickets/${this.selectedTicket.id}/comments`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ body: this.newComment, is_internal: this.internalComment })
+            });
+            if (response.ok) {
+                await this.selectTicket(this.selectedTicket);
+                await this.loadTickets();
+            }
+        },
+
+        async addWatcher() {
+            if (!this.newWatcher || !this.selectedTicket) return;
+            const response = await fetch(`/api/tickets/${this.selectedTicket.id}/watchers`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email: this.newWatcher })
+            });
+            if (response.ok) {
+                await this.selectTicket(this.selectedTicket);
+                this.newWatcher = '';
+            }
+        },
+
+        async removeWatcher(watcherId) {
+            if (!this.selectedTicket) return;
+            const response = await fetch(`/api/tickets/${this.selectedTicket.id}/watchers/${watcherId}`, {
+                method: 'DELETE'
+            });
+            if (response.ok) {
+                await this.selectTicket(this.selectedTicket);
+            }
+        },
+
+        async loadAlerts() {
+            const response = await fetch('/api/ticket-alerts');
+            if (response.ok) {
+                this.alerts = await response.json();
+            }
+        },
+
+        async createCategory() {
+            const payload = { ...this.newCategory };
+            const response = await fetch('/api/ticket-categories', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            if (response.ok) {
+                this.newCategory = { name: '', description: '', color: '#2563eb', sla_hours: 72, is_default: false };
+                await this.loadCategories();
+            }
+        },
+
+        async createAlert() {
+            const payload = { ...this.newAlert };
+            const response = await fetch('/api/ticket-alerts', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            if (response.ok) {
+                this.newAlert = {
+                    name: '',
+                    event_type: 'created',
+                    status_match: '',
+                    priority_match: '',
+                    category_id: '',
+                    recipient_emails: '',
+                    is_enabled: true
+                };
+                await this.loadAlerts();
+            }
+        },
+
+        async deleteAlert(alertId) {
+            const response = await fetch(`/api/ticket-alerts/${alertId}`, {
+                method: 'DELETE'
+            });
+            if (response.ok) {
+                await this.loadAlerts();
+            }
+        },
+
+        async loadNotificationSettings() {
+            const response = await fetch('/api/notifications/settings');
+            if (response.ok) {
+                this.notificationSettings = await response.json();
+            }
+        },
+
+        async saveNotificationSettings() {
+            const response = await fetch('/api/notifications/settings', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(this.notificationSettings)
+            });
+            if (response.ok) {
+                this.notificationSettings = await response.json();
+                this.notificationMessage = 'Einstellungen gespeichert.';
+            } else {
+                this.notificationMessage = 'Einstellungen konnten nicht gespeichert werden.';
+            }
+        },
+
+        async sendTestEmail() {
+            this.notificationMessage = '';
+            const response = await fetch('/api/notifications/test', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ recipients: this.testRecipients })
+            });
+            if (response.ok) {
+                this.notificationMessage = 'Test-E-Mail wurde versendet.';
+            } else {
+                const error = await response.json();
+                this.notificationMessage = error.error || 'Test-E-Mail fehlgeschlagen.';
+            }
+        }
+    }));
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -181,6 +181,15 @@
                 </div>
 
                 <div class="space-y-3 sidebar-primary-links">
+                    <a href="/tickets" class="flex items-center justify-between px-4 py-3 text-sm font-semibold text-slate-700 hover:text-slate-900 w-full rounded-2xl hover:bg-white transition-colors border border-slate-200 bg-white/70 shadow-sm">
+                        <span class="flex items-center">
+                            <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-amber-50 text-amber-600 mr-3">
+                                <i data-feather="life-buoy" class="w-4 h-4"></i>
+                            </span>
+                            <span class="sidebar-text">Tickets</span>
+                        </span>
+                        <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                    </a>
                     <a href="/stats" class="flex items-center justify-between px-4 py-3 text-sm font-semibold text-slate-700 hover:text-slate-900 w-full rounded-2xl hover:bg-white transition-colors border border-slate-200 bg-white/70 shadow-sm">
                         <span class="flex items-center">
                             <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-indigo-50 text-indigo-600 mr-3">

--- a/templates/locations.html
+++ b/templates/locations.html
@@ -38,6 +38,15 @@
                     </span>
                     <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
                 </a>
+                <a href="/tickets" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-amber-50 text-amber-600 mr-3">
+                            <i data-feather="life-buoy" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Tickets</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
                 <a href="/stats" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
                     <span class="flex items-center">
                         <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -53,6 +53,15 @@
                     </span>
                     <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
                 </a>
+                <a href="/tickets" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-amber-50 text-amber-600 mr-3">
+                            <i data-feather="life-buoy" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Tickets</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
 				<a href="/stats" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-indigo-100 bg-indigo-50 text-sm font-semibold text-indigo-700">
                     <span class="flex items-center">
                         <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-indigo-100 text-indigo-600 mr-3">

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -1,0 +1,475 @@
+<!DOCTYPE html>
+<html lang="de" x-data="ticketsApp()">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Inventory Pro - Helpdesk</title>
+    <script src="/static/theme.js"></script>
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body class="app-body bg-slate-950/5 text-slate-900">
+    <div class="app-shell">
+        <aside class="app-sidebar sidebar bg-white/90 backdrop-blur-xl border-r border-slate-200 shadow-sm">
+            <div class="sidebar-header p-6 border-b border-slate-200">
+                <a href="/">
+                    <div class="logo flex items-center space-x-3">
+                        <span class="inline-flex items-center justify-center w-10 h-10 rounded-2xl bg-gradient-to-br from-blue-500 via-indigo-500 to-purple-500 text-white shadow-lg">
+                            <i data-feather="cpu" class="w-5 h-5"></i>
+                        </span>
+                        <div>
+                            <p class="text-lg font-semibold text-slate-900 sidebar-text">Inventory Pro</p>
+                            <p class="text-xs text-slate-500 sidebar-text">Smart Asset Hub</p>
+                        </div>
+                    </div>
+                </a>
+            </div>
+            <nav class="p-4 space-y-3 sidebar-scroll sidebar-primary-links">
+                <a href="/" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+                            <i data-feather="layers" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Kategorien</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
+                <a href="/tickets" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-amber-100 bg-amber-50 text-sm font-semibold text-amber-700">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-amber-100 text-amber-600 mr-3">
+                            <i data-feather="life-buoy" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Tickets</span>
+                    </span>
+                    <i data-feather="clipboard" class="w-4 h-4 text-amber-400"></i>
+                </a>
+                <a href="/stats" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+                            <i data-feather="bar-chart-2" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Statistiken</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
+                <a href="/users" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+                            <i data-feather="users" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Benutzer</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
+                <a href="/locations" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+                            <i data-feather="map-pin" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Standorte</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
+            </nav>
+        </aside>
+
+        <div class="app-main app-main--fixed">
+            <header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 z-30 h-[82px]">
+                <div class="flex items-center gap-4">
+                    <button type="button" data-sidebar-toggle aria-label="Navigation umschalten" class="inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white p-2 text-slate-600 shadow-sm hover:bg-slate-50">
+                        <i data-feather="menu" class="w-4 h-4"></i>
+                    </button>
+                    <div>
+                        <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Helpdesk</p>
+                        <h1 class="text-2xl font-semibold text-slate-900">Ticket-System</h1>
+                    </div>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <span class="text-sm text-slate-500">Angemeldet als {{ username }}</span>
+                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+                        <span data-theme-icon aria-hidden="true">🌙</span>
+                        <span data-theme-label>Dark Mode</span>
+                    </button>
+                    <button @click="openNewTicket" class="inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-700 shadow-sm hover:bg-amber-100">
+                        <i data-feather="plus-circle" class="w-4 h-4"></i>
+                        Ticket erstellen
+                    </button>
+                </div>
+            </header>
+
+            <main class="flex-1 overflow-auto p-8 pt-24 space-y-8 scrollbar-hide">
+                <section class="rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-amber-900 px-8 py-8 text-white shadow-2xl shadow-slate-300/50">
+                    <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                        <div>
+                            <p class="text-xs uppercase tracking-[0.3em] text-amber-200">Support</p>
+                            <h2 class="mt-2 text-3xl font-semibold">Professioneller Helpdesk mit SLA, Alerts und Benachrichtigungen.</h2>
+                        </div>
+                        <div class="grid grid-cols-2 gap-3 text-sm">
+                            <div class="rounded-2xl bg-white/10 px-4 py-3">
+                                <p class="text-xs uppercase text-amber-100">Offen</p>
+                                <p class="text-2xl font-semibold" x-text="stats.open"></p>
+                            </div>
+                            <div class="rounded-2xl bg-white/10 px-4 py-3">
+                                <p class="text-xs uppercase text-amber-100">In Bearbeitung</p>
+                                <p class="text-2xl font-semibold" x-text="stats.in_progress"></p>
+                            </div>
+                            <div class="rounded-2xl bg-white/10 px-4 py-3">
+                                <p class="text-xs uppercase text-amber-100">Wartet</p>
+                                <p class="text-2xl font-semibold" x-text="stats.pending"></p>
+                            </div>
+                            <div class="rounded-2xl bg-white/10 px-4 py-3">
+                                <p class="text-xs uppercase text-amber-100">Gelöst</p>
+                                <p class="text-2xl font-semibold" x-text="stats.resolved"></p>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+                    <div class="space-y-6">
+                        <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm">
+                            <div class="flex flex-wrap items-center gap-4">
+                                <div class="flex-1 min-w-[200px]">
+                                    <label class="text-xs uppercase text-slate-400">Suche</label>
+                                    <input type="text" x-model="filters.search" @input.debounce.300ms="loadTickets" placeholder="Ticket, Kunde, Beschreibung" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm shadow-sm">
+                                </div>
+                                <div class="min-w-[160px]">
+                                    <label class="text-xs uppercase text-slate-400">Status</label>
+                                    <select x-model="filters.status" @change="loadTickets" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                        <option value="">Alle</option>
+                                        <template x-for="status in statusOptions" :key="status">
+                                            <option :value="status" x-text="statusLabels[status] || status"></option>
+                                        </template>
+                                    </select>
+                                </div>
+                                <div class="min-w-[160px]">
+                                    <label class="text-xs uppercase text-slate-400">Priorität</label>
+                                    <select x-model="filters.priority" @change="loadTickets" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                        <option value="">Alle</option>
+                                        <template x-for="priority in priorityOptions" :key="priority">
+                                            <option :value="priority" x-text="priority"></option>
+                                        </template>
+                                    </select>
+                                </div>
+                                <div class="min-w-[180px]">
+                                    <label class="text-xs uppercase text-slate-400">Kategorie</label>
+                                    <select x-model="filters.category_id" @change="loadTickets" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                        <option value="">Alle</option>
+                                        <template x-for="category in categories" :key="category.id">
+                                            <option :value="category.id" x-text="category.name"></option>
+                                        </template>
+                                    </select>
+                                </div>
+                                <label class="inline-flex items-center gap-2 text-sm text-slate-600">
+                                    <input type="checkbox" x-model="filters.mine" @change="loadTickets" class="rounded border-slate-300 text-amber-600">
+                                    Meine Tickets
+                                </label>
+                            </div>
+                        </div>
+
+                        <div class="space-y-4">
+                            <template x-for="ticket in tickets" :key="ticket.id">
+                                <button @click="selectTicket(ticket)" class="w-full text-left rounded-3xl border border-slate-200 bg-white p-5 shadow-sm hover:border-amber-200 hover:shadow-md transition">
+                                    <div class="flex flex-wrap items-start justify-between gap-3">
+                                        <div>
+                                            <p class="text-xs uppercase text-slate-400">Ticket #<span x-text="ticket.id"></span></p>
+                                            <h3 class="text-lg font-semibold text-slate-900" x-text="ticket.title"></h3>
+                                            <p class="mt-1 text-sm text-slate-500 line-clamp-2" x-text="ticket.description"></p>
+                                        </div>
+                                        <div class="flex flex-col items-end gap-2">
+                                            <span class="rounded-full px-3 py-1 text-xs font-semibold" :style="`background-color: ${ticket.category_color || '#e2e8f0'}; color: white;`" x-text="ticket.category_name || 'Unbekannt'"></span>
+                                            <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600" x-text="statusLabels[ticket.status] || ticket.status"></span>
+                                            <span class="rounded-full bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700" x-text="ticket.priority"></span>
+                                        </div>
+                                    </div>
+                                    <div class="mt-4 flex flex-wrap items-center gap-4 text-xs text-slate-500">
+                                        <span class="inline-flex items-center gap-1"><i data-feather="user" class="w-3 h-3"></i><span x-text="ticket.requester_name || 'Unbekannt'"></span></span>
+                                        <span class="inline-flex items-center gap-1"><i data-feather="user-check" class="w-3 h-3"></i><span x-text="ticket.assignee || 'Nicht zugewiesen'"></span></span>
+                                        <span class="inline-flex items-center gap-1"><i data-feather="calendar" class="w-3 h-3"></i><span x-text="ticket.due_date || 'Kein SLA'" ></span></span>
+                                    </div>
+                                </button>
+                            </template>
+                            <div x-show="tickets.length === 0" class="rounded-3xl border border-dashed border-slate-300 bg-slate-50 p-10 text-center text-slate-500">
+                                Keine Tickets gefunden. Erstelle das erste Ticket.
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="space-y-6">
+                        <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm" x-show="selectedTicket">
+                            <template x-if="selectedTicket">
+                                <div>
+                                    <div class="flex items-start justify-between gap-4">
+                                        <div>
+                                            <p class="text-xs uppercase text-slate-400">Ausgewähltes Ticket</p>
+                                            <h3 class="text-xl font-semibold text-slate-900" x-text="selectedTicket.title"></h3>
+                                            <p class="text-sm text-slate-500" x-text="selectedTicket.description"></p>
+                                        </div>
+                                        <button @click="closeTicket" class="text-slate-400 hover:text-slate-700">
+                                            <i data-feather="x" class="w-4 h-4"></i>
+                                        </button>
+                                    </div>
+
+                                    <div class="mt-4 grid gap-3 text-sm text-slate-600">
+                                        <div class="flex items-center justify-between">
+                                            <span>Status</span>
+                                            <select x-model="selectedTicket.status" @change="updateTicket" class="rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm">
+                                                <template x-for="status in statusOptions" :key="status">
+                                                    <option :value="status" x-text="statusLabels[status] || status"></option>
+                                                </template>
+                                            </select>
+                                        </div>
+                                        <div class="flex items-center justify-between">
+                                            <span>Priorität</span>
+                                            <select x-model="selectedTicket.priority" @change="updateTicket" class="rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm">
+                                                <template x-for="priority in priorityOptions" :key="priority">
+                                                    <option :value="priority" x-text="priority"></option>
+                                                </template>
+                                            </select>
+                                        </div>
+                                        <div class="flex items-center justify-between">
+                                            <span>Zuständig</span>
+                                            <input type="text" x-model="selectedTicket.assignee" @change="updateTicket" placeholder="Team/Name" class="rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm">
+                                        </div>
+                                        <div class="flex items-center justify-between">
+                                            <span>Assignee E-Mail</span>
+                                            <input type="email" x-model="selectedTicket.assignee_email" @change="updateTicket" placeholder="support@firma.de" class="rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm">
+                                        </div>
+                                        <div class="flex items-center justify-between">
+                                            <span>Fällig</span>
+                                            <input type="date" x-model="selectedTicket.due_date" @change="updateTicket" class="rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm">
+                                        </div>
+                                    </div>
+
+                                    <div class="mt-5">
+                                        <p class="text-xs uppercase text-slate-400">Watcher</p>
+                                        <div class="flex flex-wrap gap-2 mt-2">
+                                            <template x-for="watcher in selectedTicket.watchers" :key="watcher.id">
+                                                <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-600">
+                                                    <span x-text="watcher.email"></span>
+                                                    <button @click.stop="removeWatcher(watcher.id)" class="text-slate-400 hover:text-slate-700">&times;</button>
+                                                </span>
+                                            </template>
+                                        </div>
+                                        <div class="mt-3 flex gap-2">
+                                            <input type="email" x-model="newWatcher" placeholder="watcher@firma.de" class="flex-1 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                            <button @click="addWatcher" class="rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white">Hinzufügen</button>
+                                        </div>
+                                    </div>
+
+                                    <div class="mt-6">
+                                        <p class="text-xs uppercase text-slate-400">Kommentare</p>
+                                        <div class="mt-3 space-y-3 max-h-[240px] overflow-auto pr-2">
+                                            <template x-for="comment in selectedTicket.comments" :key="comment.id">
+                                                <div class="rounded-2xl border border-slate-200 bg-slate-50 p-3">
+                                                    <div class="flex items-center justify-between text-xs text-slate-400">
+                                                        <span x-text="comment.author || 'System'"></span>
+                                                        <span x-text="comment.created_at"></span>
+                                                    </div>
+                                                    <p class="mt-1 text-sm text-slate-700" x-text="comment.body"></p>
+                                                </div>
+                                            </template>
+                                        </div>
+                                        <div class="mt-3 space-y-2">
+                                            <textarea x-model="newComment" rows="3" placeholder="Kommentar hinzufügen" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm"></textarea>
+                                            <label class="inline-flex items-center gap-2 text-xs text-slate-500">
+                                                <input type="checkbox" x-model="internalComment" class="rounded border-slate-300 text-amber-600">
+                                                Interner Kommentar
+                                            </label>
+                                            <button @click="addComment" class="w-full rounded-2xl bg-amber-500 px-4 py-2 text-sm font-semibold text-white">Kommentar senden</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </template>
+                        </div>
+
+                        <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm">
+                            <div class="flex items-center justify-between">
+                                <div>
+                                    <p class="text-xs uppercase text-slate-400">Administration</p>
+                                    <h3 class="text-lg font-semibold text-slate-900">Einstellungen & Automationen</h3>
+                                </div>
+                                <div class="flex gap-2">
+                                    <button @click="activeAdminTab = 'categories'" :class="activeAdminTab === 'categories' ? 'bg-amber-500 text-white' : 'bg-slate-100 text-slate-600'" class="rounded-full px-3 py-1 text-xs font-semibold">Kategorien</button>
+                                    <button @click="activeAdminTab = 'alerts'" :class="activeAdminTab === 'alerts' ? 'bg-amber-500 text-white' : 'bg-slate-100 text-slate-600'" class="rounded-full px-3 py-1 text-xs font-semibold">Alerts</button>
+                                    <button @click="activeAdminTab = 'notifications'" :class="activeAdminTab === 'notifications' ? 'bg-amber-500 text-white' : 'bg-slate-100 text-slate-600'" class="rounded-full px-3 py-1 text-xs font-semibold">E-Mail</button>
+                                </div>
+                            </div>
+
+                            <div class="mt-4" x-show="activeAdminTab === 'categories'">
+                                <div class="space-y-3">
+                                    <template x-for="category in categories" :key="category.id">
+                                        <div class="flex items-center justify-between rounded-2xl border border-slate-200 px-4 py-3">
+                                            <div>
+                                                <p class="font-semibold text-slate-800" x-text="category.name"></p>
+                                                <p class="text-xs text-slate-500" x-text="category.description"></p>
+                                            </div>
+                                            <span class="rounded-full px-3 py-1 text-xs font-semibold" :style="`background-color: ${category.color}; color: white;`" x-text="`${category.sla_hours}h SLA`"></span>
+                                        </div>
+                                    </template>
+                                </div>
+                                <div class="mt-4 grid gap-3">
+                                    <input type="text" x-model="newCategory.name" placeholder="Kategorie" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                    <textarea x-model="newCategory.description" rows="2" placeholder="Beschreibung" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm"></textarea>
+                                    <div class="grid grid-cols-2 gap-3">
+                                        <input type="color" x-model="newCategory.color" class="h-10 w-full rounded-2xl border border-slate-200">
+                                        <input type="number" x-model="newCategory.sla_hours" placeholder="SLA (Std.)" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                    </div>
+                                    <label class="inline-flex items-center gap-2 text-xs text-slate-500">
+                                        <input type="checkbox" x-model="newCategory.is_default" class="rounded border-slate-300 text-amber-600">
+                                        Standard-Kategorie
+                                    </label>
+                                    <button @click="createCategory" class="rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white">Kategorie speichern</button>
+                                </div>
+                            </div>
+
+                            <div class="mt-4" x-show="activeAdminTab === 'alerts'">
+                                <div class="space-y-3">
+                                    <template x-for="alert in alerts" :key="alert.id">
+                                        <div class="rounded-2xl border border-slate-200 px-4 py-3">
+                                            <div class="flex items-center justify-between">
+                                                <div>
+                                                    <p class="font-semibold text-slate-800" x-text="alert.name"></p>
+                                                    <p class="text-xs text-slate-500">Event: <span x-text="alert.event_type"></span> · Empfänger: <span x-text="alert.recipient_emails"></span></p>
+                                                </div>
+                                                <button @click="deleteAlert(alert.id)" class="text-rose-500 text-xs font-semibold">Löschen</button>
+                                            </div>
+                                        </div>
+                                    </template>
+                                </div>
+                                <div class="mt-4 grid gap-3">
+                                    <input type="text" x-model="newAlert.name" placeholder="Alert-Name" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                    <select x-model="newAlert.event_type" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                        <option value="created">Ticket erstellt</option>
+                                        <option value="updated">Ticket aktualisiert</option>
+                                        <option value="status_changed">Status geändert</option>
+                                        <option value="commented">Kommentar</option>
+                                    </select>
+                                    <div class="grid grid-cols-2 gap-3">
+                                        <select x-model="newAlert.status_match" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                            <option value="">Status (optional)</option>
+                                            <template x-for="status in statusOptions" :key="status">
+                                                <option :value="status" x-text="statusLabels[status] || status"></option>
+                                            </template>
+                                        </select>
+                                        <select x-model="newAlert.priority_match" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                            <option value="">Priorität (optional)</option>
+                                            <template x-for="priority in priorityOptions" :key="priority">
+                                                <option :value="priority" x-text="priority"></option>
+                                            </template>
+                                        </select>
+                                    </div>
+                                    <select x-model="newAlert.category_id" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                        <option value="">Kategorie (optional)</option>
+                                        <template x-for="category in categories" :key="category.id">
+                                            <option :value="category.id" x-text="category.name"></option>
+                                        </template>
+                                    </select>
+                                    <textarea x-model="newAlert.recipient_emails" rows="2" placeholder="Empfänger (kommagetrennt)" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm"></textarea>
+                                    <label class="inline-flex items-center gap-2 text-xs text-slate-500">
+                                        <input type="checkbox" x-model="newAlert.is_enabled" class="rounded border-slate-300 text-amber-600">
+                                        Alert aktiv
+                                    </label>
+                                    <button @click="createAlert" class="rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white">Alert speichern</button>
+                                </div>
+                            </div>
+
+                            <div class="mt-4" x-show="activeAdminTab === 'notifications'">
+                                <div class="grid gap-3">
+                                    <label class="inline-flex items-center gap-2 text-sm text-slate-600">
+                                        <input type="checkbox" x-model="notificationSettings.enabled" class="rounded border-slate-300 text-amber-600">
+                                        Benachrichtigungen aktiv
+                                    </label>
+                                    <div class="grid grid-cols-2 gap-3">
+                                        <input type="text" x-model="notificationSettings.smtp_host" placeholder="SMTP Host" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                        <input type="number" x-model="notificationSettings.smtp_port" placeholder="Port" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                    </div>
+                                    <input type="text" x-model="notificationSettings.smtp_username" placeholder="SMTP Benutzer" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                    <input type="password" x-model="notificationSettings.smtp_password" placeholder="SMTP Passwort" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                    <input type="email" x-model="notificationSettings.smtp_from" placeholder="Absender E-Mail" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                    <label class="inline-flex items-center gap-2 text-sm text-slate-600">
+                                        <input type="checkbox" x-model="notificationSettings.use_tls" class="rounded border-slate-300 text-amber-600">
+                                        TLS verwenden
+                                    </label>
+                                    <textarea x-model="notificationSettings.default_recipients" rows="2" placeholder="Standard-Empfänger (kommagetrennt)" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm"></textarea>
+                                    <button @click="saveNotificationSettings" class="rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white">Einstellungen speichern</button>
+                                    <div class="flex gap-2">
+                                        <input type="text" x-model="testRecipients" placeholder="Test-Empfänger" class="flex-1 rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                        <button @click="sendTestEmail" class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-700">Test senden</button>
+                                    </div>
+                                    <p class="text-xs text-slate-500" x-text="notificationMessage"></p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </main>
+        </div>
+    </div>
+
+    <div x-show="ticketModalOpen" x-transition class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 p-4">
+        <div @click.away="ticketModalOpen = false" class="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-3xl bg-white p-6 shadow-xl">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase text-slate-400">Neues Ticket</p>
+                    <h3 class="text-xl font-semibold text-slate-900">Helpdesk Anfrage</h3>
+                </div>
+                <button @click="ticketModalOpen = false" class="text-slate-400 hover:text-slate-700">
+                    <i data-feather="x" class="w-4 h-4"></i>
+                </button>
+            </div>
+            <div class="mt-4 grid gap-3">
+                <input type="text" x-model="newTicket.title" placeholder="Titel" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                <textarea x-model="newTicket.description" rows="4" placeholder="Beschreibung" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm"></textarea>
+                <div class="grid grid-cols-2 gap-3">
+                    <select x-model="newTicket.category_id" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                        <option value="">Kategorie</option>
+                        <template x-for="category in categories" :key="category.id">
+                            <option :value="category.id" x-text="category.name"></option>
+                        </template>
+                    </select>
+                    <select x-model="newTicket.priority" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                        <template x-for="priority in priorityOptions" :key="priority">
+                            <option :value="priority" x-text="priority"></option>
+                        </template>
+                    </select>
+                </div>
+                <div class="grid grid-cols-2 gap-3">
+                    <input type="text" x-model="newTicket.requester_name" placeholder="Anfragender" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                    <input type="email" x-model="newTicket.requester_email" placeholder="Anfragender E-Mail" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                </div>
+                <div class="grid grid-cols-2 gap-3">
+                    <input type="text" x-model="newTicket.assignee" placeholder="Zuständig" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                    <input type="email" x-model="newTicket.assignee_email" placeholder="Assignee E-Mail" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                </div>
+                <input type="date" x-model="newTicket.due_date" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                <input type="text" x-model="newTicket.tags" placeholder="Tags (kommagetrennt)" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+
+                <div class="space-y-2">
+                    <p class="text-xs uppercase text-slate-400">Benutzerdefinierte Felder</p>
+                    <template x-for="(field, index) in newTicket.custom_fields" :key="index">
+                        <div class="grid grid-cols-[1fr_1fr_auto] gap-2">
+                            <input type="text" x-model="field.key" placeholder="Feldname" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                            <input type="text" x-model="field.value" placeholder="Wert" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                            <button @click="removeCustomField(index)" class="rounded-2xl border border-slate-200 px-3 py-2 text-xs">Entfernen</button>
+                        </div>
+                    </template>
+                    <button @click="addCustomField" class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-2 text-xs font-semibold text-amber-700">Feld hinzufügen</button>
+                </div>
+
+                <button @click="createTicket" class="rounded-2xl bg-amber-500 px-4 py-2 text-sm font-semibold text-white">Ticket speichern</button>
+                <p class="text-xs text-rose-500" x-text="ticketError"></p>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://unpkg.com/feather-icons"></script>
+    <script src="/static/tickets.js"></script>
+    <script src="/static/ui.js"></script>
+    <script src="/static/theme.js"></script>
+</body>
+</html>

--- a/templates/users.html
+++ b/templates/users.html
@@ -39,6 +39,15 @@
                     </span>
                     <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
                 </a>
+                <a href="/tickets" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-amber-50 text-amber-600 mr-3">
+                            <i data-feather="life-buoy" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Tickets</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
                 <a href="/stats" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
                     <span class="flex items-center">
                         <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">


### PR DESCRIPTION
### Motivation
- Provide a full-featured, customizable helpdesk/ticketing system integrated into the inventory app to allow users and admins to create, track and manage tickets. 
- Add alerts and email notifications so teams can be informed about ticket events (creation, comments, status changes, etc.).
- Ship a simple, responsive UI so admins and users can manage tickets, categories, watchers, alerts and SMTP settings from the app.

### Description
- Add ticketing schema and persistence by creating new tables in `app.py`: `ticket_categories`, `tickets`, `ticket_comments`, `ticket_watchers`, `ticket_alerts` and `notification_settings` and seed default ticket categories. 
- Implement notification helpers and SMTP integration in `app.py` with `send_notification_email`, `trigger_ticket_notifications`, settings serialization and parsing helpers. 
- Add REST APIs for the helpdesk: ticket categories (`/api/ticket-categories`), tickets (`/api/tickets`), comments (`/api/tickets/<id>/comments`), watchers (`/api/tickets/<id>/watchers`), alerts (`/api/ticket-alerts`) and notification settings (`/api/notifications/*`). 
- Add UI and client logic: new template `templates/tickets.html`, client controller `static/tickets.js`, and navigation links injected into existing templates (`templates/index.html`, `templates/users.html`, `templates/locations.html`, `templates/stats.html`). 

### Testing
- Installed Python requirements via `pip install -r requirements.txt` which resolved missing dependencies and completed successfully. 
- Started the development server (`python app.py`) and confirmed the app served pages and created the initial temporary admin user. 
- Ran a headless Playwright smoke test that logged in as the temporary admin, navigated to `/tickets` and captured a full-page screenshot, which completed successfully and produced an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973bf2b6fa0832d972096978cfee763)