### PR TITLE
Fix mobile sidebar overlay behavior

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -316,7 +316,7 @@ footer {
     z-index: 30;
   }
 
-  .app-body:not(.sidebar-collapsed) .app-shell::before {
+  .app-body.sidebar-open .app-shell::before {
     opacity: 1;
   }
 
@@ -328,7 +328,7 @@ footer {
     box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
   }
 
-  .app-body:not(.sidebar-collapsed) .app-sidebar {
+  .app-body.sidebar-open .app-sidebar {
     transform: translateX(0);
   }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -4,6 +4,7 @@ const bodyElement = document.body;
 
 const setSidebarCollapsed = (collapsed) => {
   bodyElement.classList.toggle('sidebar-collapsed', collapsed);
+  bodyElement.classList.toggle('sidebar-open', !collapsed);
   sidebarToggleButtons.forEach((button) => {
     button.setAttribute('aria-pressed', collapsed ? 'true' : 'false');
     button.setAttribute(


### PR DESCRIPTION
### Motivation
- The left sidebar and its overlay were appearing or blocking content on small screens unintentionally, so mobile navigation must be explicitly opened to avoid blocking the UI.

### Description
- Use a dedicated body state class `sidebar-open` in CSS so the overlay and sidebar slide-in are shown only when the sidebar is explicitly opened by the user, by replacing `.app-body:not(.sidebar-collapsed)` with `.app-body.sidebar-open` in `static/style.css`.
- Keep `sidebar-collapsed` semantics but sync an open flag by toggling `sidebar-open` in `setSidebarCollapsed` so the JS and CSS state are consistent in `static/ui.js`.
- Changed files: `static/style.css` and `static/ui.js`.

### Testing
- Installed dependencies with `pip install -r requirements.txt`, which completed successfully. 
- Started the app with `python app.py`, which launched the dev server successfully and created an admin account. 
- Ran an automated Playwright script that logged in and captured a mobile screenshot; the script completed and produced `artifacts/mobile-dashboard.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f4eb3174832dbac477faaad316c7)