### PR TITLE
Refine mobile header buttons

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -283,18 +283,18 @@
                     <h1 class="text-2xl font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h1>
                     </div>
                 </div>
-                <div class="flex items-center space-x-3">
+                <div class="flex items-center gap-2 sm:gap-3">
                     <button @click="openAddDeviceModal()" class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-blue-200 hover:from-blue-500 hover:to-indigo-500">
                         <i data-feather="plus" class="w-4 h-4"></i>
                         <span>Neues Gerät</span>
                     </button>
-                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white p-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
                         <span data-theme-icon aria-hidden="true">🌙</span>
-                        <span data-theme-label>Dark Mode</span>
+                        <span data-theme-label class="sr-only sm:not-sr-only">Dark Mode</span>
                     </button>
-                    <button onclick="logout()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+                    <button onclick="logout()" class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white p-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
                         <i data-feather="log-out" class="w-4 h-4"></i>
-                        Abmelden
+                        <span class="sr-only sm:not-sr-only">Abmelden</span>
                     </button>
                 </div>
             </header>

--- a/templates/locations.html
+++ b/templates/locations.html
@@ -96,15 +96,15 @@
                         <h1 class="text-2xl font-semibold text-slate-900">Standorte verwalten</h1>
                     </div>
                 </div>
-                <div class="flex items-center space-x-4">
-                    <span class="text-sm text-slate-500">Angemeldet als {{ username }}</span>
-                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+                <div class="flex items-center gap-2 sm:gap-3">
+                    <span class="hidden text-sm text-slate-500 sm:inline">Angemeldet als {{ username }}</span>
+                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white p-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
                         <span data-theme-icon aria-hidden="true">🌙</span>
-                        <span data-theme-label>Dark Mode</span>
+                        <span data-theme-label class="sr-only sm:not-sr-only">Dark Mode</span>
                     </button>
-                    <button onclick="logout()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+                    <button onclick="logout()" class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white p-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
                         <i data-feather="log-out" class="w-4 h-4"></i>
-                        Abmelden
+                        <span class="sr-only sm:not-sr-only">Abmelden</span>
                     </button>
                 </div>
                 <script>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -114,15 +114,15 @@
             </div>
 
 			<!-- Rechte Seite: Button-Gruppe -->
-			<div class="flex items-center space-x-4">
-			  <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+			<div class="flex items-center gap-2 sm:gap-3">
+			  <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white p-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
 				<span data-theme-icon aria-hidden="true">🌙</span>
-				<span data-theme-label>Dark Mode</span>
+				<span data-theme-label class="sr-only sm:not-sr-only">Dark Mode</span>
 			  </button>
 			  <!-- Logout Button -->
-			  <button onclick="logout()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+			  <button onclick="logout()" class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white p-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
 				<i data-feather="log-out" class="w-4 h-4"></i>
-				Abmelden
+				<span class="sr-only sm:not-sr-only">Abmelden</span>
 			  </button>
 			</div>
 

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -102,20 +102,20 @@
                         <h1 class="text-2xl font-semibold text-slate-900">Ticket-System</h1>
                     </div>
                 </div>
-                <div class="flex flex-wrap items-center justify-end gap-3">
-                    <span class="text-sm text-slate-500 w-full sm:w-auto">Angemeldet als {{ username }}</span>
-                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex w-full items-center justify-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:w-auto">
+                <div class="flex items-center justify-end gap-2 sm:gap-3">
+                    <span class="hidden text-sm text-slate-500 sm:inline">Angemeldet als {{ username }}</span>
+                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white p-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
                         <span data-theme-icon aria-hidden="true">🌙</span>
-                        <span data-theme-label>Dark Mode</span>
+                        <span data-theme-label class="sr-only sm:not-sr-only">Dark Mode</span>
                     </button>
-                    <button onclick="logout()" class="inline-flex w-full items-center justify-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:w-auto">
+                    <button onclick="logout()" class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white p-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
                         <i data-feather="log-out" class="w-4 h-4"></i>
-                        Abmelden
+                        <span class="sr-only sm:not-sr-only">Abmelden</span>
                     </button>
                     {% if 'tickets.create' in permissions %}
-                    <button @click="openNewTicket" class="inline-flex w-full items-center justify-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-700 shadow-sm hover:bg-amber-100 sm:w-auto">
+                    <button @click="openNewTicket" class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-amber-200 bg-amber-50 p-2 text-sm font-semibold text-amber-700 shadow-sm hover:bg-amber-100 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
                         <i data-feather="plus-circle" class="w-4 h-4"></i>
-                        Ticket erstellen
+                        <span class="sr-only sm:not-sr-only">Ticket erstellen</span>
                     </button>
                     {% endif %}
                 </div>

--- a/templates/users.html
+++ b/templates/users.html
@@ -101,15 +101,15 @@
                         <h1 class="text-2xl font-semibold text-slate-900">Benutzerverwaltung</h1>
                     </div>
                 </div>
-                <div class="flex items-center space-x-4">
-                    <span class="text-sm text-slate-500">Angemeldet als {{ username }}</span>
-                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+                <div class="flex items-center gap-2 sm:gap-3">
+                    <span class="hidden text-sm text-slate-500 sm:inline">Angemeldet als {{ username }}</span>
+                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white p-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
                         <span data-theme-icon aria-hidden="true">🌙</span>
-                        <span data-theme-label>Dark Mode</span>
+                        <span data-theme-label class="sr-only sm:not-sr-only">Dark Mode</span>
                     </button>
-                    <button onclick="logout()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
+                    <button onclick="logout()" class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white p-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
                         <i data-feather="log-out" class="w-4 h-4"></i>
-                        Abmelden
+                        <span class="sr-only sm:not-sr-only">Abmelden</span>
                     </button>
                 </div>
                 <script>


### PR DESCRIPTION
### Motivation
- Reduce header clutter and prevent wrapping on small screens by making theme toggle, logout and ticket-create actions compact icon-only buttons while keeping labels accessible on larger screens.
- Improve consistency across pages (Dashboard, Tickets, Locations, Stats, Users) so mobile headers behave uniformly.

### Description
- Replaced full-width text buttons with compact icon buttons on small screens and added responsive classes to preserve full labels on larger viewports in `templates/index.html`, `templates/tickets.html`, `templates/locations.html`, `templates/stats.html`, and `templates/users.html`.
- Hid the username on small screens using `hidden sm:inline` to reduce header height and prevent wrap, and switched layout gaps to `gap-2 sm:gap-3` for tighter mobile spacing.
- Kept accessible labels by adding `sr-only sm:not-sr-only` to button label spans so screen readers still announce actions.

### Testing
- Installed Python dependencies with `pip install -r requirements.txt`, which completed successfully (including installing `ldap3`).
- Started the app with `python app.py`, which launched for testing purposes without runtime import errors after dependencies were installed.
- Captured a mobile screenshot of `/tickets` using a Playwright script to verify the header layout, and the capture succeeded producing `artifacts/tickets-mobile.png` (an earlier attempt had a transient `ERR_EMPTY_RESPONSE` but the final run succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973fa6b40c8832d935d24b3e861f8ce)