### PR TITLE
Close mobile sidebar on outside click

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -42,3 +42,16 @@ sidebarToggleButtons.forEach((button) => {
     }
   });
 });
+
+document.addEventListener('click', (event) => {
+  if (!mobileQuery.matches || bodyElement.classList.contains('sidebar-collapsed')) {
+    return;
+  }
+
+  const target = event.target;
+  if (target.closest('[data-sidebar-toggle]') || target.closest('.app-sidebar')) {
+    return;
+  }
+
+  setSidebarCollapsed(true);
+});


### PR DESCRIPTION
### Motivation
- Improve mobile UX by automatically closing the left sidebar when the user taps outside the menu area on small screens.

### Description
- Add a `document` `click` listener in `static/ui.js` that detects mobile view (`(max-width: 1024px)`) and collapses the sidebar via `setSidebarCollapsed(true)` when the click is outside `.app-sidebar` and not on a `[data-sidebar-toggle]` control.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973fc2a3dac832da1aed344732af5f0)