### PR TITLE
Fix dark-mode amber styles and make ticket UI responsive; rewrite README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,20 +1,99 @@
-# Inventarisierungssoftware für Hardwarekomponenten
+# Inventory Pro – Inventarisierung & Helpdesk
 
-## Projektbeschreibung
-
-Diese Webanwendung dient der strukturierten Inventarisierung von Hardwarekomponenten in einer IT-Umgebung. Ziel des Projekts ist die Entwicklung eines erweiterbaren, webbasierten Systems zur Erfassung, Kategorisierung und Auswertung von Hardwaredaten. Das System ermöglicht es, über eine Weboberfläche individuelle Kategorien zu erstellen und die zugehörigen Datenfelder flexibel über JSON-Definitionen zu konfigurieren. Zusätzlich wurde ein Sicherheitsmechanismus zur Benutzerauthentifizierung mit optionaler Zwei-Faktor-Authentifizierung (TOTP) implementiert.
+Inventory Pro ist eine professionelle Webplattform zur Verwaltung von Hardwarebeständen und Support-Tickets. Die Anwendung kombiniert eine flexible Inventarisierung, ein integriertes Helpdesk-System und ein rollenbasiertes Sicherheitskonzept. Damit eignet sie sich sowohl für IT-Abteilungen als auch für Managed-Service-Provider, die Asset- und Ticketdaten zentral und nachvollziehbar steuern möchten.
 
 ---
 
-## Funktionsumfang
+## Inhaltsverzeichnis
 
