### PR TITLE
Ensure mobile sidebar stays closed on small screens

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -316,7 +316,7 @@ footer {
     z-index: 30;
   }
 
-  .app-body:not(.sidebar-collapsed) .app-shell::before {
+  .app-body.sidebar-open .app-shell::before {
     opacity: 1;
   }
 
@@ -328,7 +328,7 @@ footer {
     box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
   }
 
-  .app-body:not(.sidebar-collapsed) .app-sidebar {
+  .app-body.sidebar-open .app-sidebar {
     transform: translateX(0);
   }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -4,6 +4,7 @@ const bodyElement = document.body;
 
 const setSidebarCollapsed = (collapsed) => {
   bodyElement.classList.toggle('sidebar-collapsed', collapsed);
+  bodyElement.classList.toggle('sidebar-open', !collapsed);
   sidebarToggleButtons.forEach((button) => {
     button.setAttribute('aria-pressed', collapsed ? 'true' : 'false');
     button.setAttribute(
@@ -13,17 +14,31 @@ const setSidebarCollapsed = (collapsed) => {
   });
 };
 
-const storedSidebarState = localStorage.getItem(sidebarStorageKey);
-if (storedSidebarState !== null) {
-  setSidebarCollapsed(storedSidebarState === 'true');
-} else if (window.matchMedia('(max-width: 1024px)').matches) {
-  setSidebarCollapsed(true);
-}
+const mobileQuery = window.matchMedia('(max-width: 1024px)');
+
+const applyResponsiveSidebarState = () => {
+  if (mobileQuery.matches) {
+    setSidebarCollapsed(true);
+    return;
+  }
+
+  const storedSidebarState = localStorage.getItem(sidebarStorageKey);
+  if (storedSidebarState !== null) {
+    setSidebarCollapsed(storedSidebarState === 'true');
+  } else {
+    setSidebarCollapsed(false);
+  }
+};
+
+applyResponsiveSidebarState();
+mobileQuery.addEventListener('change', applyResponsiveSidebarState);
 
 sidebarToggleButtons.forEach((button) => {
   button.addEventListener('click', () => {
     const nextState = !bodyElement.classList.contains('sidebar-collapsed');
     setSidebarCollapsed(nextState);
-    localStorage.setItem(sidebarStorageKey, String(nextState));
+    if (!mobileQuery.matches) {
+      localStorage.setItem(sidebarStorageKey, String(nextState));
+    }
   });
 });


### PR DESCRIPTION
### Motivation
- The sidebar and its overlay were appearing or blocking content on small screens because desktop preferences were being applied on mobile, so mobile navigation must default to closed and not persist mobile toggles.

### Description
- Update `static/style.css` to show the overlay and slide-in sidebar only when the body has the explicit `sidebar-open` class instead of relying on `:not(.sidebar-collapsed)` so the overlay is only visible when the user opens navigation on mobile.
- Update `static/ui.js` to add a `mobileQuery` media query and force the sidebar collapsed on `(max-width: 1024px)` viewports so mobile starts closed.
- Apply stored desktop preference only on non-mobile viewports and avoid persisting mobile toggles to `localStorage` so desktop state and mobile behavior do not conflict.
- Listen for viewport changes and re-apply the responsive sidebar state so the UI updates when the window crosses the mobile threshold.

### Testing
- Launched the app with `python app.py` which started the development server successfully.
- Executed an automated Playwright script that opened the app with a mobile viewport, logged in, and captured `artifacts/mobile-dashboard.png`, and the script completed successfully, confirming the mobile sidebar is collapsed and the UI is usable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f4eb3174832dbac477faaad316c7)