### PR TITLE
Add asset lifecycle tracking and ticket-asset associations

### DIFF
--- a/app.py
+++ b/app.py
@@ -604,6 +604,12 @@ def init_db():
                 name TEXT NOT NULL,
                 notes TEXT,
                 specs TEXT,
+                acquisition_date TEXT,
+                commissioning_date TEXT,
+                warranty_end TEXT,
+                depreciation_months INTEGER,
+                retirement_date TEXT,
+                retirement_reason TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         ''')
@@ -618,6 +624,19 @@ def init_db():
         except sqlite3.OperationalError:
             pass
 
+        for column, column_type in (
+            ("acquisition_date", "TEXT"),
+            ("commissioning_date", "TEXT"),
+            ("warranty_end", "TEXT"),
+            ("depreciation_months", "INTEGER"),
+            ("retirement_date", "TEXT"),
+            ("retirement_reason", "TEXT"),
+        ):
+            try:
+                c.execute(f'ALTER TABLE assets ADD COLUMN {column} {column_type}')
+            except sqlite3.OperationalError:
+                pass
+
         c.execute('''
             CREATE TABLE IF NOT EXISTS asset_devices (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -626,6 +645,41 @@ def init_db():
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 FOREIGN KEY (asset_id) REFERENCES assets(id),
                 FOREIGN KEY (device_id) REFERENCES devices(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS asset_relation_types (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS asset_relations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_id INTEGER NOT NULL,
+                related_asset_id INTEGER NOT NULL,
+                relation_type_id INTEGER,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(asset_id, related_asset_id, relation_type_id),
+                FOREIGN KEY (asset_id) REFERENCES assets(id),
+                FOREIGN KEY (related_asset_id) REFERENCES assets(id),
+                FOREIGN KEY (relation_type_id) REFERENCES asset_relation_types(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS ticket_assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ticket_id INTEGER NOT NULL,
+                asset_id INTEGER NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(ticket_id, asset_id),
+                FOREIGN KEY (ticket_id) REFERENCES tickets(id),
+                FOREIGN KEY (asset_id) REFERENCES assets(id)
             )
         ''')
 
@@ -818,6 +872,18 @@ def init_db():
             INSERT OR IGNORE INTO ticket_categories (name, description, color, sla_hours, is_default)
             VALUES (?, ?, ?, ?, ?)
         ''', default_ticket_categories)
+
+        default_relation_types = [
+            ("hostet", "Asset stellt Ressourcen für ein anderes bereit"),
+            ("nutzt", "Asset nutzt ein anderes Asset"),
+            ("verbunden mit", "Direkte technische Verbindung"),
+            ("gehört zu", "Asset ist Teil eines größeren Systems"),
+            ("ersetzt", "Asset ersetzt ein anderes")
+        ]
+        c.executemany('''
+            INSERT OR IGNORE INTO asset_relation_types (name, description)
+            VALUES (?, ?)
+        ''', default_relation_types)
 
         try:
             c.execute('ALTER TABLE devices ADD COLUMN location_id INTEGER')
@@ -1033,6 +1099,80 @@ def normalize_ticket_row(row):
     except json.JSONDecodeError:
         ticket['custom_fields'] = []
     return ticket
+
+def parse_date(value):
+    if not value:
+        return None
+    for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(value).date()
+    except ValueError:
+        return None
+
+def warranty_status(warranty_end):
+    parsed = parse_date(warranty_end)
+    if not parsed:
+        return "Unbekannt"
+    today = datetime.utcnow().date()
+    return "Aktiv" if parsed >= today else "Abgelaufen"
+
+def extract_manufacturer(specs):
+    for key in ("Hersteller", "Manufacturer", "Vendor", "Marke"):
+        value = specs.get(key)
+        if value:
+            return value
+    return None
+
+def summarize_device_info(device_rows):
+    serials = []
+    locations = []
+    for row in device_rows:
+        serial_number = row.get("serial_number") if isinstance(row, dict) else row["serial_number"]
+        location_name = row.get("location_name") if isinstance(row, dict) else row["location_name"]
+        if serial_number and serial_number not in serials:
+            serials.append(serial_number)
+        if location_name and location_name not in locations:
+            locations.append(location_name)
+    return serials, locations
+
+def get_asset_devices_info(db, asset_id):
+    rows = db.execute('''
+        SELECT d.serial_number, l.name as location_name
+        FROM devices d
+        JOIN asset_devices ad ON ad.device_id = d.id
+        LEFT JOIN locations l ON d.location_id = l.id
+        WHERE ad.asset_id = ?
+    ''', (asset_id,)).fetchall()
+    return [dict(row) for row in rows]
+
+def build_asset_summary(db, asset_row, device_rows=None):
+    asset = dict(asset_row)
+    try:
+        asset_specs = json.loads(asset.get('specs') or '{}')
+    except json.JSONDecodeError:
+        asset_specs = {}
+    asset['specs'] = asset_specs
+    device_rows = device_rows if device_rows is not None else get_asset_devices_info(db, asset["id"])
+    serials, locations = summarize_device_info(device_rows)
+    asset['serial_numbers'] = serials
+    asset['locations'] = locations
+    asset['manufacturer'] = extract_manufacturer(asset_specs)
+    asset['warranty_status'] = warranty_status(asset.get("warranty_end"))
+    return asset
+
+def fetch_ticket_assets(db, ticket_id):
+    rows = db.execute('''
+        SELECT a.*
+        FROM assets a
+        JOIN ticket_assets ta ON ta.asset_id = a.id
+        WHERE ta.ticket_id = ?
+        ORDER BY a.name
+    ''', (ticket_id,)).fetchall()
+    return [build_asset_summary(db, row) for row in rows]
 
 def get_ad_settings(db):
     settings = db.execute('SELECT * FROM ad_settings WHERE id = 1').fetchone()
@@ -1450,20 +1590,49 @@ def manage_assets():
         name = (data.get('name') or '').strip()
         notes = (data.get('notes') or '').strip()
         specs = json.dumps(data.get('specs', {}))
+        acquisition_date = (data.get('acquisition_date') or '').strip() or None
+        commissioning_date = (data.get('commissioning_date') or '').strip() or None
+        warranty_end = (data.get('warranty_end') or '').strip() or None
+        depreciation_months = data.get('depreciation_months')
+        retirement_date = (data.get('retirement_date') or '').strip() or None
+        retirement_reason = (data.get('retirement_reason') or '').strip()
         device_ids = data.get('device_ids') or []
+        relations = data.get('relations') or []
         if not name:
             return jsonify({"error": "Name ist erforderlich"}), 400
         try:
             cursor = db.execute('''
-                INSERT INTO assets (name, notes, specs)
-                VALUES (?, ?, ?)
-            ''', (name, notes, specs))
+                INSERT INTO assets (
+                    name, notes, specs, acquisition_date, commissioning_date,
+                    warranty_end, depreciation_months, retirement_date, retirement_reason
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ''', (
+                name,
+                notes,
+                specs,
+                acquisition_date,
+                commissioning_date,
+                warranty_end,
+                depreciation_months,
+                retirement_date,
+                retirement_reason
+            ))
             asset_id = cursor.lastrowid
             for device_id in device_ids:
                 db.execute('''
                     INSERT INTO asset_devices (asset_id, device_id)
                     VALUES (?, ?)
                 ''', (asset_id, device_id))
+            for relation in relations:
+                related_asset_id = relation.get("related_asset_id")
+                relation_type_id = relation.get("relation_type_id")
+                if not related_asset_id or related_asset_id == asset_id:
+                    continue
+                db.execute('''
+                    INSERT OR IGNORE INTO asset_relations (asset_id, related_asset_id, relation_type_id)
+                    VALUES (?, ?, ?)
+                ''', (asset_id, related_asset_id, relation_type_id))
             log_activity(db, "create", "asset", asset_id, {"name": name})
             db.commit()
             return jsonify({"status": "created", "id": asset_id}), 201
@@ -1481,11 +1650,7 @@ def manage_assets():
     ''').fetchall()
     result = []
     for row in assets:
-        asset = dict(row)
-        try:
-            asset['specs'] = json.loads(asset.get('specs') or '{}')
-        except json.JSONDecodeError:
-            asset['specs'] = {}
+        asset = build_asset_summary(db, row)
         result.append(asset)
     return jsonify(result)
 
@@ -1509,12 +1674,33 @@ def asset_detail(asset_id):
             WHERE ad.asset_id = ?
             ORDER BY d.created_at DESC
         ''', (asset_id,)).fetchall()
-        asset = dict(asset_row)
-        try:
-            asset['specs'] = json.loads(asset.get('specs') or '{}')
-        except json.JSONDecodeError:
-            asset['specs'] = {}
+        asset = build_asset_summary(db, asset_row, device_rows=[dict(row) for row in device_rows])
         asset['devices'] = [dict(row) for row in device_rows]
+        relation_rows = db.execute('''
+            SELECT ar.id, ar.asset_id, ar.related_asset_id, ar.relation_type_id,
+                   rt.name as relation_type_name,
+                   a.name as asset_name, ra.name as related_asset_name
+            FROM asset_relations ar
+            LEFT JOIN asset_relation_types rt ON ar.relation_type_id = rt.id
+            LEFT JOIN assets a ON ar.asset_id = a.id
+            LEFT JOIN assets ra ON ar.related_asset_id = ra.id
+            WHERE ar.asset_id = ? OR ar.related_asset_id = ?
+            ORDER BY ar.created_at DESC
+        ''', (asset_id, asset_id)).fetchall()
+        relations = []
+        for row in relation_rows:
+            item = dict(row)
+            item["direction"] = "outgoing" if item["asset_id"] == asset_id else "incoming"
+            relations.append(item)
+        asset["relations"] = relations
+        open_ticket_rows = db.execute('''
+            SELECT t.id, t.title, t.status, t.priority, t.created_at
+            FROM tickets t
+            JOIN ticket_assets ta ON ta.ticket_id = t.id
+            WHERE ta.asset_id = ? AND t.status NOT IN ('resolved', 'closed')
+            ORDER BY t.created_at DESC
+        ''', (asset_id,)).fetchall()
+        asset["open_tickets"] = [dict(row) for row in open_ticket_rows]
         return jsonify(asset)
 
     if request.method == 'PUT':
@@ -1524,31 +1710,75 @@ def asset_detail(asset_id):
         name = (data.get('name') or '').strip()
         notes = (data.get('notes') or '').strip()
         specs = json.dumps(data.get('specs', {}))
+        acquisition_date = (data.get('acquisition_date') or '').strip() or None
+        commissioning_date = (data.get('commissioning_date') or '').strip() or None
+        warranty_end = (data.get('warranty_end') or '').strip() or None
+        depreciation_months = data.get('depreciation_months')
+        retirement_date = (data.get('retirement_date') or '').strip() or None
+        retirement_reason = (data.get('retirement_reason') or '').strip()
         device_ids = data.get('device_ids') or []
+        relations = data.get('relations') or []
         if not name:
             return jsonify({"error": "Name ist erforderlich"}), 400
         db.execute('''
             UPDATE assets
-            SET name = ?, notes = ?, specs = ?
+            SET name = ?, notes = ?, specs = ?, acquisition_date = ?, commissioning_date = ?,
+                warranty_end = ?, depreciation_months = ?, retirement_date = ?, retirement_reason = ?
             WHERE id = ?
-        ''', (name, notes, specs, asset_id))
+        ''', (
+            name,
+            notes,
+            specs,
+            acquisition_date,
+            commissioning_date,
+            warranty_end,
+            depreciation_months,
+            retirement_date,
+            retirement_reason,
+            asset_id
+        ))
         db.execute('DELETE FROM asset_devices WHERE asset_id = ?', (asset_id,))
         for device_id in device_ids:
             db.execute('''
                 INSERT INTO asset_devices (asset_id, device_id)
                 VALUES (?, ?)
             ''', (asset_id, device_id))
+        db.execute('DELETE FROM asset_relations WHERE asset_id = ?', (asset_id,))
+        for relation in relations:
+            related_asset_id = relation.get("related_asset_id")
+            relation_type_id = relation.get("relation_type_id")
+            if not related_asset_id or related_asset_id == asset_id:
+                continue
+            db.execute('''
+                INSERT OR IGNORE INTO asset_relations (asset_id, related_asset_id, relation_type_id)
+                VALUES (?, ?, ?)
+            ''', (asset_id, related_asset_id, relation_type_id))
         log_activity(db, "update", "asset", asset_id, {"name": name})
         db.commit()
         return jsonify({"status": "updated"}), 200
 
     if not user_can('assets.manage'):
         return jsonify({"error": "Keine Berechtigung"}), 403
+    db.execute('DELETE FROM ticket_assets WHERE asset_id = ?', (asset_id,))
     db.execute('DELETE FROM asset_devices WHERE asset_id = ?', (asset_id,))
+    db.execute('DELETE FROM asset_relations WHERE asset_id = ? OR related_asset_id = ?', (asset_id, asset_id))
     db.execute('DELETE FROM assets WHERE id = ?', (asset_id,))
     log_activity(db, "delete", "asset", asset_id)
     db.commit()
     return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/asset-relation-types', methods=['GET'])
+@login_required
+def asset_relation_types():
+    db = get_db()
+    if not (user_can('assets.view') or user_can('assets.manage')):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    rows = db.execute('''
+        SELECT id, name, description
+        FROM asset_relation_types
+        ORDER BY name
+    ''').fetchall()
+    return jsonify([dict(row) for row in rows])
 
 @app.route('/api/locations', methods=['GET', 'POST'])
 @login_required
@@ -1702,6 +1932,7 @@ def tickets():
             due_date = ''
         tags = json.dumps(data.get('tags') or [])
         custom_fields = json.dumps(data.get('custom_fields') or [])
+        asset_ids = data.get('asset_ids') or []
         if not title or not description:
             return jsonify({"error": "Titel und Beschreibung sind erforderlich"}), 400
         cursor = db.execute('''
@@ -1715,6 +1946,11 @@ def tickets():
             session.get('username'), assignee, assignee_email, due_date, tags, custom_fields
         ))
         ticket_id = cursor.lastrowid
+        for asset_id in asset_ids:
+            db.execute('''
+                INSERT OR IGNORE INTO ticket_assets (ticket_id, asset_id)
+                VALUES (?, ?)
+            ''', (ticket_id, asset_id))
         log_activity(db, "create", "ticket", ticket_id, {"title": title})
         db.commit()
         ticket = fetch_ticket(db, ticket_id)
@@ -1796,6 +2032,9 @@ def ticket_detail(ticket_id):
         ''', (ticket_id,)).fetchall()
         ticket['comments'] = [dict(row) for row in comments]
         ticket['watchers'] = [dict(row) for row in watchers]
+        ticket_assets = fetch_ticket_assets(db, ticket_id)
+        ticket['assets'] = ticket_assets
+        ticket['asset_ids'] = [asset["id"] for asset in ticket_assets]
         return jsonify(ticket)
 
     if request.method == 'PUT':
@@ -1816,6 +2055,7 @@ def ticket_detail(ticket_id):
         due_date = (data.get('due_date') or ticket.get('due_date') or '').strip()
         tags = json.dumps(data.get('tags') or json.loads(ticket.get('tags') or '[]'))
         custom_fields = json.dumps(data.get('custom_fields') or json.loads(ticket.get('custom_fields') or '[]'))
+        asset_ids = data.get('asset_ids')
         status_changed = status != ticket.get('status')
 
         db.execute('''
@@ -1828,6 +2068,13 @@ def ticket_detail(ticket_id):
             title, description, category_id, priority, status, requester_name, requester_email,
             assignee, assignee_email, due_date, tags, custom_fields, ticket_id
         ))
+        if asset_ids is not None:
+            db.execute('DELETE FROM ticket_assets WHERE ticket_id = ?', (ticket_id,))
+            for asset_id in asset_ids:
+                db.execute('''
+                    INSERT OR IGNORE INTO ticket_assets (ticket_id, asset_id)
+                    VALUES (?, ?)
+                ''', (ticket_id, asset_id))
         log_activity(db, "update", "ticket", ticket_id, {"title": title})
         db.commit()
         updated_ticket = fetch_ticket(db, ticket_id)
@@ -1844,6 +2091,7 @@ def ticket_detail(ticket_id):
         return jsonify({"error": "Keine Berechtigung"}), 403
     db.execute('DELETE FROM ticket_comments WHERE ticket_id = ?', (ticket_id,))
     db.execute('DELETE FROM ticket_watchers WHERE ticket_id = ?', (ticket_id,))
+    db.execute('DELETE FROM ticket_assets WHERE ticket_id = ?', (ticket_id,))
     db.execute('DELETE FROM tickets WHERE id = ?', (ticket_id,))
     log_activity(db, "delete", "ticket", ticket_id)
     db.commit()

--- a/static/script.js
+++ b/static/script.js
@@ -7,6 +7,7 @@ document.addEventListener('alpine:init', () => {
         filteredDevices: [],
         allDevices: [],
         assets: [],
+        relationTypes: [],
         activeCategory: null,
         searchQuery: '',
         sortDropdownOpen: false,
@@ -69,7 +70,14 @@ document.addEventListener('alpine:init', () => {
             name: '',
             notes: '',
             specs: [],
-            device_ids: []
+            device_ids: [],
+            acquisition_date: '',
+            commissioning_date: '',
+            warranty_end: '',
+            depreciation_months: '',
+            retirement_date: '',
+            retirement_reason: '',
+            relations: []
         },
 
         // Initialization
@@ -79,6 +87,7 @@ document.addEventListener('alpine:init', () => {
             await this.loadAllDevices();
             await this.loadDevices();
             await this.loadAssets();
+            await this.loadRelationTypes();
             await this.loadFeatureFlags();
             await this.loadMaintenanceSummary();
             await this.loadActivityFeed();
@@ -173,6 +182,13 @@ document.addEventListener('alpine:init', () => {
             const response = await fetch('/api/assets');
             if (response.ok) {
                 this.assets = await response.json();
+            }
+        },
+
+        async loadRelationTypes() {
+            const response = await fetch('/api/asset-relation-types');
+            if (response.ok) {
+                this.relationTypes = await response.json();
             }
         },
 
@@ -702,10 +718,20 @@ document.addEventListener('alpine:init', () => {
                 name: '',
                 notes: '',
                 specs: [],
-                device_ids: []
+                device_ids: [],
+                acquisition_date: '',
+                commissioning_date: '',
+                warranty_end: '',
+                depreciation_months: '',
+                retirement_date: '',
+                retirement_reason: '',
+                relations: []
             };
             if (this.allDevices.length === 0) {
                 await this.loadAllDevices();
+            }
+            if (this.relationTypes.length === 0) {
+                await this.loadRelationTypes();
             }
             this.isAssetModalOpen = true;
         },
@@ -727,8 +753,24 @@ document.addEventListener('alpine:init', () => {
                         name: key,
                         value
                     })),
-                    device_ids: (data.devices || []).map(device => device.id)
+                    device_ids: (data.devices || []).map(device => device.id),
+                    acquisition_date: data.acquisition_date || '',
+                    commissioning_date: data.commissioning_date || '',
+                    warranty_end: data.warranty_end || '',
+                    depreciation_months: data.depreciation_months ?? '',
+                    retirement_date: data.retirement_date || '',
+                    retirement_reason: data.retirement_reason || '',
+                    relations: (data.relations || [])
+                        .filter(relation => relation.direction === 'outgoing')
+                        .map((relation) => ({
+                            id: relation.id || crypto.randomUUID(),
+                            related_asset_id: relation.related_asset_id,
+                            relation_type_id: relation.relation_type_id || ''
+                        }))
                 };
+                if (this.relationTypes.length === 0) {
+                    await this.loadRelationTypes();
+                }
                 this.isAssetModalOpen = true;
             } catch (error) {
                 console.error('Error loading asset:', error);
@@ -752,6 +794,18 @@ document.addEventListener('alpine:init', () => {
             this.currentAsset.specs = this.currentAsset.specs.filter(spec => spec.id !== specId);
         },
 
+        addAssetRelation() {
+            this.currentAsset.relations.push({
+                id: crypto.randomUUID(),
+                related_asset_id: '',
+                relation_type_id: ''
+            });
+        },
+
+        removeAssetRelation(relationId) {
+            this.currentAsset.relations = this.currentAsset.relations.filter(relation => relation.id !== relationId);
+        },
+
         async saveAsset() {
             try {
                 const specs = {};
@@ -765,7 +819,19 @@ document.addEventListener('alpine:init', () => {
                     name: this.currentAsset.name,
                     notes: this.currentAsset.notes,
                     specs,
-                    device_ids: this.currentAsset.device_ids
+                    device_ids: this.currentAsset.device_ids,
+                    acquisition_date: this.currentAsset.acquisition_date,
+                    commissioning_date: this.currentAsset.commissioning_date,
+                    warranty_end: this.currentAsset.warranty_end,
+                    depreciation_months: this.currentAsset.depreciation_months || null,
+                    retirement_date: this.currentAsset.retirement_date,
+                    retirement_reason: this.currentAsset.retirement_reason,
+                    relations: this.currentAsset.relations
+                        .filter(relation => relation.related_asset_id)
+                        .map((relation) => ({
+                            related_asset_id: relation.related_asset_id,
+                            relation_type_id: relation.relation_type_id || null
+                        }))
                 };
 
                 let response;

--- a/static/tickets.js
+++ b/static/tickets.js
@@ -3,6 +3,7 @@ document.addEventListener('alpine:init', () => {
         tickets: [],
         categories: [],
         alerts: [],
+        assets: [],
         selectedTicket: null,
         userPermissions: window.inventoryPermissions || [],
         isSuperuser: window.inventoryIsSuperuser || false,
@@ -41,7 +42,8 @@ document.addEventListener('alpine:init', () => {
             assignee_email: '',
             due_date: '',
             tags: '',
-            custom_fields: []
+            custom_fields: [],
+            asset_ids: []
         },
         newComment: '',
         internalComment: false,
@@ -78,6 +80,7 @@ document.addEventListener('alpine:init', () => {
 
         async init() {
             await this.loadCategories();
+            await this.loadAssets();
             await this.loadTickets();
             if (this.can('ticket_alerts.manage')) {
                 await this.loadAlerts();
@@ -128,6 +131,13 @@ document.addEventListener('alpine:init', () => {
             this.$nextTick(() => feather.replace());
         },
 
+        async loadAssets() {
+            const response = await fetch('/api/assets');
+            if (response.ok) {
+                this.assets = await response.json();
+            }
+        },
+
         async loadStats() {
             const response = await fetch('/api/tickets');
             if (!response.ok) return;
@@ -145,6 +155,9 @@ document.addEventListener('alpine:init', () => {
             const response = await fetch(`/api/tickets/${ticket.id}`);
             if (response.ok) {
                 this.selectedTicket = await response.json();
+                if (!this.selectedTicket.asset_ids) {
+                    this.selectedTicket.asset_ids = (this.selectedTicket.assets || []).map((asset) => asset.id);
+                }
                 this.newComment = '';
                 this.internalComment = false;
                 this.newWatcher = '';
@@ -170,7 +183,8 @@ document.addEventListener('alpine:init', () => {
                 assignee_email: this.selectedTicket.assignee_email,
                 due_date: this.selectedTicket.due_date,
                 tags: this.selectedTicket.tags,
-                custom_fields: this.selectedTicket.custom_fields
+                custom_fields: this.selectedTicket.custom_fields,
+                asset_ids: this.selectedTicket.asset_ids
             };
             const response = await fetch(`/api/tickets/${this.selectedTicket.id}`, {
                 method: 'PUT',
@@ -178,6 +192,7 @@ document.addEventListener('alpine:init', () => {
                 body: JSON.stringify(payload)
             });
             if (response.ok) {
+                await this.selectTicket(this.selectedTicket);
                 await this.loadTickets();
                 await this.loadStats();
             }
@@ -201,7 +216,8 @@ document.addEventListener('alpine:init', () => {
                 assignee_email: this.newTicket.assignee_email,
                 due_date: this.newTicket.due_date,
                 tags,
-                custom_fields: customFields
+                custom_fields: customFields,
+                asset_ids: this.newTicket.asset_ids
             };
 
             const response = await fetch('/api/tickets', {
@@ -223,7 +239,8 @@ document.addEventListener('alpine:init', () => {
                     assignee_email: '',
                     due_date: '',
                     tags: '',
-                    custom_fields: []
+                    custom_fields: [],
+                    asset_ids: []
                 };
                 await this.loadTickets();
                 await this.loadStats();
@@ -257,6 +274,11 @@ document.addEventListener('alpine:init', () => {
                 await this.selectTicket(this.selectedTicket);
                 this.newWatcher = '';
             }
+        },
+
+        selectedAssetsForNewTicket() {
+            const selectedIds = new Set(this.newTicket.asset_ids || []);
+            return this.assets.filter((asset) => selectedIds.has(asset.id));
         },
 
         async removeWatcher(watcherId) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -774,6 +774,37 @@
                     </div>
 
                     <div class="rounded-2xl border border-slate-200 bg-white p-4">
+                        <p class="text-sm font-semibold text-slate-900">Lebenszyklus</p>
+                        <div class="mt-3 grid gap-2 text-sm text-slate-600">
+                            <div class="flex justify-between">
+                                <span>Anschaffungsdatum</span>
+                                <span class="font-semibold text-slate-900" x-text="selectedAsset?.acquisition_date || '-'"></span>
+                            </div>
+                            <div class="flex justify-between">
+                                <span>Inbetriebnahme</span>
+                                <span class="font-semibold text-slate-900" x-text="selectedAsset?.commissioning_date || '-'"></span>
+                            </div>
+                            <div class="flex justify-between">
+                                <span>Garantieende</span>
+                                <span class="font-semibold text-slate-900" x-text="selectedAsset?.warranty_end || '-'"></span>
+                            </div>
+                            <div class="flex justify-between">
+                                <span>Garantie-Status</span>
+                                <span class="font-semibold text-slate-900" x-text="selectedAsset?.warranty_status || '-'"></span>
+                            </div>
+                            <div class="flex justify-between">
+                                <span>Abschreibung</span>
+                                <span class="font-semibold text-slate-900" x-text="selectedAsset?.depreciation_months ? `${selectedAsset.depreciation_months} Monate` : '-'"></span>
+                            </div>
+                            <div class="flex justify-between">
+                                <span>Aussonderung</span>
+                                <span class="font-semibold text-slate-900" x-text="selectedAsset?.retirement_date || '-'"></span>
+                            </div>
+                        </div>
+                        <p class="mt-2 text-xs text-slate-500" x-text="selectedAsset?.retirement_reason || ''"></p>
+                    </div>
+
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4">
                         <p class="text-sm font-semibold text-slate-900">Spezifikationen</p>
                         <div class="mt-3 space-y-2 text-sm text-slate-600">
                             <template x-for="spec in Object.entries(selectedAsset?.specs || {})" :key="spec[0]">
@@ -811,6 +842,42 @@
                             <p x-show="(selectedAsset?.devices || []).length === 0" class="text-xs text-indigo-500">Keine Geräte zugeordnet.</p>
                         </div>
                     </div>
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-slate-900">Beziehungen</p>
+                                <p class="text-xs text-slate-500">Verknüpfte Assets</p>
+                            </div>
+                            <i data-feather="share-2" class="w-4 h-4 text-slate-400"></i>
+                        </div>
+                        <div class="mt-4 space-y-2 text-sm">
+                            <template x-for="relation in selectedAsset?.relations || []" :key="relation.id">
+                                <div class="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2">
+                                    <p class="font-semibold text-slate-800" x-text="relation.direction === 'outgoing' ? relation.related_asset_name : relation.asset_name"></p>
+                                    <p class="text-xs text-slate-500" x-text="relation.relation_type_name || 'Beziehung'"></p>
+                                </div>
+                            </template>
+                            <p x-show="(selectedAsset?.relations || []).length === 0" class="text-xs text-slate-400">Keine Beziehungen hinterlegt.</p>
+                        </div>
+                    </div>
+                    <div class="rounded-2xl border border-amber-100 bg-amber-50/60 p-4">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-amber-700">Offene Tickets</p>
+                                <p class="text-xs text-amber-500">Aktive Supportfälle</p>
+                            </div>
+                            <i data-feather="life-buoy" class="w-4 h-4 text-amber-400"></i>
+                        </div>
+                        <div class="mt-4 space-y-2 text-sm">
+                            <template x-for="ticket in selectedAsset?.open_tickets || []" :key="ticket.id">
+                                <div class="rounded-2xl border border-amber-100 bg-white px-3 py-2">
+                                    <p class="font-semibold text-slate-800" x-text="ticket.title"></p>
+                                    <p class="text-xs text-slate-500" x-text="`#${ticket.id} • ${ticket.status}`"></p>
+                                </div>
+                            </template>
+                            <p x-show="(selectedAsset?.open_tickets || []).length === 0" class="text-xs text-amber-500">Keine offenen Tickets.</p>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -838,6 +905,35 @@
                     <textarea x-model="currentAsset.notes" rows="3" class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Zusätzliche Infos, z. B. Einsatzzweck"></textarea>
                 </div>
                 <div>
+                    <label class="text-sm font-semibold text-slate-700">Lebenszyklus</label>
+                    <div class="mt-3 grid gap-3 sm:grid-cols-2">
+                        <div>
+                            <label class="text-xs font-semibold text-slate-500">Anschaffungsdatum</label>
+                            <input type="date" x-model="currentAsset.acquisition_date" class="mt-1 w-full rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div>
+                            <label class="text-xs font-semibold text-slate-500">Inbetriebnahme</label>
+                            <input type="date" x-model="currentAsset.commissioning_date" class="mt-1 w-full rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div>
+                            <label class="text-xs font-semibold text-slate-500">Garantieende</label>
+                            <input type="date" x-model="currentAsset.warranty_end" class="mt-1 w-full rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div>
+                            <label class="text-xs font-semibold text-slate-500">Abschreibungszeitraum (Monate)</label>
+                            <input type="number" min="0" x-model="currentAsset.depreciation_months" class="mt-1 w-full rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div>
+                            <label class="text-xs font-semibold text-slate-500">Aussonderungsdatum</label>
+                            <input type="date" x-model="currentAsset.retirement_date" class="mt-1 w-full rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div class="sm:col-span-2">
+                            <label class="text-xs font-semibold text-slate-500">Grund der Ausmusterung</label>
+                            <textarea x-model="currentAsset.retirement_reason" rows="2" class="mt-1 w-full rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500"></textarea>
+                        </div>
+                    </div>
+                </div>
+                <div>
                     <div class="flex items-center justify-between">
                         <label class="text-sm font-semibold text-slate-700">Spezifikationen</label>
                         <button type="button" @click="addAssetSpec()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-100">
@@ -862,6 +958,43 @@
                             </div>
                         </template>
                         <p x-show="currentAsset.specs.length === 0" class="text-xs text-slate-400">Keine Spezifikationen angelegt.</p>
+                    </div>
+                </div>
+                <div>
+                    <div class="flex items-center justify-between">
+                        <label class="text-sm font-semibold text-slate-700">Asset-Beziehungen</label>
+                        <button type="button" @click="addAssetRelation()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-100">
+                            <i data-feather="plus" class="w-3 h-3"></i>
+                            Beziehung hinzufügen
+                        </button>
+                    </div>
+                    <div class="mt-3 space-y-3">
+                        <template x-for="relation in currentAsset.relations" :key="relation.id">
+                            <div class="flex flex-col gap-2 rounded-2xl border border-slate-200 bg-slate-50 p-3 sm:flex-row sm:items-center">
+                                <div class="flex-1">
+                                    <label class="text-xs font-semibold text-slate-500">Ziel-Asset</label>
+                                    <select x-model="relation.related_asset_id" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                        <option value="">-- Asset wählen --</option>
+                                        <template x-for="asset in assets.filter(item => item.id !== currentAsset.id)" :key="asset.id">
+                                            <option :value="asset.id" x-text="asset.name"></option>
+                                        </template>
+                                    </select>
+                                </div>
+                                <div class="flex-1">
+                                    <label class="text-xs font-semibold text-slate-500">Relationstyp</label>
+                                    <select x-model="relation.relation_type_id" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                        <option value="">-- Typ wählen --</option>
+                                        <template x-for="type in relationTypes" :key="type.id">
+                                            <option :value="type.id" x-text="type.name"></option>
+                                        </template>
+                                    </select>
+                                </div>
+                                <button type="button" @click="removeAssetRelation(relation.id)" class="self-start rounded-full border border-rose-200 px-3 py-2 text-xs font-semibold text-rose-600 hover:bg-rose-50 sm:self-center">
+                                    Entfernen
+                                </button>
+                            </div>
+                        </template>
+                        <p x-show="currentAsset.relations.length === 0" class="text-xs text-slate-400">Noch keine Beziehungen definiert.</p>
                     </div>
                 </div>
                 <div>

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -265,6 +265,39 @@
                                         </div>
                                     </div>
 
+                                    <div class="mt-5 rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
+                                        <div class="flex items-center justify-between">
+                                            <div>
+                                                <p class="text-xs uppercase text-slate-400">Assets</p>
+                                                <p class="text-sm font-semibold text-slate-700">Betroffene Assets</p>
+                                            </div>
+                                            <i data-feather="package" class="w-4 h-4 text-slate-400"></i>
+                                        </div>
+                                        <div class="mt-3 grid gap-2">
+                                            <template x-for="asset in assets" :key="asset.id">
+                                                <label class="flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
+                                                    <input type="checkbox" :value="asset.id" x-model="selectedTicket.asset_ids" @change="updateTicket" :disabled="!(can('tickets.update') || can('tickets.update_own'))" class="rounded border-slate-300 text-amber-600 focus:ring-amber-500">
+                                                    <span class="truncate" x-text="asset.name"></span>
+                                                </label>
+                                            </template>
+                                            <p x-show="assets.length === 0" class="text-xs text-slate-400">Keine Assets verfügbar.</p>
+                                        </div>
+                                        <div class="mt-4 space-y-2 text-xs text-slate-500">
+                                            <template x-for="asset in selectedTicket.assets || []" :key="asset.id">
+                                                <div class="rounded-2xl border border-slate-200 bg-white px-3 py-2">
+                                                    <div class="flex items-center justify-between">
+                                                        <p class="font-semibold text-slate-800" x-text="asset.name"></p>
+                                                        <span class="text-[11px] text-slate-500" x-text="asset.warranty_status || 'Unbekannt'"></span>
+                                                    </div>
+                                                    <p class="text-[11px] text-slate-500" x-text="asset.manufacturer ? `Hersteller: ${asset.manufacturer}` : 'Hersteller: -'"></p>
+                                                    <p class="text-[11px] text-slate-500" x-text="asset.serial_numbers?.length ? `Seriennummern: ${asset.serial_numbers.join(', ')}` : 'Seriennummern: -'"></p>
+                                                    <p class="text-[11px] text-slate-500" x-text="asset.locations?.length ? `Standorte: ${asset.locations.join(', ')}` : 'Standorte: -'"></p>
+                                                </div>
+                                            </template>
+                                            <p x-show="(selectedTicket.assets || []).length === 0" class="text-xs text-slate-400">Noch keine Assets zugewiesen.</p>
+                                        </div>
+                                    </div>
+
                                     <div class="mt-5" x-show="can('tickets.watch') || can('tickets.watch_own')">
                                         <p class="text-xs uppercase text-slate-400">Watcher</p>
                                         <div class="flex flex-wrap gap-2 mt-2">
@@ -468,6 +501,39 @@
                 </div>
                 <input type="date" x-model="newTicket.due_date" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm" x-show="can('tickets.update')">
                 <input type="text" x-model="newTicket.tags" placeholder="Tags (kommagetrennt)" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+
+                <div class="rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <p class="text-xs uppercase text-slate-400">Assets</p>
+                            <p class="text-sm font-semibold text-slate-700">Ticket verknüpfen</p>
+                        </div>
+                        <i data-feather="package" class="w-4 h-4 text-slate-400"></i>
+                    </div>
+                    <div class="mt-3 grid gap-2">
+                        <template x-for="asset in assets" :key="asset.id">
+                            <label class="flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
+                                <input type="checkbox" :value="asset.id" x-model="newTicket.asset_ids" class="rounded border-slate-300 text-amber-600 focus:ring-amber-500">
+                                <span class="truncate" x-text="asset.name"></span>
+                            </label>
+                        </template>
+                        <p x-show="assets.length === 0" class="text-xs text-slate-400">Keine Assets verfügbar.</p>
+                    </div>
+                    <div class="mt-4 space-y-2 text-xs text-slate-500">
+                        <template x-for="asset in selectedAssetsForNewTicket()" :key="asset.id">
+                            <div class="rounded-2xl border border-slate-200 bg-white px-3 py-2">
+                                <div class="flex items-center justify-between">
+                                    <p class="font-semibold text-slate-800" x-text="asset.name"></p>
+                                    <span class="text-[11px] text-slate-500" x-text="asset.warranty_status || 'Unbekannt'"></span>
+                                </div>
+                                <p class="text-[11px] text-slate-500" x-text="asset.manufacturer ? `Hersteller: ${asset.manufacturer}` : 'Hersteller: -'"></p>
+                                <p class="text-[11px] text-slate-500" x-text="asset.serial_numbers?.length ? `Seriennummern: ${asset.serial_numbers.join(', ')}` : 'Seriennummern: -'"></p>
+                                <p class="text-[11px] text-slate-500" x-text="asset.locations?.length ? `Standorte: ${asset.locations.join(', ')}` : 'Standorte: -'"></p>
+                            </div>
+                        </template>
+                        <p x-show="selectedAssetsForNewTicket().length === 0" class="text-xs text-slate-400">Keine Assets ausgewählt.</p>
+                    </div>
+                </div>
 
                 <div class="space-y-2">
                     <p class="text-xs uppercase text-slate-400">Benutzerdefinierte Felder</p>


### PR DESCRIPTION
### Motivation
- Provide asset lifecycle metadata so inventory items are more than flat lists and can be reported for finance and operations. 
- Model relationships between assets to reflect real-world dependencies and topology. 
- Link tickets to assets so support workflows carry asset context (manufacturer, serials, locations, warranty) and reduce back-and-forth.

### Description
- Extended the database schema with lifecycle fields on `assets` (`acquisition_date`, `commissioning_date`, `warranty_end`, `depreciation_months`, `retirement_date`, `retirement_reason`) and added `asset_relation_types`, `asset_relations`, and `ticket_assets` tables, plus safe `ALTER TABLE` migration attempts. 
- Implemented server-side helpers and APIs that summarize assets (`build_asset_summary`, `fetch_ticket_assets`, `asset_relation_types`) and updated the `GET/POST/PUT/DELETE /api/assets` and `POST/GET/PUT/DELETE /api/tickets` flows to persist and surface relations and ticket-asset links. 
- Updated UI to capture lifecycle and relation data: asset modal now includes lifecycle fields and relation UI, asset detail shows lifecycle, relations and open tickets, and tickets UI/modal can link to assets and show asset summaries (manufacturer, serials, locations, warranty status). 
- Frontend JS enhancements: `static/script.js` and `static/tickets.js` load relation types/assets and wire the new fields; templates `templates/index.html` and `templates/tickets.html` render the new controls and summaries.

### Testing
- Ran `python -m py_compile app.py` to validate syntax and it completed successfully. 
- Launched the development server (`python app.py`) and installed missing runtime deps from `requirements.txt` to allow the app to start; server booted and created an admin user. 
- Executed a Playwright smoke script that logs in as the auto-created admin, opens the asset modal and captures a screenshot; the script ran and produced `artifacts/asset-lifecycle.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973fecaa938832dad80f95a0bced8e1)