-### 1. Kategoriebasierte Inventarisierung
+- [Produktüberblick](#produktüberblick)
+- [Hauptfunktionen](#hauptfunktionen)
+- [Technischer Stack](#technischer-stack)
+- [Architektur & Datenmodell](#architektur--datenmodell)
+- [Installation](#installation)
+- [Konfiguration](#konfiguration)
+- [Betrieb & Deployment](#betrieb--deployment)
+- [Sicherheit](#sicherheit)
+- [Wartung & Betriebshinweise](#wartung--betriebshinweise)
+- [Lizenz](#lizenz)
+- [Kontakt](#kontakt)
 
-* Kategorien können über die Weboberfläche erstellt, bearbeitet und gelöscht werden.
-* Jede Kategorie enthält beliebig viele Geräte/Objekte.
-* Pro Kategorie können individuelle Datenfelder definiert werden, welche als JSON-Struktur gespeichert sind.
+---
 
-**Beispielhafte JSON-Felddaten:**
+## Produktüberblick
+
+Inventory Pro bietet eine konsolidierte Oberfläche zur Inventarisierung von IT-Komponenten sowie zur Bearbeitung von Support-Anfragen. Kategorien und Felder lassen sich dynamisch definieren, sodass Sie die Datenstruktur ohne Quellcodeänderung an Ihre Umgebung anpassen können. Gleichzeitig sorgt das Ticket-System für eine strukturierte Bearbeitung mit Status, Prioritäten, Kommentaren, Watchern und SLA-Informationen.
+
+---
+
+## Hauptfunktionen
+
+### Inventarisierung
+- **Dynamische Kategorien**: Frei definierbare Kategorien mit eigenen Felddefinitionen pro Asset-Typ.
+- **Formulargenerierung**: Eingabeformulare werden automatisch aus den JSON-Definitionen erstellt.
+- **Status-Tracking**: Statusinformationen werden für Auswertungen und Berichte genutzt.
+
+### Helpdesk / Tickets
+- **Ticket-Management**: Erstellung, Priorisierung, Statuswechsel und Zuweisungen.
+- **SLA-Informationen**: Tickets können mit Fälligkeits- und SLA-Daten geführt werden.
+- **Kommentare & Watcher**: Interne und externe Kommentare sowie Benachrichtigungsempfänger.
+- **Alerts & Benachrichtigungen**: Automationsregeln für Ereignisse (Statuswechsel, Kommentare etc.).
+
+### Benutzer & Sicherheit
+- **Authentifizierung**: Benutzername/Passwort mit Passwort-Hashing.
+- **2FA (TOTP)**: Optionale Zwei-Faktor-Authentifizierung.
+- **Sicheres Passwort-Reset**: Reset via TOTP oder im eingeloggten Zustand.
+
+### UX & Bedienung
+- **Responsive Oberfläche**: Optimiert für Desktop und mobile Geräte.
+- **Dark Mode**: Integriertes Theme-System für helle und dunkle Darstellung.
+- **Moderne UI-Komponenten**: Klar strukturierte Bereiche, schnelle Navigation und konsistente Bedienelemente.
+
+---
+
+## Technischer Stack
+
+| Ebene | Technologie |
+| --- | --- |
+| Frontend | HTML5, CSS3, JavaScript (Vanilla), Alpine.js, Tailwind via CDN |
+| Backend | Python 3.12, Flask |
+| Datenhaltung | SQLite |
+| Authentifizierung | bcrypt, TOTP (RFC 6238) |
+| API | RESTful, JSON-basiert |
+
+---
+
+## Architektur & Datenmodell
+
+- **Trennung von UI & Backend**: UI-Templates und REST-Endpunkte sind klar getrennt.
+- **Dynamische Felder**: Kategorien speichern Felddefinitionen als JSON, Einträge übernehmen diese Struktur.
+- **Ticket-Datenmodell**: Enthält Status, Priorität, Kategorie, SLA/Deadline, Kommentare, Watcher und Benachrichtigungsregeln.
+
+---
+
+## Installation
+
+```bash
+# 1) Virtuelle Umgebung erstellen
+python -m venv venv
+source venv/bin/activate
+
+# 2) Abhängigkeiten installieren
+pip install -r requirements.txt
+
+# 3) Anwendung starten
+python app.py
+```
+
+Nach dem Start ist die Anwendung in der Regel unter `http://localhost:5000` erreichbar.
+
+---
+
+## Konfiguration
+
+- **SMTP / Benachrichtigungen**: Über das Ticket-Admin-Panel konfigurierbar.
+- **2FA aktivieren**: In der Benutzerverwaltung aktivieren und TOTP-Seed in einer Authenticator-App hinterlegen.
+- **JSON-Felder**: Kategorien definieren Felder über JSON, z. B.:
 
 ```json
 {
@@ -26,97 +105,35 @@ Diese Webanwendung dient der strukturierten Inventarisierung von Hardwarekompone
 }
 ```
 
-* Die Feldnamen sind frei wählbar, wobei "Status" (Großschreibung beachten) eine besondere Bedeutung für die statistische Auswertung hat.
+Der Feldname **"Status"** hat eine besondere Bedeutung für die Auswertungslogik.
 
 ---
 
-### 2. Datenverwaltung
+## Betrieb & Deployment
 
-* Für jede Kategorie lassen sich neue Einträge (z. B. Hardwaregeräte) hinzufügen, bearbeiten oder löschen.
-* Die Eingabe erfolgt über automatisch generierte Formulare, basierend auf den JSON-Definitionen.
-* Änderungen an den Felddefinitionen wirken sich sofort auf alle zugehörigen Formulare und Datensätze aus.
+Empfohlene Vorgehensweise für Produktionsumgebungen:
 
----
-
-### 3. Statistikmodul
-
-* Basierend auf dem "Status"-Feld werden die Zustände der Geräte automatisch ausgewertet und grafisch/statistisch dargestellt.
-* Unterstützte Statuswerte sind u. a.:
-
-  * "Verwendung"
-  * "Defekt"
-  * "Lager"
-* Die Darstellung erfolgt aggregiert je Kategorie.
+- **WSGI-Server nutzen** (z. B. Gunicorn oder uWSGI).
+- **Reverse Proxy** (z. B. Nginx) für SSL-Termination und Caching.
+- **Datenbank-Backup** regelmäßig einplanen.
+- **Secrets schützen** (SMTP-Credentials, TOTP-Secrets).
 
 ---
 
-### 4. Authentifizierung und Sicherheit
+## Sicherheit
 
-* Zugriff auf die Webanwendung erfolgt über ein Benutzerkonto (Benutzername + Passwort).
-* Zusätzlich kann ein TOTP-basierter Zwei-Faktor-Authentifizierungsmechanismus (2FA) aktiviert werden.
-* TOTP kann über einen QR-Code oder manuell durch einen Schlüssel in Authenticator-Apps (z. B. Google Authenticator) hinzugefügt werden.
-* Bei aktivierter 2FA kann das Passwort zurückgesetzt werden, sofern ein gültiger TOTP-Code eingegeben wird.
-* Alternativ ist das Zurücksetzen direkt innerhalb der Anwendung (bei bestehender Sitzung) möglich.
-
----
-
-### 5. Benutzeroberfläche
-
-* Die Webanwendung ist vollständig responsiv und im hellen, minimalistischen Stil mit abgerundeten UI-Elementen gestaltet.
-* Die Benutzeroberfläche ist modern und orientiert sich an aktuellen Designstandards im Bereich UI/UX.
+- Passwort-Hashing mit **bcrypt**.
+- **TOTP-basierte Zwei-Faktor-Authentifizierung** (RFC 6238).
+- Session- und Rollenlogik in der Applikationsschicht.
+- Empfohlene Ergänzungen: TLS, regelmäßige Updates, Restriktionen für Admin-Zugriffe.
 
 ---
 
-## Technische Architektur
+## Wartung & Betriebshinweise
 
-| Komponente             | Technologie                                    |
-| ---------------------- | ---------------------------------------------- |
-| **Frontend**           | HTML5, CSS3, JavaScript (Vanilla), Alpine.js   |
-| **Backend**            | Python 3.12 mit Flask                          |
-| **Datenhaltung**       | SQLite                                         |
-| **Authentifizierung**  | Passwort-Hashing (bcrypt), TOTP gemäß RFC 6238 |
-| **API-Schnittstellen** | REST-konform, JSON-basiert                     |
-
----
-
-## Systemanforderungen
-
-* Python 3.12
-* Webserver mit WSGI-Support (z. B. Gunicorn, uWSGI)
-* Webbrowser mit aktiviertem JavaScript
-
----
-
-## Projektumfang
-
-* **Frontend-Code:** \~3000 Zeilen (inkl. Formularlogik, dynamisches Rendering, UX-Komponenten)
-* **Backend-Code:** \~600 Zeilen (REST-API, Authentifizierung, Datenpersistenz)
-* **Datenmodell:** dynamisch, JSON-basiert pro Kategorie
-* **Sicherheitsmodul:** Integration von TOTP und Passwort-Reset-Funktionalität
-
----
-
-## Einrichtung
-
-```bash
-# Voraussetzungen
-python -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-
-# Starten der Anwendung
-python app.py
-```
-
-> ⚠️ Die genaue Installationsanleitung kann je nach Hostingumgebung angepasst werden.
-
----
-
-## Weiterentwicklung & Erweiterbarkeit
-
-* Modularer Aufbau erlaubt spätere Erweiterung (z. B. Exportfunktionen, Gerätegruppen, Benutzerrollen)
-* JSON-basierte Felddefinition ermöglicht individuelle Anpassung ohne Codeänderung
-* Trennung von Frontend und Backend durch API-Architektur
+- **Backups**: SQLite-Datei regelmäßig sichern (auch vor Updates).
+- **Monitoring**: Verfügbarkeit, Fehlerraten und Logs überwachen.
+- **Updates**: Abhängigkeiten regelmäßig prüfen und aktualisieren.
 
 ---
 
@@ -124,18 +141,17 @@ python app.py
 
 Dieses Projekt steht unter der GNU Affero General Public License Version 3 (AGPL-3.0).
 
-Sie dürfen diese Software verwenden, verändern und verbreiten, solange alle Änderungen und Erweiterungen unter denselben Bedingungen (AGPL-3.0) veröffentlicht werden, insbesondere bei Nutzung über ein Netzwerk (z. B. als Webanwendung).
+Sie dürfen diese Software verwenden, verändern und verbreiten, solange alle Änderungen und Erweiterungen unter denselben Bedingungen (AGPL-3.0) veröffentlicht werden, insbesondere bei Nutzung über ein Netzwerk (z. B. als Webanwendung).
 
-Für die kommerzielle Nutzung ohne Offenlegungspflicht (z. B. in geschlossenen Systemen oder als SaaS ohne Quellcodeveröffentlichung) ist eine separate Lizenzvereinbarung notwendig.
+Für die kommerzielle Nutzung ohne Offenlegungspflicht (z. B. in geschlossenen Systemen oder als SaaS ohne Quellcodeveröffentlichung) ist eine separate Lizenzvereinbarung notwendig.
 
-Kontakt für kommerzielle Lizenzen: [joshua@pondsec.com](mailto:joshua@pondsec.com)
-
-Der vollständige Lizenztext ist verfügbar unter: [https://www.gnu.org/licenses/agpl-3.0.de.html](https://www.gnu.org/licenses/agpl-3.0.de.html)
+Der vollständige Lizenztext: https://www.gnu.org/licenses/agpl-3.0.de.html
 
 ---
 
-## Autor
+## Kontakt
 
 Joshua Pond
 Fachinformatiker für Systemintegration
+E-Mail: joshua@pondsec.com
 Stand: Juli 2025

--- a/static/style.css
+++ b/static/style.css
@@ -347,6 +347,14 @@ footer {
   background-color: rgba(99, 102, 241, 0.25);
 }
 
+.dark .bg-amber-50 {
+  background-color: rgba(120, 53, 15, 0.35);
+}
+
+.dark .bg-amber-100 {
+  background-color: rgba(120, 53, 15, 0.45);
+}
+
 .dark .bg-rose-50 {
   background-color: rgba(225, 29, 72, 0.15);
 }
@@ -387,6 +395,14 @@ footer {
   color: #94a3b8;
 }
 
+.dark .text-amber-700 {
+  color: #fcd34d;
+}
+
+.dark .text-amber-600 {
+  color: #fbbf24;
+}
+
 .dark .text-indigo-700 {
   color: #c7d2fe;
 }
@@ -413,6 +429,14 @@ footer {
 
 .dark .border-indigo-100 {
   border-color: rgba(99, 102, 241, 0.4);
+}
+
+.dark .border-amber-100 {
+  border-color: rgba(251, 191, 36, 0.35);
+}
+
+.dark .border-amber-200 {
+  border-color: rgba(251, 191, 36, 0.45);
 }
 
 .dark .border-rose-100 {

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -88,13 +88,13 @@
                         <h1 class="text-2xl font-semibold text-slate-900">Ticket-System</h1>
                     </div>
                 </div>
-                <div class="flex items-center space-x-4">
-                    <span class="text-sm text-slate-500">Angemeldet als {{ username }}</span>
-                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+                <div class="flex flex-wrap items-center justify-end gap-3">
+                    <span class="text-sm text-slate-500 w-full sm:w-auto">Angemeldet als {{ username }}</span>
+                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex w-full items-center justify-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:w-auto">
                         <span data-theme-icon aria-hidden="true">🌙</span>
                         <span data-theme-label>Dark Mode</span>
                     </button>
-                    <button @click="openNewTicket" class="inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-700 shadow-sm hover:bg-amber-100">
+                    <button @click="openNewTicket" class="inline-flex w-full items-center justify-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-700 shadow-sm hover:bg-amber-100 sm:w-auto">
                         <i data-feather="plus-circle" class="w-4 h-4"></i>
                         Ticket erstellen
                     </button>
@@ -133,11 +133,11 @@
                     <div class="space-y-6">
                         <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm">
                             <div class="flex flex-wrap items-center gap-4">
-                                <div class="flex-1 min-w-[200px]">
+                                <div class="w-full sm:flex-1 sm:min-w-[200px]">
                                     <label class="text-xs uppercase text-slate-400">Suche</label>
                                     <input type="text" x-model="filters.search" @input.debounce.300ms="loadTickets" placeholder="Ticket, Kunde, Beschreibung" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm shadow-sm">
                                 </div>
-                                <div class="min-w-[160px]">
+                                <div class="w-full sm:min-w-[160px]">
                                     <label class="text-xs uppercase text-slate-400">Status</label>
                                     <select x-model="filters.status" @change="loadTickets" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
                                         <option value="">Alle</option>
@@ -146,7 +146,7 @@
                                         </template>
                                     </select>
                                 </div>
-                                <div class="min-w-[160px]">
+                                <div class="w-full sm:min-w-[160px]">
                                     <label class="text-xs uppercase text-slate-400">Priorität</label>
                                     <select x-model="filters.priority" @change="loadTickets" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
                                         <option value="">Alle</option>
@@ -155,7 +155,7 @@
                                         </template>
                                     </select>
                                 </div>
-                                <div class="min-w-[180px]">
+                                <div class="w-full sm:min-w-[180px]">
                                     <label class="text-xs uppercase text-slate-400">Kategorie</label>
                                     <select x-model="filters.category_id" @change="loadTickets" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
                                         <option value="">Alle</option>
@@ -164,7 +164,7 @@
                                         </template>
                                     </select>
                                 </div>
-                                <label class="inline-flex items-center gap-2 text-sm text-slate-600">
+                                <label class="inline-flex w-full items-center gap-2 text-sm text-slate-600 sm:w-auto">
                                     <input type="checkbox" x-model="filters.mine" @change="loadTickets" class="rounded border-slate-300 text-amber-600">
                                     Meine Tickets
                                 </label>
@@ -215,33 +215,33 @@
                                     </div>
 
                                     <div class="mt-4 grid gap-3 text-sm text-slate-600">
-                                        <div class="flex items-center justify-between">
+                                        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                                             <span>Status</span>
-                                            <select x-model="selectedTicket.status" @change="updateTicket" class="rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm">
+                                            <select x-model="selectedTicket.status" @change="updateTicket" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm sm:w-auto">
                                                 <template x-for="status in statusOptions" :key="status">
                                                     <option :value="status" x-text="statusLabels[status] || status"></option>
                                                 </template>
                                             </select>
                                         </div>
-                                        <div class="flex items-center justify-between">
+                                        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                                             <span>Priorität</span>
-                                            <select x-model="selectedTicket.priority" @change="updateTicket" class="rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm">
+                                            <select x-model="selectedTicket.priority" @change="updateTicket" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm sm:w-auto">
                                                 <template x-for="priority in priorityOptions" :key="priority">
                                                     <option :value="priority" x-text="priority"></option>
                                                 </template>
                                             </select>
                                         </div>
-                                        <div class="flex items-center justify-between">
+                                        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                                             <span>Zuständig</span>
-                                            <input type="text" x-model="selectedTicket.assignee" @change="updateTicket" placeholder="Team/Name" class="rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm">
+                                            <input type="text" x-model="selectedTicket.assignee" @change="updateTicket" placeholder="Team/Name" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm sm:w-auto">
                                         </div>
-                                        <div class="flex items-center justify-between">
+                                        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                                             <span>Assignee E-Mail</span>
-                                            <input type="email" x-model="selectedTicket.assignee_email" @change="updateTicket" placeholder="support@firma.de" class="rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm">
+                                            <input type="email" x-model="selectedTicket.assignee_email" @change="updateTicket" placeholder="support@firma.de" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm sm:w-auto">
                                         </div>
-                                        <div class="flex items-center justify-between">
+                                        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                                             <span>Fällig</span>
-                                            <input type="date" x-model="selectedTicket.due_date" @change="updateTicket" class="rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm">
+                                            <input type="date" x-model="selectedTicket.due_date" @change="updateTicket" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-1 text-sm sm:w-auto">
                                         </div>
                                     </div>
 
@@ -255,9 +255,9 @@
                                                 </span>
                                             </template>
                                         </div>
-                                        <div class="mt-3 flex gap-2">
-                                            <input type="email" x-model="newWatcher" placeholder="watcher@firma.de" class="flex-1 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm">
-                                            <button @click="addWatcher" class="rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white">Hinzufügen</button>
+                                        <div class="mt-3 flex flex-col gap-2 sm:flex-row">
+                                            <input type="email" x-model="newWatcher" placeholder="watcher@firma.de" class="w-full flex-1 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                            <button @click="addWatcher" class="w-full rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white sm:w-auto">Hinzufügen</button>
                                         </div>
                                     </div>
 
@@ -293,10 +293,10 @@
                                     <p class="text-xs uppercase text-slate-400">Administration</p>
                                     <h3 class="text-lg font-semibold text-slate-900">Einstellungen & Automationen</h3>
                                 </div>
-                                <div class="flex gap-2">
-                                    <button @click="activeAdminTab = 'categories'" :class="activeAdminTab === 'categories' ? 'bg-amber-500 text-white' : 'bg-slate-100 text-slate-600'" class="rounded-full px-3 py-1 text-xs font-semibold">Kategorien</button>
-                                    <button @click="activeAdminTab = 'alerts'" :class="activeAdminTab === 'alerts' ? 'bg-amber-500 text-white' : 'bg-slate-100 text-slate-600'" class="rounded-full px-3 py-1 text-xs font-semibold">Alerts</button>
-                                    <button @click="activeAdminTab = 'notifications'" :class="activeAdminTab === 'notifications' ? 'bg-amber-500 text-white' : 'bg-slate-100 text-slate-600'" class="rounded-full px-3 py-1 text-xs font-semibold">E-Mail</button>
+                                <div class="flex flex-wrap gap-2">
+                                    <button @click="activeAdminTab = 'categories'" :class="activeAdminTab === 'categories' ? 'bg-amber-500 text-white' : 'bg-slate-100 text-slate-600'" class="w-full rounded-full px-3 py-1 text-xs font-semibold sm:w-auto">Kategorien</button>
+                                    <button @click="activeAdminTab = 'alerts'" :class="activeAdminTab === 'alerts' ? 'bg-amber-500 text-white' : 'bg-slate-100 text-slate-600'" class="w-full rounded-full px-3 py-1 text-xs font-semibold sm:w-auto">Alerts</button>
+                                    <button @click="activeAdminTab = 'notifications'" :class="activeAdminTab === 'notifications' ? 'bg-amber-500 text-white' : 'bg-slate-100 text-slate-600'" class="w-full rounded-full px-3 py-1 text-xs font-semibold sm:w-auto">E-Mail</button>
                                 </div>
                             </div>
 
@@ -315,7 +315,7 @@
                                 <div class="mt-4 grid gap-3">
                                     <input type="text" x-model="newCategory.name" placeholder="Kategorie" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
                                     <textarea x-model="newCategory.description" rows="2" placeholder="Beschreibung" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm"></textarea>
-                                    <div class="grid grid-cols-2 gap-3">
+                                    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
                                         <input type="color" x-model="newCategory.color" class="h-10 w-full rounded-2xl border border-slate-200">
                                         <input type="number" x-model="newCategory.sla_hours" placeholder="SLA (Std.)" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
                                     </div>
@@ -349,7 +349,7 @@
                                         <option value="status_changed">Status geändert</option>
                                         <option value="commented">Kommentar</option>
                                     </select>
-                                    <div class="grid grid-cols-2 gap-3">
+                                    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
                                         <select x-model="newAlert.status_match" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
                                             <option value="">Status (optional)</option>
                                             <template x-for="status in statusOptions" :key="status">
@@ -384,7 +384,7 @@
                                         <input type="checkbox" x-model="notificationSettings.enabled" class="rounded border-slate-300 text-amber-600">
                                         Benachrichtigungen aktiv
                                     </label>
-                                    <div class="grid grid-cols-2 gap-3">
+                                    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
                                         <input type="text" x-model="notificationSettings.smtp_host" placeholder="SMTP Host" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
                                         <input type="number" x-model="notificationSettings.smtp_port" placeholder="Port" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
                                     </div>
@@ -397,9 +397,9 @@
                                     </label>
                                     <textarea x-model="notificationSettings.default_recipients" rows="2" placeholder="Standard-Empfänger (kommagetrennt)" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm"></textarea>
                                     <button @click="saveNotificationSettings" class="rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white">Einstellungen speichern</button>
-                                    <div class="flex gap-2">
-                                        <input type="text" x-model="testRecipients" placeholder="Test-Empfänger" class="flex-1 rounded-2xl border border-slate-200 px-3 py-2 text-sm">
-                                        <button @click="sendTestEmail" class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-700">Test senden</button>
+                                    <div class="flex flex-col gap-2 sm:flex-row">
+                                        <input type="text" x-model="testRecipients" placeholder="Test-Empfänger" class="w-full flex-1 rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                        <button @click="sendTestEmail" class="w-full rounded-2xl border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-700 sm:w-auto">Test senden</button>
                                     </div>
                                     <p class="text-xs text-slate-500" x-text="notificationMessage"></p>
                                 </div>
@@ -425,7 +425,7 @@
             <div class="mt-4 grid gap-3">
                 <input type="text" x-model="newTicket.title" placeholder="Titel" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
                 <textarea x-model="newTicket.description" rows="4" placeholder="Beschreibung" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm"></textarea>
-                <div class="grid grid-cols-2 gap-3">
+                <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
                     <select x-model="newTicket.category_id" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
                         <option value="">Kategorie</option>
                         <template x-for="category in categories" :key="category.id">
@@ -438,11 +438,11 @@
                         </template>
                     </select>
                 </div>
-                <div class="grid grid-cols-2 gap-3">
+                <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
                     <input type="text" x-model="newTicket.requester_name" placeholder="Anfragender" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
                     <input type="email" x-model="newTicket.requester_email" placeholder="Anfragender E-Mail" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
                 </div>
-                <div class="grid grid-cols-2 gap-3">
+                <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
                     <input type="text" x-model="newTicket.assignee" placeholder="Zuständig" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
                     <input type="email" x-model="newTicket.assignee_email" placeholder="Assignee E-Mail" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
                 </div>
@@ -452,10 +452,10 @@
                 <div class="space-y-2">
                     <p class="text-xs uppercase text-slate-400">Benutzerdefinierte Felder</p>
                     <template x-for="(field, index) in newTicket.custom_fields" :key="index">
-                        <div class="grid grid-cols-[1fr_1fr_auto] gap-2">
+                        <div class="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_1fr_auto]">
                             <input type="text" x-model="field.key" placeholder="Feldname" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
                             <input type="text" x-model="field.value" placeholder="Wert" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
-                            <button @click="removeCustomField(index)" class="rounded-2xl border border-slate-200 px-3 py-2 text-xs">Entfernen</button>
+                            <button @click="removeCustomField(index)" class="w-full rounded-2xl border border-slate-200 px-3 py-2 text-xs sm:w-auto">Entfernen</button>
                         </div>
                     </template>
                     <button @click="addCustomField" class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-2 text-xs font-semibold text-amber-700">Feld hinzufügen</button>


### PR DESCRIPTION
### Motivation
- The ticket UI showed amber-accented buttons/badges as white in dark mode, reducing contrast and readability. 
- Several ticket controls (buttons, inputs, admin tabs, grids) overflowed or broke layout at narrow viewport widths. 
- The repository README was brief and inconsistent with the project scope and needed a professional, comprehensive replacement.

### Description
- Update `templates/tickets.html` to add responsive classes (`w-full`, `sm:w-auto`, `sm:grid-cols-*`, `flex-col` fallbacks, etc.) so controls, forms and admin buttons wrap cleanly on narrow viewports and avoid overflow. 
- Extend dark-mode CSS in `static/style.css` by adding `.dark` variants for amber backgrounds, text and borders (`.bg-amber-50`, `.bg-amber-100`, `.text-amber-700`, `.text-amber-600`, `.border-amber-100`, `.border-amber-200`) so amber accents remain visible and consistent in dark theme. 
- Replace `readme.md` with a comprehensive, professional `README` (`Inventory Pro – Inventarisierung & Helpdesk`) that documents product overview, features, stack, installation, configuration, deployment, security and contact details.

### Testing
- Installed dependencies with `pip install -r requirements.txt`, which completed successfully. 
- Started the development server with `python app.py`, which launched the app and served endpoints required for the ticket UI. 
- Executed an automated Playwright script that logged in, navigated to `/tickets` with dark theme set, and captured `artifacts/tickets-darkmode.png` to verify dark-mode appearance and responsive behavior, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973c913ba18832db53eab8fa3b561fb)