### PR TITLE
Add logout button to tickets page and mobile-friendly layout tweaks

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -296,6 +296,62 @@ footer {
   padding-right: 0.5rem;
 }
 
+@media (max-width: 1024px) {
+  .app-body {
+    --sidebar-width: 0px;
+  }
+
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .app-shell::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.35);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+    z-index: 30;
+  }
+
+  .app-body:not(.sidebar-collapsed) .app-shell::before {
+    opacity: 1;
+  }
+
+  .app-sidebar {
+    width: min(85vw, 320px);
+    transform: translateX(-120%);
+    transition: transform 0.25s ease;
+    z-index: 40;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
+  }
+
+  .app-body:not(.sidebar-collapsed) .app-sidebar {
+    transform: translateX(0);
+  }
+
+  .app-main--fixed {
+    margin-left: 0;
+  }
+
+  .app-header {
+    left: 0;
+    width: 100%;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    height: auto;
+    padding: 0.75rem 1rem;
+  }
+
+  .app-main--fixed main {
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 6.5rem;
+  }
+}
+
 /* Dark mode overrides */
 .dark body,
 .dark .app-body {

--- a/static/ui.js
+++ b/static/ui.js
@@ -16,6 +16,8 @@ const setSidebarCollapsed = (collapsed) => {
 const storedSidebarState = localStorage.getItem(sidebarStorageKey);
 if (storedSidebarState !== null) {
   setSidebarCollapsed(storedSidebarState === 'true');
+} else if (window.matchMedia('(max-width: 1024px)').matches) {
+  setSidebarCollapsed(true);
 }
 
 sidebarToggleButtons.forEach((button) => {

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -108,6 +108,10 @@
                         <span data-theme-icon aria-hidden="true">🌙</span>
                         <span data-theme-label>Dark Mode</span>
                     </button>
+                    <button onclick="logout()" class="inline-flex w-full items-center justify-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:w-auto">
+                        <i data-feather="log-out" class="w-4 h-4"></i>
+                        Abmelden
+                    </button>
                     {% if 'tickets.create' in permissions %}
                     <button @click="openNewTicket" class="inline-flex w-full items-center justify-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-700 shadow-sm hover:bg-amber-100 sm:w-auto">
                         <i data-feather="plus-circle" class="w-4 h-4"></i>
@@ -484,6 +488,26 @@
     </div>
 
     <script src="https://unpkg.com/feather-icons"></script>
+    <script>
+        async function logout() {
+            try {
+                const response = await fetch('/logout', {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: { 'Content-Type': 'application/json' }
+                });
+
+                if (response.ok) {
+                    window.location.href = '/login';
+                } else {
+                    const data = await response.json();
+                    alert('Logout failed: ' + (data.error || 'Unknown error'));
+                }
+            } catch (error) {
+                alert('Network error: ' + error.message);
+            }
+        }
+    </script>
     <script src="/static/tickets.js"></script>
     <script src="/static/ui.js"></script>
     <script src="/static/theme.js"></script>


### PR DESCRIPTION
### Motivation

- Das Ticketsystem braucht einen sichtbaren Abmelden-Button in der Ticket-UI, damit Benutzer sich direkt vom Ticketscreen abmelden können.
- Die Oberfläche soll auf mobilen Geräten uneingeschränkt nutzbar und optisch ansprechend sein, ohne das Desktop-Layout zu verändern.

### Description

- Ergänzt `templates/tickets.html` um einen „Abmelden“-Button in der Header-Leiste und einen einfachen `logout()`-Handler (POST an `/logout`).
- Fügt in `static/style.css` eine `@media (max-width: 1024px)`-Regel hinzu, die eine Off‑Canvas-Sidebar, Overlay sowie Header- und Content-Abstände für mobile Geräte bereitstellt.
- Passt `static/ui.js` an, sodass die Sidebar auf kleinen Bildschirmen standardmäßig eingeklappt ist (`localStorage`-Fallback mit `matchMedia`).
- Änderungen wurden zusammengefasst und committet (`static/style.css`, `static/ui.js`, `templates/tickets.html`).

### Testing

- Abhängigkeiten installiert mit `pip install -r requirements.txt` und der Dev-Server erfolgreich gestartet mit `python app.py`, dabei wurde ein Admin-Konto erzeugt (Server läuft im Debug-Modus).
- Ein automatisiertes Playwright-Skript hat sich als Admin eingeloggt und die Seite ` /tickets ` geladen, dabei wurde ein Mobile-Screenshot erstellt (Screenshot-Artifact `artifacts/tickets-mobile.png`), dieser Schritt war erfolgreich.
- Es wurden keine zusätzliche Unit-Tests hinzugefügt; alle oben genannten automatisierten Prüfungen liefen erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f2824c68832db68182c646cc295c)