### PR TITLE
Improve mobile UX responsiveness

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -352,6 +352,115 @@ footer {
   }
 }
 
+/* Mobile experience polish */
+@media (max-width: 640px) {
+  body {
+    font-size: 15px;
+  }
+
+  .container {
+    width: 92%;
+    padding: 24px 0;
+  }
+
+  .app-shell {
+    background: #f8fafc;
+  }
+
+  .app-sidebar {
+    border-radius: 0 24px 24px 0;
+  }
+
+  .sidebar-header {
+    padding: 1.5rem 1.25rem;
+  }
+
+  .sidebar-scroll {
+    padding-bottom: 5rem;
+  }
+
+  .app-header {
+    position: sticky;
+    top: 0;
+    height: auto;
+    padding: 0.75rem 1rem;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .app-header-title {
+    width: 100%;
+  }
+
+  .app-header-title h1 {
+    font-size: 1.4rem;
+    line-height: 1.2;
+  }
+
+  .app-header-actions {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .app-header-actions > * {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .app-header-actions > * + * {
+    margin-left: 0 !important;
+  }
+
+  .app-main--fixed main {
+    padding: 1rem;
+    padding-top: 7.5rem;
+    gap: 1.5rem;
+    margin-top: 0;
+  }
+
+  .app-main--fixed main .rounded-3xl {
+    border-radius: 1.5rem;
+  }
+
+  .app-main--fixed main .rounded-2xl {
+    border-radius: 1.25rem;
+  }
+
+  .app-main--fixed main .shadow-2xl {
+    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.15);
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .table-scroll table {
+    min-width: 520px;
+  }
+
+  .auth-shell {
+    align-items: flex-start;
+    padding-top: 2.5rem;
+    padding-bottom: 2.5rem;
+  }
+
+  .auth-top-actions {
+    position: static;
+    margin-bottom: 1rem;
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .auth-card {
+    padding: 1.5rem;
+    border-radius: 1.5rem;
+  }
+}
+
 /* Dark mode overrides */
 .dark body,
 .dark .app-body {

--- a/templates/index.html
+++ b/templates/index.html
@@ -274,7 +274,7 @@
 
         <div class="main-content app-main app-main--fixed">
             <header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 z-30 h-[82px]">
-                <div class="flex items-center gap-4">
+                <div class="app-header-title flex items-center gap-4">
                     <button type="button" data-sidebar-toggle aria-label="Navigation umschalten" class="inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white p-2 text-slate-600 shadow-sm hover:bg-slate-50">
                         <i data-feather="menu" class="w-4 h-4"></i>
                     </button>
@@ -283,7 +283,7 @@
                     <h1 class="text-2xl font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h1>
                     </div>
                 </div>
-                <div class="flex items-center space-x-3">
+                <div class="app-header-actions flex items-center space-x-3">
                     <button @click="openAddDeviceModal()" class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-blue-200 hover:from-blue-500 hover:to-indigo-500">
                         <i data-feather="plus" class="w-4 h-4"></i>
                         <span>Neues Gerät</span>
@@ -474,7 +474,7 @@
                             Asset hinzufügen
                         </button>
                     </div>
-                    <div class="overflow-x-hidden scrollbar-hide">
+                    <div class="overflow-x-hidden scrollbar-hide table-scroll">
                         <table class="w-full table-fixed text-sm">
                             <thead class="text-left text-slate-500">
                                 <tr class="border-b border-slate-200">
@@ -523,7 +523,7 @@
                             <span x-text="filteredDevices.length"></span> Einträge
                         </span>
                     </div>
-                    <div class="overflow-x-hidden scrollbar-hide">
+                    <div class="overflow-x-hidden scrollbar-hide table-scroll">
                         <table class="w-full table-fixed text-sm">
                             <thead class="text-left text-slate-500">
                                 <tr class="border-b border-slate-200">

--- a/templates/locations.html
+++ b/templates/locations.html
@@ -87,7 +87,7 @@
 
         <div class="app-main app-main--fixed">
             <header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 z-30 h-[82px]">
-                <div class="flex items-center gap-4">
+                <div class="app-header-title flex items-center gap-4">
                     <button type="button" data-sidebar-toggle aria-label="Navigation umschalten" class="inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white p-2 text-slate-600 shadow-sm hover:bg-slate-50">
                         <i data-feather="menu" class="w-4 h-4"></i>
                     </button>
@@ -96,7 +96,7 @@
                         <h1 class="text-2xl font-semibold text-slate-900">Standorte verwalten</h1>
                     </div>
                 </div>
-                <div class="flex items-center space-x-4">
+                <div class="app-header-actions flex items-center space-x-4">
                     <span class="text-sm text-slate-500">Angemeldet als {{ username }}</span>
                     <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
                         <span data-theme-icon aria-hidden="true">🌙</span>

--- a/templates/login.html
+++ b/templates/login.html
@@ -11,14 +11,14 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="/static/style.css">
 </head>
-<body class="min-h-screen bg-slate-950/5 text-slate-900 flex items-center justify-center px-6">
-    <div class="absolute right-6 top-6">
+<body class="auth-shell min-h-screen bg-slate-950/5 text-slate-900 flex items-center justify-center px-6">
+    <div class="auth-top-actions absolute right-6 top-6">
         <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
             <span data-theme-icon aria-hidden="true">🌙</span>
             <span data-theme-label>Dark Mode</span>
         </button>
     </div>
-    <div class="w-full max-w-md rounded-3xl bg-white shadow-2xl shadow-slate-200/60 border border-slate-200 p-8">
+    <div class="auth-card w-full max-w-md rounded-3xl bg-white shadow-2xl shadow-slate-200/60 border border-slate-200 p-8">
         <div class="flex items-center gap-3 mb-6">
             <span class="inline-flex items-center justify-center w-12 h-12 rounded-2xl bg-gradient-to-br from-blue-500 via-indigo-500 to-purple-500 text-white shadow-lg">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -11,14 +11,14 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="/static/style.css">
 </head>
-<body class="min-h-screen bg-slate-950/5 text-slate-900 flex items-center justify-center px-6">
-    <div class="absolute right-6 top-6">
+<body class="auth-shell min-h-screen bg-slate-950/5 text-slate-900 flex items-center justify-center px-6">
+    <div class="auth-top-actions absolute right-6 top-6">
         <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
             <span data-theme-icon aria-hidden="true">🌙</span>
             <span data-theme-label>Dark Mode</span>
         </button>
     </div>
-    <div class="w-full max-w-md rounded-3xl bg-white shadow-2xl shadow-slate-200/60 border border-slate-200 p-8">
+    <div class="auth-card w-full max-w-md rounded-3xl bg-white shadow-2xl shadow-slate-200/60 border border-slate-200 p-8">
         <div class="mb-6">
             <p class="text-xs uppercase tracking-[0.3em] text-slate-400">Security</p>
             <h1 class="text-2xl font-semibold text-slate-900">Passwort zurücksetzen</h1>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -103,7 +103,7 @@
         <div class="app-main app-main--fixed">
 		<header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 z-30 h-[82px]">
 			<!-- Linke Seite: Titel -->
-            <div class="flex items-center gap-4">
+            <div class="app-header-title flex items-center gap-4">
                 <button type="button" data-sidebar-toggle aria-label="Navigation umschalten" class="inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white p-2 text-slate-600 shadow-sm hover:bg-slate-50">
                     <i data-feather="menu" class="w-4 h-4"></i>
                 </button>
@@ -114,7 +114,7 @@
             </div>
 
 			<!-- Rechte Seite: Button-Gruppe -->
-			<div class="flex items-center space-x-4">
+			<div class="app-header-actions flex items-center space-x-4">
 			  <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
 				<span data-theme-icon aria-hidden="true">🌙</span>
 				<span data-theme-label>Dark Mode</span>

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -93,7 +93,7 @@
 
         <div class="app-main app-main--fixed">
             <header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 z-30 h-[82px]">
-                <div class="flex items-center gap-4">
+                <div class="app-header-title flex items-center gap-4">
                     <button type="button" data-sidebar-toggle aria-label="Navigation umschalten" class="inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white p-2 text-slate-600 shadow-sm hover:bg-slate-50">
                         <i data-feather="menu" class="w-4 h-4"></i>
                     </button>
@@ -102,7 +102,7 @@
                         <h1 class="text-2xl font-semibold text-slate-900">Ticket-System</h1>
                     </div>
                 </div>
-                <div class="flex flex-wrap items-center justify-end gap-3">
+                <div class="app-header-actions flex flex-wrap items-center justify-end gap-3">
                     <span class="text-sm text-slate-500 w-full sm:w-auto">Angemeldet als {{ username }}</span>
                     <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex w-full items-center justify-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:w-auto">
                         <span data-theme-icon aria-hidden="true">🌙</span>

--- a/templates/users.html
+++ b/templates/users.html
@@ -92,7 +92,7 @@
 
         <div class="app-main app-main--fixed">
             <header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 z-30 h-[82px]">
-                <div class="flex items-center gap-4">
+                <div class="app-header-title flex items-center gap-4">
                     <button type="button" data-sidebar-toggle aria-label="Navigation umschalten" class="inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white p-2 text-slate-600 shadow-sm hover:bg-slate-50">
                         <i data-feather="menu" class="w-4 h-4"></i>
                     </button>
@@ -101,7 +101,7 @@
                         <h1 class="text-2xl font-semibold text-slate-900">Benutzerverwaltung</h1>
                     </div>
                 </div>
-                <div class="flex items-center space-x-4">
+                <div class="app-header-actions flex items-center space-x-4">
                     <span class="text-sm text-slate-500">Angemeldet als {{ username }}</span>
                     <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
                         <span data-theme-icon aria-hidden="true">🌙</span>

--- a/templates/verify_otp.html
+++ b/templates/verify_otp.html
@@ -11,14 +11,14 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="/static/style.css">
 </head>
-<body class="min-h-screen bg-slate-950/5 text-slate-900 flex items-center justify-center px-6">
-    <div class="absolute right-6 top-6">
+<body class="auth-shell min-h-screen bg-slate-950/5 text-slate-900 flex items-center justify-center px-6">
+    <div class="auth-top-actions absolute right-6 top-6">
         <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
             <span data-theme-icon aria-hidden="true">🌙</span>
             <span data-theme-label>Dark Mode</span>
         </button>
     </div>
-    <div class="w-full max-w-md rounded-3xl bg-white shadow-2xl shadow-slate-200/60 border border-slate-200 p-8">
+    <div class="auth-card w-full max-w-md rounded-3xl bg-white shadow-2xl shadow-slate-200/60 border border-slate-200 p-8">
         <div class="mb-6">
             <p class="text-xs uppercase tracking-[0.3em] text-slate-400">Security</p>
             <h1 class="text-2xl font-semibold text-slate-900">OTP-Verifizierung</h1>


### PR DESCRIPTION
### Motivation
- The site had a subpar mobile experience and needed a focused UI/UX polish so the web app feels smooth and native-like on phones. 
- Goal was to make headers, action groups, tables and auth screens stack and behave nicely on small viewports without changing backend logic.

### Description
- Added a mobile-specific CSS block (`@media (max-width: 640px)`) in `static/style.css` introducing layout adjustments, header/action stacking, touch-friendly table scrolling (`.table-scroll`), and auth-card helpers (`.auth-shell`, `.auth-card`, `.auth-top-actions`).
- Standardized header structure by splitting into `app-header-title` and `app-header-actions` and applied this across `templates/index.html`, `templates/tickets.html`, `templates/users.html`, `templates/stats.html`, and `templates/locations.html` for consistent responsive stacking.
- Wrapped wide tables with a `table-scroll` container in `templates/index.html` to enable horizontal scrolling on small screens while keeping desktop layout intact.
- Updated auth pages (`templates/login.html`, `templates/reset_password.html`, `templates/verify_otp.html`) to use the new `auth-*` helpers to improve spacing and top-action placement on mobile.

### Testing
- Installed Python dependencies with `pip install -r requirements.txt` which completed successfully.
- Launched the app via `python app.py` and verified the server returned `200` for `/login` and served static assets.
- Ran a Playwright script that opened the app in a mobile viewport (`390x844`) and saved a screenshot (`artifacts/mobile-login.png`) to validate the mobile login layout; the script completed and produced the artifact.
- All automated checks performed (dependency install, server start, Playwright screenshot) succeeded; no unit tests were required because changes are UI-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f840075c832db4b49b3b7e66cf08)