### PR TITLE
Add integrated roadmap board and ticket automation

### DIFF
--- a/app.py
+++ b/app.py
@@ -217,6 +217,18 @@ PERMISSIONS = [
         "label": "Aktivitätslog anzeigen",
         "description": "Aktivitätslog einsehen.",
         "group": "Reporting"
+    },
+    {
+        "key": "roadmap.view",
+        "label": "Roadmaps anzeigen",
+        "description": "Roadmaps und Pläne einsehen.",
+        "group": "Roadmap"
+    },
+    {
+        "key": "roadmap.manage",
+        "label": "Roadmaps verwalten",
+        "description": "Roadmaps erstellen, bearbeiten und löschen.",
+        "group": "Roadmap"
     }
 ]
 
@@ -255,7 +267,9 @@ DEFAULT_ROLES = [
             "ticket_alerts.manage",
             "notifications.manage",
             "stats.view",
-            "activity.view"
+            "activity.view",
+            "roadmap.view",
+            "roadmap.manage"
         ]
     },
     {
@@ -267,7 +281,8 @@ DEFAULT_ROLES = [
             "tickets.view_own",
             "tickets.create",
             "tickets.comment_own",
-            "tickets.watch_own"
+            "tickets.watch_own",
+            "roadmap.view"
         ]
     }
 ]
@@ -936,6 +951,38 @@ def init_db():
             )
         ''')
 
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS roadmaps (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ticket_id INTEGER UNIQUE,
+                title TEXT NOT NULL,
+                objective TEXT,
+                status TEXT DEFAULT 'planned',
+                owner TEXT,
+                start_date TEXT,
+                target_date TEXT,
+                created_by TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (ticket_id) REFERENCES tickets(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS roadmap_steps (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                roadmap_id INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                description TEXT,
+                status TEXT DEFAULT 'planned',
+                position INTEGER DEFAULT 0,
+                owner TEXT,
+                due_date TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (roadmap_id) REFERENCES roadmaps(id)
+            )
+        ''')
+
         # Default-Kategorien
         default_categories = [
             ("CPU", "cpu", '{"cores":"number","clock":"text","manufacturer":"text"}'),
@@ -960,7 +1007,8 @@ def init_db():
             ("Allgemein", "Allgemeine Anfragen und Rückfragen", "#2563eb", 72, 1),
             ("Incident", "Störungen und dringende Ausfälle", "#dc2626", 24, 0),
             ("Service Request", "Bestellungen und Service-Anfragen", "#0f766e", 120, 0),
-            ("Change", "Geplante Änderungen und Wartungen", "#7c3aed", 168, 0)
+            ("Change", "Geplante Änderungen und Wartungen", "#7c3aed", 168, 0),
+            ("Verbesserungen", "Optimierungen, neue Features und Produktideen", "#0ea5e9", 168, 0)
         ]
         c.executemany('''
             INSERT OR IGNORE INTO ticket_categories (name, description, color, sla_hours, is_default)
@@ -1222,6 +1270,79 @@ def parse_datetime(value):
 
 def is_closed_status(status):
     return (status or "").strip().lower() in {"closed", "resolved", "done"}
+
+def should_auto_create_roadmap(category_name):
+    if not category_name:
+        return False
+    lowered = category_name.strip().lower()
+    keywords = ("verbesser", "improvement", "enhancement", "feature", "upgrade", "optim")
+    return any(keyword in lowered for keyword in keywords)
+
+def create_roadmap_for_ticket(db, ticket, category_name=None, created_by=None):
+    if not ticket:
+        return None
+    existing = db.execute('SELECT id FROM roadmaps WHERE ticket_id = ?', (ticket["id"],)).fetchone()
+    if existing:
+        return existing["id"]
+    title = f"Roadmap: {ticket['title']}"
+    objective = f"Umsetzungsplan für Ticket #{ticket['id']}: {ticket['title']}"
+    owner = ticket.get("assignee") or ticket.get("created_by")
+    start_date = datetime.utcnow().strftime("%Y-%m-%d")
+    target_date = ticket.get("due_date") or None
+    roadmap_cursor = db.execute('''
+        INSERT INTO roadmaps (ticket_id, title, objective, status, owner, start_date, target_date, created_by)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    ''', (
+        ticket["id"],
+        title,
+        objective,
+        "planned",
+        owner,
+        start_date,
+        target_date,
+        created_by or session.get('username')
+    ))
+    roadmap_id = roadmap_cursor.lastrowid
+    default_steps = [
+        ("Analyse & Scope", "Ziele, Anforderungen und Erfolgskriterien definieren.", "planned"),
+        ("Konzept & Design", "Architektur, UI/UX und technische Umsetzung planen.", "planned"),
+        ("Implementierung", "Features entwickeln und integrieren.", "planned"),
+        ("Qualitätssicherung", "Tests, Review und Abnahme durchführen.", "planned"),
+        ("Rollout & Monitoring", "Deployment, Dokumentation und Monitoring vorbereiten.", "planned")
+    ]
+    for position, (step_title, description, status) in enumerate(default_steps, start=1):
+        db.execute('''
+            INSERT INTO roadmap_steps (roadmap_id, title, description, status, position)
+            VALUES (?, ?, ?, ?, ?)
+        ''', (roadmap_id, step_title, description, status, position))
+    log_activity(db, "create", "roadmap", roadmap_id, {
+        "ticket_id": ticket["id"],
+        "title": title,
+        "category": category_name
+    })
+    return roadmap_id
+
+def fetch_roadmap(db, roadmap_id):
+    row = db.execute('''
+        SELECT r.*, t.title as ticket_title, t.status as ticket_status, t.created_by as ticket_owner
+        FROM roadmaps r
+        LEFT JOIN tickets t ON r.ticket_id = t.id
+        WHERE r.id = ?
+    ''', (roadmap_id,)).fetchone()
+    return dict(row) if row else None
+
+def fetch_roadmap_for_ticket(db, ticket_id):
+    row = db.execute('SELECT * FROM roadmaps WHERE ticket_id = ?', (ticket_id,)).fetchone()
+    return dict(row) if row else None
+
+def fetch_roadmap_steps(db, roadmap_id):
+    rows = db.execute('''
+        SELECT *
+        FROM roadmap_steps
+        WHERE roadmap_id = ?
+        ORDER BY position ASC, created_at ASC
+    ''', (roadmap_id,)).fetchall()
+    return [dict(row) for row in rows]
 
 def warranty_status(warranty_end):
     parsed = parse_date(warranty_end)
@@ -1508,6 +1629,13 @@ def locations_page():
 def tickets_page():
     access = get_user_access(get_db())
     return render_template('tickets.html', username=session.get('username'), permissions=sorted(access["permissions"]), is_superuser=access["is_superuser"])
+
+@app.route('/roadmap')
+@login_required
+@require_permissions('roadmap.view', 'roadmap.manage')
+def roadmap_page():
+    access = get_user_access(get_db())
+    return render_template('roadmap.html', username=session.get('username'), permissions=sorted(access["permissions"]), is_superuser=access["is_superuser"])
 
 @app.route('/api/categories/<int:category_id>', methods=['PUT', 'DELETE'])
 @login_required
@@ -2016,6 +2144,244 @@ def ticket_category_detail(category_id):
     db.commit()
     return jsonify({"status": "deleted"}), 200
 
+@app.route('/api/roadmaps', methods=['GET', 'POST'])
+@login_required
+def roadmaps():
+    db = get_db()
+    access = get_user_access(db)
+    if request.method == 'POST':
+        if not user_can('roadmap.manage'):
+            return jsonify({"error": "Keine Berechtigung"}), 403
+        data = request.get_json() or {}
+        ticket_id = data.get('ticket_id')
+        title = (data.get('title') or '').strip()
+        objective = (data.get('objective') or '').strip()
+        status = (data.get('status') or 'planned').strip()
+        owner = (data.get('owner') or '').strip()
+        start_date = (data.get('start_date') or '').strip()
+        target_date = (data.get('target_date') or '').strip()
+        steps = data.get('steps') or []
+        ticket = None
+        if ticket_id:
+            ticket = fetch_ticket(db, ticket_id)
+            if not ticket:
+                return jsonify({"error": "Ticket nicht gefunden"}), 404
+            if not ensure_ticket_access(ticket, access, require_owner_permission=True):
+                return jsonify({"error": "Keine Berechtigung"}), 403
+            existing = db.execute('SELECT id FROM roadmaps WHERE ticket_id = ?', (ticket_id,)).fetchone()
+            if existing:
+                return jsonify({"error": "Roadmap für dieses Ticket existiert bereits"}), 400
+            if not title:
+                title = f"Roadmap: {ticket['title']}"
+            if not objective:
+                objective = f"Umsetzungsplan für Ticket #{ticket['id']}: {ticket['title']}"
+            if not owner:
+                owner = ticket.get("assignee") or ticket.get("created_by") or ''
+
+        if not title:
+            return jsonify({"error": "Titel ist erforderlich"}), 400
+
+        cursor = db.execute('''
+            INSERT INTO roadmaps (ticket_id, title, objective, status, owner, start_date, target_date, created_by)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ''', (
+            ticket_id,
+            title,
+            objective,
+            status,
+            owner,
+            start_date or None,
+            target_date or None,
+            session.get('username')
+        ))
+        roadmap_id = cursor.lastrowid
+        for index, step in enumerate(steps, start=1):
+            step_title = (step.get('title') or '').strip()
+            if not step_title:
+                continue
+            db.execute('''
+                INSERT INTO roadmap_steps (roadmap_id, title, description, status, position, owner, due_date)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            ''', (
+                roadmap_id,
+                step_title,
+                (step.get('description') or '').strip(),
+                (step.get('status') or 'planned').strip(),
+                int(step.get('position') or index),
+                (step.get('owner') or '').strip(),
+                (step.get('due_date') or '').strip() or None
+            ))
+        log_activity(db, "create", "roadmap", roadmap_id, {"title": title, "ticket_id": ticket_id})
+        db.commit()
+        return jsonify({"status": "created", "id": roadmap_id}), 201
+
+    if not user_can('roadmap.view'):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+
+    filters = []
+    params = []
+    status = (request.args.get('status') or '').strip()
+    search = (request.args.get('search') or '').strip()
+    ticket_id = request.args.get('ticket_id')
+    mine = request.args.get('mine')
+
+    if status:
+        filters.append('r.status = ?')
+        params.append(status)
+    if ticket_id:
+        filters.append('r.ticket_id = ?')
+        params.append(ticket_id)
+    if search:
+        filters.append('(r.title LIKE ? OR r.objective LIKE ? OR t.title LIKE ?)')
+        params.extend([f'%{search}%', f'%{search}%', f'%{search}%'])
+    if mine:
+        filters.append('(r.created_by = ? OR t.created_by = ?)')
+        params.extend([session.get('username'), session.get('username')])
+    if not access["is_superuser"] and 'tickets.view_all' not in access["permissions"]:
+        filters.append('(t.created_by = ? OR r.created_by = ?)')
+        params.extend([session.get('username'), session.get('username')])
+
+    query = '''
+        SELECT r.*, t.title as ticket_title, t.status as ticket_status,
+               c.name as category_name, c.color as category_color,
+               (SELECT COUNT(*) FROM roadmap_steps rs WHERE rs.roadmap_id = r.id) as step_count
+        FROM roadmaps r
+        LEFT JOIN tickets t ON r.ticket_id = t.id
+        LEFT JOIN ticket_categories c ON t.category_id = c.id
+    '''
+    if filters:
+        query += ' WHERE ' + ' AND '.join(filters)
+    query += ' ORDER BY r.updated_at DESC, r.created_at DESC'
+    rows = db.execute(query, params).fetchall()
+    return jsonify([dict(row) for row in rows])
+
+@app.route('/api/roadmaps/<int:roadmap_id>', methods=['GET', 'PUT', 'DELETE'])
+@login_required
+def roadmap_detail(roadmap_id):
+    db = get_db()
+    access = get_user_access(db)
+    roadmap = fetch_roadmap(db, roadmap_id)
+    if not roadmap:
+        return jsonify({"error": "Roadmap nicht gefunden"}), 404
+    if roadmap.get("ticket_id"):
+        ticket = fetch_ticket(db, roadmap["ticket_id"])
+        if not ensure_ticket_access(ticket, access):
+            return jsonify({"error": "Keine Berechtigung"}), 403
+    elif not user_can('roadmap.view'):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+
+    if request.method == 'GET':
+        roadmap["steps"] = fetch_roadmap_steps(db, roadmap_id)
+        return jsonify(roadmap)
+
+    if request.method == 'PUT':
+        if not user_can('roadmap.manage'):
+            return jsonify({"error": "Keine Berechtigung"}), 403
+        data = request.get_json() or {}
+        title = (data.get('title') or roadmap.get('title') or '').strip()
+        objective = (data.get('objective') or roadmap.get('objective') or '').strip()
+        status = (data.get('status') or roadmap.get('status') or 'planned').strip()
+        owner = (data.get('owner') or roadmap.get('owner') or '').strip()
+        start_date = (data.get('start_date') or roadmap.get('start_date') or '').strip()
+        target_date = (data.get('target_date') or roadmap.get('target_date') or '').strip()
+        if not title:
+            return jsonify({"error": "Titel ist erforderlich"}), 400
+        db.execute('''
+            UPDATE roadmaps
+            SET title = ?, objective = ?, status = ?, owner = ?, start_date = ?, target_date = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+        ''', (title, objective, status, owner, start_date or None, target_date or None, roadmap_id))
+        log_activity(db, "update", "roadmap", roadmap_id, {"title": title})
+        db.commit()
+        return jsonify({"status": "updated"}), 200
+
+    if not user_can('roadmap.manage'):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    db.execute('DELETE FROM roadmap_steps WHERE roadmap_id = ?', (roadmap_id,))
+    db.execute('DELETE FROM roadmaps WHERE id = ?', (roadmap_id,))
+    log_activity(db, "delete", "roadmap", roadmap_id)
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/roadmaps/<int:roadmap_id>/steps', methods=['POST'])
+@login_required
+def roadmap_steps_create(roadmap_id):
+    db = get_db()
+    access = get_user_access(db)
+    roadmap = fetch_roadmap(db, roadmap_id)
+    if not roadmap:
+        return jsonify({"error": "Roadmap nicht gefunden"}), 404
+    if roadmap.get("ticket_id"):
+        ticket = fetch_ticket(db, roadmap["ticket_id"])
+        if not ensure_ticket_access(ticket, access):
+            return jsonify({"error": "Keine Berechtigung"}), 403
+    if not user_can('roadmap.manage'):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    data = request.get_json() or {}
+    title = (data.get('title') or '').strip()
+    if not title:
+        return jsonify({"error": "Titel ist erforderlich"}), 400
+    description = (data.get('description') or '').strip()
+    status = (data.get('status') or 'planned').strip()
+    owner = (data.get('owner') or '').strip()
+    due_date = (data.get('due_date') or '').strip()
+    position = int(data.get('position') or 0)
+    if position <= 0:
+        row = db.execute('SELECT MAX(position) as max_pos FROM roadmap_steps WHERE roadmap_id = ?', (roadmap_id,)).fetchone()
+        position = (row["max_pos"] or 0) + 1
+    cursor = db.execute('''
+        INSERT INTO roadmap_steps (roadmap_id, title, description, status, position, owner, due_date)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    ''', (roadmap_id, title, description, status, position, owner, due_date or None))
+    db.execute('UPDATE roadmaps SET updated_at = CURRENT_TIMESTAMP WHERE id = ?', (roadmap_id,))
+    log_activity(db, "create", "roadmap_step", cursor.lastrowid, {"roadmap_id": roadmap_id, "title": title})
+    db.commit()
+    return jsonify({"status": "created", "id": cursor.lastrowid}), 201
+
+@app.route('/api/roadmaps/<int:roadmap_id>/steps/<int:step_id>', methods=['PUT', 'DELETE'])
+@login_required
+def roadmap_steps_detail(roadmap_id, step_id):
+    db = get_db()
+    access = get_user_access(db)
+    roadmap = fetch_roadmap(db, roadmap_id)
+    if not roadmap:
+        return jsonify({"error": "Roadmap nicht gefunden"}), 404
+    if roadmap.get("ticket_id"):
+        ticket = fetch_ticket(db, roadmap["ticket_id"])
+        if not ensure_ticket_access(ticket, access):
+            return jsonify({"error": "Keine Berechtigung"}), 403
+    if not user_can('roadmap.manage'):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    step = db.execute('SELECT * FROM roadmap_steps WHERE id = ? AND roadmap_id = ?', (step_id, roadmap_id)).fetchone()
+    if not step:
+        return jsonify({"error": "Step nicht gefunden"}), 404
+
+    if request.method == 'PUT':
+        data = request.get_json() or {}
+        title = (data.get('title') or step["title"]).strip()
+        description = (data.get('description') or step["description"] or '').strip()
+        status = (data.get('status') or step["status"] or 'planned').strip()
+        owner = (data.get('owner') or step["owner"] or '').strip()
+        due_date = (data.get('due_date') or step["due_date"] or '').strip()
+        position = int(data.get('position') or step["position"] or 0)
+        if not title:
+            return jsonify({"error": "Titel ist erforderlich"}), 400
+        db.execute('''
+            UPDATE roadmap_steps
+            SET title = ?, description = ?, status = ?, owner = ?, due_date = ?, position = ?
+            WHERE id = ? AND roadmap_id = ?
+        ''', (title, description, status, owner, due_date or None, position, step_id, roadmap_id))
+        db.execute('UPDATE roadmaps SET updated_at = CURRENT_TIMESTAMP WHERE id = ?', (roadmap_id,))
+        log_activity(db, "update", "roadmap_step", step_id, {"roadmap_id": roadmap_id, "title": title})
+        db.commit()
+        return jsonify({"status": "updated"}), 200
+
+    db.execute('DELETE FROM roadmap_steps WHERE id = ? AND roadmap_id = ?', (step_id, roadmap_id))
+    db.execute('UPDATE roadmaps SET updated_at = CURRENT_TIMESTAMP WHERE id = ?', (roadmap_id,))
+    log_activity(db, "delete", "roadmap_step", step_id, {"roadmap_id": roadmap_id})
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
+
 @app.route('/api/tickets', methods=['GET', 'POST'])
 @login_required
 def tickets():
@@ -2054,6 +2420,10 @@ def tickets():
         resolved_at = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S") if is_closed_status(status) else None
         if not title or not description:
             return jsonify({"error": "Titel und Beschreibung sind erforderlich"}), 400
+        category_name = None
+        if category_id:
+            category_row = db.execute('SELECT name FROM ticket_categories WHERE id = ?', (category_id,)).fetchone()
+            category_name = category_row["name"] if category_row else None
         cursor = db.execute('''
             INSERT INTO tickets (
                 title, description, category_id, priority, status, requester_name,
@@ -2072,6 +2442,22 @@ def tickets():
                 INSERT OR IGNORE INTO ticket_assets (ticket_id, asset_id)
                 VALUES (?, ?)
             ''', (ticket_id, asset_id))
+        new_ticket = {
+            "id": ticket_id,
+            "title": title,
+            "description": description,
+            "category_id": category_id,
+            "priority": priority,
+            "status": status,
+            "requester_name": requester_name,
+            "requester_email": requester_email,
+            "created_by": session.get('username'),
+            "assignee": assignee,
+            "assignee_email": assignee_email,
+            "due_date": due_date
+        }
+        if should_auto_create_roadmap(category_name):
+            create_roadmap_for_ticket(db, new_ticket, category_name, created_by=session.get('username'))
         log_activity(db, "create", "ticket", ticket_id, {"title": title})
         db.commit()
         ticket = fetch_ticket(db, ticket_id)
@@ -2156,6 +2542,10 @@ def ticket_detail(ticket_id):
         ticket_assets = fetch_ticket_assets(db, ticket_id)
         ticket['assets'] = ticket_assets
         ticket['asset_ids'] = [asset["id"] for asset in ticket_assets]
+        roadmap = fetch_roadmap_for_ticket(db, ticket_id)
+        if roadmap:
+            roadmap["steps"] = fetch_roadmap_steps(db, roadmap["id"])
+        ticket['roadmap'] = roadmap
         return jsonify(ticket)
 
     if request.method == 'PUT':
@@ -2188,6 +2578,10 @@ def ticket_detail(ticket_id):
                 resolved_at = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
             else:
                 resolved_at = None
+        category_name = None
+        if category_id:
+            category_row = db.execute('SELECT name FROM ticket_categories WHERE id = ?', (category_id,)).fetchone()
+            category_name = category_row["name"] if category_row else None
 
         db.execute('''
             UPDATE tickets
@@ -2210,6 +2604,22 @@ def ticket_detail(ticket_id):
                     VALUES (?, ?)
                 ''', (ticket_id, asset_id))
         log_activity(db, "update", "ticket", ticket_id, {"title": title})
+        if should_auto_create_roadmap(category_name):
+            updated_ticket = {
+                "id": ticket_id,
+                "title": title,
+                "description": description,
+                "category_id": category_id,
+                "priority": priority,
+                "status": status,
+                "requester_name": requester_name,
+                "requester_email": requester_email,
+                "created_by": ticket.get('created_by'),
+                "assignee": assignee,
+                "assignee_email": assignee_email,
+                "due_date": due_date
+            }
+            create_roadmap_for_ticket(db, updated_ticket, category_name, created_by=session.get('username'))
         db.commit()
         updated_ticket = fetch_ticket(db, ticket_id)
         if updated_ticket:

--- a/static/roadmap.js
+++ b/static/roadmap.js
@@ -1,0 +1,219 @@
+document.addEventListener('alpine:init', () => {
+    Alpine.data('roadmapApp', () => ({
+        roadmaps: [],
+        selectedRoadmap: null,
+        userPermissions: window.inventoryPermissions || [],
+        isSuperuser: window.inventoryIsSuperuser || false,
+        filters: {
+            status: '',
+            search: '',
+            mine: false
+        },
+        roadmapStatuses: ['planned', 'in_progress', 'blocked', 'done'],
+        roadmapStatusLabels: {
+            planned: 'Geplant',
+            in_progress: 'In Arbeit',
+            blocked: 'Blockiert',
+            done: 'Erledigt'
+        },
+        overview: {
+            planned: 0,
+            in_progress: 0,
+            blocked: 0,
+            done: 0
+        },
+        roadmapModalOpen: false,
+        roadmapError: '',
+        stepFormOpen: false,
+        newRoadmap: {
+            title: '',
+            objective: '',
+            status: 'planned',
+            owner: '',
+            start_date: '',
+            target_date: '',
+            ticket_id: ''
+        },
+        newStep: {
+            title: '',
+            description: '',
+            status: 'planned',
+            owner: '',
+            due_date: ''
+        },
+        preselectedTicketId: null,
+
+        async init() {
+            const params = new URLSearchParams(window.location.search);
+            this.preselectedTicketId = params.get('ticket_id');
+            await this.loadRoadmaps();
+            if (this.preselectedTicketId) {
+                const match = this.roadmaps.find((roadmap) => String(roadmap.ticket_id) === String(this.preselectedTicketId));
+                if (match) {
+                    await this.selectRoadmap(match);
+                }
+            }
+            this.$nextTick(() => feather.replace());
+        },
+
+        can(permissionKey) {
+            return this.isSuperuser || this.userPermissions.includes(permissionKey);
+        },
+
+        openNewRoadmap() {
+            this.roadmapError = '';
+            this.roadmapModalOpen = true;
+        },
+
+        toggleStepForm() {
+            this.stepFormOpen = !this.stepFormOpen;
+        },
+
+        async loadRoadmaps() {
+            const params = new URLSearchParams();
+            if (this.filters.status) params.append('status', this.filters.status);
+            if (this.filters.search) params.append('search', this.filters.search);
+            if (this.filters.mine) params.append('mine', '1');
+            if (this.preselectedTicketId) params.append('ticket_id', this.preselectedTicketId);
+
+            const response = await fetch(`/api/roadmaps?${params.toString()}`);
+            if (response.ok) {
+                this.roadmaps = await response.json();
+                this.updateOverview();
+            }
+            this.$nextTick(() => feather.replace());
+        },
+
+        updateOverview() {
+            const counts = { planned: 0, in_progress: 0, blocked: 0, done: 0 };
+            this.roadmaps.forEach((roadmap) => {
+                if (counts[roadmap.status] !== undefined) {
+                    counts[roadmap.status] += 1;
+                }
+            });
+            this.overview = counts;
+        },
+
+        async selectRoadmap(roadmap) {
+            const response = await fetch(`/api/roadmaps/${roadmap.id}`);
+            if (response.ok) {
+                this.selectedRoadmap = await response.json();
+                this.stepFormOpen = false;
+            }
+            this.$nextTick(() => feather.replace());
+        },
+
+        closeRoadmap() {
+            this.selectedRoadmap = null;
+        },
+
+        stepsByStatus(status) {
+            if (!this.selectedRoadmap || !this.selectedRoadmap.steps) return [];
+            return this.selectedRoadmap.steps.filter((step) => step.status === status);
+        },
+
+        async saveRoadmap() {
+            if (!this.selectedRoadmap) return;
+            const payload = {
+                title: this.selectedRoadmap.title,
+                objective: this.selectedRoadmap.objective,
+                status: this.selectedRoadmap.status,
+                owner: this.selectedRoadmap.owner,
+                start_date: this.selectedRoadmap.start_date,
+                target_date: this.selectedRoadmap.target_date
+            };
+            const response = await fetch(`/api/roadmaps/${this.selectedRoadmap.id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            if (response.ok) {
+                await this.loadRoadmaps();
+                await this.selectRoadmap({ id: this.selectedRoadmap.id });
+            }
+        },
+
+        async addStep() {
+            if (!this.selectedRoadmap || !this.newStep.title) return;
+            const payload = { ...this.newStep };
+            const response = await fetch(`/api/roadmaps/${this.selectedRoadmap.id}/steps`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            if (response.ok) {
+                this.newStep = {
+                    title: '',
+                    description: '',
+                    status: 'planned',
+                    owner: '',
+                    due_date: ''
+                };
+                this.stepFormOpen = false;
+                await this.selectRoadmap({ id: this.selectedRoadmap.id });
+                await this.loadRoadmaps();
+            }
+        },
+
+        async updateStep(step) {
+            if (!this.selectedRoadmap) return;
+            const payload = {
+                title: step.title,
+                description: step.description,
+                status: step.status,
+                owner: step.owner,
+                due_date: step.due_date,
+                position: step.position
+            };
+            const response = await fetch(`/api/roadmaps/${this.selectedRoadmap.id}/steps/${step.id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            if (response.ok) {
+                await this.selectRoadmap({ id: this.selectedRoadmap.id });
+                await this.loadRoadmaps();
+            }
+        },
+
+        async deleteStep(step) {
+            if (!this.selectedRoadmap) return;
+            const response = await fetch(`/api/roadmaps/${this.selectedRoadmap.id}/steps/${step.id}`, {
+                method: 'DELETE'
+            });
+            if (response.ok) {
+                await this.selectRoadmap({ id: this.selectedRoadmap.id });
+                await this.loadRoadmaps();
+            }
+        },
+
+        async createRoadmap() {
+            this.roadmapError = '';
+            const payload = { ...this.newRoadmap };
+            if (!payload.ticket_id) {
+                delete payload.ticket_id;
+            }
+            const response = await fetch('/api/roadmaps', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            if (response.ok) {
+                this.roadmapModalOpen = false;
+                this.newRoadmap = {
+                    title: '',
+                    objective: '',
+                    status: 'planned',
+                    owner: '',
+                    start_date: '',
+                    target_date: '',
+                    ticket_id: ''
+                };
+                await this.loadRoadmaps();
+            } else {
+                const error = await response.json();
+                this.roadmapError = error.error || 'Roadmap konnte nicht erstellt werden.';
+            }
+        }
+    }));
+});

--- a/static/tickets.js
+++ b/static/tickets.js
@@ -22,6 +22,12 @@ document.addEventListener('alpine:init', () => {
             resolved: 'Gelöst',
             closed: 'Geschlossen'
         },
+        roadmapStatusLabels: {
+            planned: 'Geplant',
+            in_progress: 'In Arbeit',
+            blocked: 'Blockiert',
+            done: 'Erledigt'
+        },
         priorityOptions: ['low', 'normal', 'high', 'urgent'],
         stats: {
             open: 0,
@@ -273,6 +279,32 @@ document.addEventListener('alpine:init', () => {
             if (response.ok) {
                 await this.selectTicket(this.selectedTicket);
                 this.newWatcher = '';
+            }
+        },
+
+        defaultRoadmapSteps() {
+            return [
+                { title: 'Analyse & Scope', description: 'Ziele, Anforderungen und Erfolgskriterien definieren.', status: 'planned' },
+                { title: 'Konzept & Design', description: 'Architektur, UI/UX und technische Umsetzung planen.', status: 'planned' },
+                { title: 'Implementierung', description: 'Features entwickeln und integrieren.', status: 'planned' },
+                { title: 'Qualitätssicherung', description: 'Tests, Review und Abnahme durchführen.', status: 'planned' },
+                { title: 'Rollout & Monitoring', description: 'Deployment, Dokumentation und Monitoring vorbereiten.', status: 'planned' }
+            ];
+        },
+
+        async createRoadmapForTicket() {
+            if (!this.selectedTicket) return;
+            const payload = {
+                ticket_id: this.selectedTicket.id,
+                steps: this.defaultRoadmapSteps()
+            };
+            const response = await fetch('/api/roadmaps', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            if (response.ok) {
+                await this.selectTicket(this.selectedTicket);
             }
         },
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -192,6 +192,17 @@
                         <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
                     </a>
                     {% endif %}
+                    {% if 'roadmap.view' in permissions or 'roadmap.manage' in permissions %}
+                    <a href="/roadmap" class="flex items-center justify-between px-4 py-3 text-sm font-semibold text-slate-700 hover:text-slate-900 w-full rounded-2xl hover:bg-white transition-colors border border-slate-200 bg-white/70 shadow-sm">
+                        <span class="flex items-center">
+                            <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-indigo-50 text-indigo-600 mr-3">
+                                <i data-feather="git-merge" class="w-4 h-4"></i>
+                            </span>
+                            <span class="sidebar-text">Roadmap</span>
+                        </span>
+                        <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                    </a>
+                    {% endif %}
                     {% if 'stats.view' in permissions %}
                     <a href="/stats" class="flex items-center justify-between px-4 py-3 text-sm font-semibold text-slate-700 hover:text-slate-900 w-full rounded-2xl hover:bg-white transition-colors border border-slate-200 bg-white/70 shadow-sm">
                         <span class="flex items-center">

--- a/templates/locations.html
+++ b/templates/locations.html
@@ -51,6 +51,17 @@
                     <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
                 </a>
                 {% endif %}
+                {% if 'roadmap.view' in permissions or 'roadmap.manage' in permissions %}
+                <a href="/roadmap" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-indigo-50 text-indigo-600 mr-3">
+                            <i data-feather="git-merge" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Roadmap</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
+                {% endif %}
                 {% if 'stats.view' in permissions %}
                 <a href="/stats" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
                     <span class="flex items-center">

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -1,0 +1,398 @@
+<!DOCTYPE html>
+<html lang="de" x-data="roadmapApp()">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Inventory Pro - Roadmap</title>
+    <script src="/static/theme.js"></script>
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+    <script>
+        window.inventoryPermissions = {{ permissions | tojson }};
+        window.inventoryIsSuperuser = {{ is_superuser | tojson }};
+    </script>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body class="app-body bg-slate-950/5 text-slate-900">
+    <div class="app-shell">
+        <aside class="app-sidebar sidebar bg-white/90 backdrop-blur-xl border-r border-slate-200 shadow-sm">
+            <div class="sidebar-header p-6 border-b border-slate-200">
+                <a href="/">
+                    <div class="logo flex items-center space-x-3">
+                        <span class="inline-flex items-center justify-center w-10 h-10 rounded-2xl bg-gradient-to-br from-blue-500 via-indigo-500 to-purple-500 text-white shadow-lg">
+                            <i data-feather="cpu" class="w-5 h-5"></i>
+                        </span>
+                        <div>
+                            <p class="text-lg font-semibold text-slate-900 sidebar-text">Inventory Pro</p>
+                            <p class="text-xs text-slate-500 sidebar-text">Smart Asset Hub</p>
+                        </div>
+                    </div>
+                </a>
+            </div>
+            <nav class="p-4 space-y-3 sidebar-scroll sidebar-primary-links">
+                {% if 'categories.view' in permissions or 'categories.manage' in permissions %}
+                <a href="/" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+                            <i data-feather="layers" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Kategorien</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
+                {% endif %}
+                {% if 'tickets.view_all' in permissions or 'tickets.view_own' in permissions or 'tickets.create' in permissions %}
+                <a href="/tickets" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+                            <i data-feather="life-buoy" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Tickets</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
+                {% endif %}
+                {% if 'roadmap.view' in permissions or 'roadmap.manage' in permissions %}
+                <a href="/roadmap" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-indigo-100 bg-indigo-50 text-sm font-semibold text-indigo-700">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-indigo-100 text-indigo-600 mr-3">
+                            <i data-feather="git-merge" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Roadmap</span>
+                    </span>
+                    <i data-feather="clipboard" class="w-4 h-4 text-indigo-400"></i>
+                </a>
+                {% endif %}
+                {% if 'stats.view' in permissions %}
+                <a href="/stats" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+                            <i data-feather="bar-chart-2" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Statistiken</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
+                {% endif %}
+                {% if 'users.manage' in permissions %}
+                <a href="/users" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+                            <i data-feather="users" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Benutzer</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
+                {% endif %}
+                {% if 'locations.view' in permissions or 'locations.manage' in permissions %}
+                <a href="/locations" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+                            <i data-feather="map-pin" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Standorte</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
+                {% endif %}
+            </nav>
+        </aside>
+
+        <div class="app-main app-main--fixed">
+            <header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 z-30 h-[82px]">
+                <div class="flex items-center gap-4">
+                    <button type="button" data-sidebar-toggle aria-label="Navigation umschalten" class="inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white p-2 text-slate-600 shadow-sm hover:bg-slate-50">
+                        <i data-feather="menu" class="w-4 h-4"></i>
+                    </button>
+                    <div>
+                        <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Planung</p>
+                        <h1 class="text-2xl font-semibold text-slate-900">Roadmap Board</h1>
+                    </div>
+                </div>
+                <div class="flex items-center justify-end gap-2 sm:gap-3">
+                    <span class="hidden text-sm text-slate-500 sm:inline">Angemeldet als {{ username }}</span>
+                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white p-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
+                        <span data-theme-icon aria-hidden="true">🌙</span>
+                        <span data-theme-label class="sr-only sm:not-sr-only">Dark Mode</span>
+                    </button>
+                    <button onclick="logout()" class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white p-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
+                        <i data-feather="log-out" class="w-4 h-4"></i>
+                        <span class="sr-only sm:not-sr-only">Abmelden</span>
+                    </button>
+                    {% if 'roadmap.manage' in permissions %}
+                    <button @click="openNewRoadmap" class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-indigo-200 bg-indigo-50 p-2 text-sm font-semibold text-indigo-700 shadow-sm hover:bg-indigo-100 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
+                        <i data-feather="plus-circle" class="w-4 h-4"></i>
+                        <span class="sr-only sm:not-sr-only">Roadmap erstellen</span>
+                    </button>
+                    {% endif %}
+                </div>
+            </header>
+
+            <main class="flex-1 overflow-auto p-8 pt-24 space-y-8 scrollbar-hide">
+                <section class="rounded-3xl bg-gradient-to-br from-indigo-900 via-slate-800 to-slate-900 px-8 py-8 text-white shadow-2xl shadow-slate-300/50">
+                    <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                        <div>
+                            <p class="text-xs uppercase tracking-[0.3em] text-indigo-200">Roadmap</p>
+                            <h2 class="mt-2 text-3xl font-semibold">Transparente Planung mit Board, Status und Milestones.</h2>
+                            <p class="mt-2 text-sm text-indigo-100">Roadmaps werden automatisch für Verbesserungs-Tickets generiert und zentral mit den Ticket-Daten synchronisiert.</p>
+                        </div>
+                        <div class="grid grid-cols-2 gap-3 text-sm">
+                            <div class="rounded-2xl bg-white/10 px-4 py-3">
+                                <p class="text-xs uppercase text-indigo-100">Geplant</p>
+                                <p class="text-2xl font-semibold" x-text="overview.planned"></p>
+                            </div>
+                            <div class="rounded-2xl bg-white/10 px-4 py-3">
+                                <p class="text-xs uppercase text-indigo-100">In Arbeit</p>
+                                <p class="text-2xl font-semibold" x-text="overview.in_progress"></p>
+                            </div>
+                            <div class="rounded-2xl bg-white/10 px-4 py-3">
+                                <p class="text-xs uppercase text-indigo-100">Blockiert</p>
+                                <p class="text-2xl font-semibold" x-text="overview.blocked"></p>
+                            </div>
+                            <div class="rounded-2xl bg-white/10 px-4 py-3">
+                                <p class="text-xs uppercase text-indigo-100">Erledigt</p>
+                                <p class="text-2xl font-semibold" x-text="overview.done"></p>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="grid gap-6 xl:grid-cols-[0.9fr_1.1fr]">
+                    <div class="space-y-6">
+                        <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm">
+                            <div class="flex flex-wrap items-center gap-4">
+                                <div class="w-full sm:flex-1 sm:min-w-[200px]">
+                                    <label class="text-xs uppercase text-slate-400">Suche</label>
+                                    <input type="text" x-model="filters.search" @input.debounce.300ms="loadRoadmaps" placeholder="Roadmap, Ziel, Ticket" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm shadow-sm">
+                                </div>
+                                <div class="w-full sm:min-w-[160px]">
+                                    <label class="text-xs uppercase text-slate-400">Status</label>
+                                    <select x-model="filters.status" @change="loadRoadmaps" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                        <option value="">Alle</option>
+                                        <template x-for="status in roadmapStatuses" :key="status">
+                                            <option :value="status" x-text="roadmapStatusLabels[status] || status"></option>
+                                        </template>
+                                    </select>
+                                </div>
+                                <label class="inline-flex w-full items-center gap-2 text-sm text-slate-600 sm:w-auto">
+                                    <input type="checkbox" x-model="filters.mine" @change="loadRoadmaps" class="rounded border-slate-300 text-indigo-600">
+                                    Meine Roadmaps
+                                </label>
+                            </div>
+                        </div>
+
+                        <div class="space-y-4">
+                            <template x-for="roadmap in roadmaps" :key="roadmap.id">
+                                <button @click="selectRoadmap(roadmap)" class="w-full text-left rounded-3xl border border-slate-200 bg-white p-5 shadow-sm hover:border-indigo-200 hover:shadow-md transition">
+                                    <div class="flex flex-wrap items-start justify-between gap-3">
+                                        <div>
+                                            <p class="text-xs uppercase text-slate-400">Roadmap #<span x-text="roadmap.id"></span></p>
+                                            <h3 class="text-lg font-semibold text-slate-900" x-text="roadmap.title"></h3>
+                                            <p class="mt-1 text-sm text-slate-500 line-clamp-2" x-text="roadmap.objective || 'Kein Ziel hinterlegt'"></p>
+                                        </div>
+                                        <div class="flex flex-col items-end gap-2">
+                                            <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600" x-text="roadmapStatusLabels[roadmap.status] || roadmap.status"></span>
+                                            <span class="rounded-full px-3 py-1 text-xs font-semibold text-white" :style="`background-color: ${roadmap.category_color || '#6366f1'}`" x-text="roadmap.category_name || 'Roadmap'"></span>
+                                        </div>
+                                    </div>
+                                    <div class="mt-4 flex flex-wrap items-center gap-4 text-xs text-slate-500">
+                                        <span class="inline-flex items-center gap-1"><i data-feather="git-branch" class="w-3 h-3"></i><span x-text="roadmap.step_count || 0"></span> Schritte</span>
+                                        <span class="inline-flex items-center gap-1"><i data-feather="calendar" class="w-3 h-3"></i><span x-text="roadmap.target_date || 'Kein Zieltermin'"></span></span>
+                                        <span class="inline-flex items-center gap-1"><i data-feather="user-check" class="w-3 h-3"></i><span x-text="roadmap.owner || 'Kein Owner'"></span></span>
+                                    </div>
+                                </button>
+                            </template>
+                            <div x-show="roadmaps.length === 0" class="rounded-3xl border border-dashed border-slate-300 bg-slate-50 p-10 text-center text-slate-500">
+                                Keine Roadmaps gefunden. Erstelle die erste Roadmap.
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="space-y-6">
+                        <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm" x-show="selectedRoadmap">
+                            <template x-if="selectedRoadmap">
+                                <div class="space-y-5">
+                                    <div class="flex items-start justify-between gap-4">
+                                        <div>
+                                            <p class="text-xs uppercase text-slate-400">Aktive Roadmap</p>
+                                            <h3 class="text-xl font-semibold text-slate-900" x-text="selectedRoadmap.title"></h3>
+                                            <p class="text-sm text-slate-500" x-text="selectedRoadmap.objective || 'Kein Ziel definiert.'"></p>
+                                        </div>
+                                        <button @click="closeRoadmap" class="text-slate-400 hover:text-slate-700">
+                                            <i data-feather="x" class="w-4 h-4"></i>
+                                        </button>
+                                    </div>
+
+                                    <div class="grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
+                                        <label class="flex flex-col gap-1">
+                                            <span class="text-xs uppercase text-slate-400">Owner</span>
+                                            <input type="text" x-model="selectedRoadmap.owner" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
+                                        </label>
+                                        <label class="flex flex-col gap-1">
+                                            <span class="text-xs uppercase text-slate-400">Status</span>
+                                            <select x-model="selectedRoadmap.status" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
+                                                <template x-for="status in roadmapStatuses" :key="status">
+                                                    <option :value="status" x-text="roadmapStatusLabels[status] || status"></option>
+                                                </template>
+                                            </select>
+                                        </label>
+                                        <label class="flex flex-col gap-1">
+                                            <span class="text-xs uppercase text-slate-400">Start</span>
+                                            <input type="date" x-model="selectedRoadmap.start_date" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
+                                        </label>
+                                        <label class="flex flex-col gap-1">
+                                            <span class="text-xs uppercase text-slate-400">Ziel</span>
+                                            <input type="date" x-model="selectedRoadmap.target_date" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
+                                        </label>
+                                    </div>
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                        <input type="text" x-model="selectedRoadmap.title" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
+                                        <button @click="saveRoadmap" class="w-full rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white sm:w-auto" :disabled="!can('roadmap.manage')">Roadmap speichern</button>
+                                    </div>
+                                    <textarea x-model="selectedRoadmap.objective" rows="3" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')" placeholder="Ziel / Outcome"></textarea>
+                                </div>
+                            </template>
+                        </div>
+
+                        <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm" x-show="selectedRoadmap">
+                            <div class="flex flex-col gap-4">
+                                <div class="flex items-center justify-between">
+                                    <div>
+                                        <p class="text-xs uppercase text-slate-400">Roadmap Board</p>
+                                        <p class="text-sm font-semibold text-slate-700">Schritte, Status & Abhängigkeiten</p>
+                                    </div>
+                                    <button @click="toggleStepForm" class="rounded-2xl border border-indigo-200 bg-indigo-50 px-4 py-2 text-xs font-semibold text-indigo-700" x-show="can('roadmap.manage')">
+                                        Schritt hinzufügen
+                                    </button>
+                                </div>
+
+                                <div x-show="stepFormOpen" class="rounded-2xl border border-slate-200 bg-slate-50 p-4 space-y-3">
+                                    <div class="grid gap-3 sm:grid-cols-2">
+                                        <input type="text" x-model="newStep.title" placeholder="Titel" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                        <input type="text" x-model="newStep.owner" placeholder="Owner" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                    </div>
+                                    <textarea x-model="newStep.description" rows="2" placeholder="Beschreibung" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm"></textarea>
+                                    <div class="grid gap-3 sm:grid-cols-2">
+                                        <select x-model="newStep.status" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                            <template x-for="status in roadmapStatuses" :key="status">
+                                                <option :value="status" x-text="roadmapStatusLabels[status] || status"></option>
+                                            </template>
+                                        </select>
+                                        <input type="date" x-model="newStep.due_date" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                    </div>
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                                        <button @click="stepFormOpen = false" class="rounded-2xl border border-slate-200 px-4 py-2 text-xs">Abbrechen</button>
+                                        <button @click="addStep" class="rounded-2xl bg-indigo-600 px-4 py-2 text-xs font-semibold text-white">Schritt speichern</button>
+                                    </div>
+                                </div>
+
+                                <div class="grid gap-4 lg:grid-cols-4">
+                                    <template x-for="status in roadmapStatuses" :key="status">
+                                        <div class="rounded-2xl border border-slate-200 bg-slate-50/70 p-3 space-y-3">
+                                            <div class="flex items-center justify-between">
+                                                <p class="text-xs uppercase text-slate-400" x-text="roadmapStatusLabels[status] || status"></p>
+                                                <span class="text-xs text-slate-400" x-text="stepsByStatus(status).length"></span>
+                                            </div>
+                                            <template x-for="step in stepsByStatus(status)" :key="step.id">
+                                                <div class="rounded-2xl border border-slate-200 bg-white p-3 text-sm space-y-2">
+                                                    <div class="flex items-start justify-between gap-2">
+                                                        <div>
+                                                            <p class="font-semibold text-slate-800" x-text="step.title"></p>
+                                                            <p class="text-xs text-slate-500" x-text="step.description || 'Keine Beschreibung'"></p>
+                                                        </div>
+                                                        <button @click="deleteStep(step)" class="text-slate-400 hover:text-rose-500" x-show="can('roadmap.manage')">
+                                                            <i data-feather="trash-2" class="w-4 h-4"></i>
+                                                        </button>
+                                                    </div>
+                                                    <div class="grid gap-2 text-xs text-slate-500">
+                                                        <input type="text" x-model="step.owner" placeholder="Owner" class="rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                        <input type="date" x-model="step.due_date" class="rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                        <select x-model="step.status" class="rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                            <template x-for="statusOption in roadmapStatuses" :key="statusOption">
+                                                                <option :value="statusOption" x-text="roadmapStatusLabels[statusOption] || statusOption"></option>
+                                                            </template>
+                                                        </select>
+                                                        <button @click="updateStep(step)" class="rounded-xl bg-slate-900 px-3 py-1 text-[11px] font-semibold text-white" :disabled="!can('roadmap.manage')">Speichern</button>
+                                                    </div>
+                                                </div>
+                                            </template>
+                                            <div x-show="stepsByStatus(status).length === 0" class="rounded-2xl border border-dashed border-slate-200 bg-white px-3 py-6 text-center text-xs text-slate-400">
+                                                Keine Schritte
+                                            </div>
+                                        </div>
+                                    </template>
+                                </div>
+                            </div>
+                        </div>
+                        <div x-show="!selectedRoadmap" class="rounded-3xl border border-dashed border-slate-300 bg-slate-50 p-10 text-center text-slate-500">
+                            Wähle eine Roadmap aus, um Details und Board zu sehen.
+                        </div>
+                    </div>
+                </section>
+            </main>
+        </div>
+    </div>
+
+    <div x-show="roadmapModalOpen" x-transition class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 p-4">
+        <div @click.away="roadmapModalOpen = false" class="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-3xl bg-white p-6 shadow-xl">
+            <div class="flex items-start justify-between">
+                <div>
+                    <p class="text-xs uppercase text-slate-400">Neue Roadmap</p>
+                    <h3 class="text-xl font-semibold text-slate-900">Roadmap erstellen</h3>
+                </div>
+                <button @click="roadmapModalOpen = false" class="text-slate-400 hover:text-slate-700">
+                    <i data-feather="x" class="w-4 h-4"></i>
+                </button>
+            </div>
+            <div class="mt-4 grid gap-3">
+                <input type="text" x-model="newRoadmap.title" placeholder="Titel" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                <textarea x-model="newRoadmap.objective" rows="3" placeholder="Ziel / Outcome" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm"></textarea>
+                <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <input type="text" x-model="newRoadmap.owner" placeholder="Owner" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                    <select x-model="newRoadmap.status" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                        <template x-for="status in roadmapStatuses" :key="status">
+                            <option :value="status" x-text="roadmapStatusLabels[status] || status"></option>
+                        </template>
+                    </select>
+                </div>
+                <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <input type="date" x-model="newRoadmap.start_date" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                    <input type="date" x-model="newRoadmap.target_date" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                </div>
+                <input type="number" x-model="newRoadmap.ticket_id" placeholder="Ticket-ID (optional)" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                <button @click="createRoadmap" class="rounded-2xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white">Roadmap speichern</button>
+                <p class="text-xs text-rose-500" x-text="roadmapError"></p>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://unpkg.com/feather-icons"></script>
+    <script>
+        async function logout() {
+            try {
+                const response = await fetch('/logout', {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: { 'Content-Type': 'application/json' }
+                });
+
+                if (response.ok) {
+                    window.location.href = '/login';
+                } else {
+                    const data = await response.json();
+                    alert('Logout failed: ' + (data.error || 'Unknown error'));
+                }
+            } catch (error) {
+                alert('Network error: ' + error.message);
+            }
+        }
+    </script>
+    <script src="/static/roadmap.js"></script>
+    <script src="/static/ui.js"></script>
+    <script src="/static/theme.js"></script>
+</body>
+</html>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -66,6 +66,17 @@
                     <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
                 </a>
                 {% endif %}
+                {% if 'roadmap.view' in permissions or 'roadmap.manage' in permissions %}
+                <a href="/roadmap" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-indigo-50 text-indigo-600 mr-3">
+                            <i data-feather="git-merge" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Roadmap</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
+                {% endif %}
 				<a href="/stats" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-indigo-100 bg-indigo-50 text-sm font-semibold text-indigo-700">
                     <span class="flex items-center">
                         <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-indigo-100 text-indigo-600 mr-3">

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -55,6 +55,17 @@
                     <i data-feather="clipboard" class="w-4 h-4 text-amber-400"></i>
                 </a>
                 {% endif %}
+                {% if 'roadmap.view' in permissions or 'roadmap.manage' in permissions %}
+                <a href="/roadmap" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-500 mr-3">
+                            <i data-feather="git-merge" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Roadmap</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
+                {% endif %}
                 {% if 'stats.view' in permissions %}
                 <a href="/stats" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
                     <span class="flex items-center">
@@ -296,6 +307,39 @@
                                             </template>
                                             <p x-show="(selectedTicket.assets || []).length === 0" class="text-xs text-slate-400">Noch keine Assets zugewiesen.</p>
                                         </div>
+                                    </div>
+
+                                    <div class="mt-5 rounded-2xl border border-slate-200 bg-white p-4" x-show="can('roadmap.view') || can('roadmap.manage')">
+                                        <div class="flex items-center justify-between gap-3">
+                                            <div>
+                                                <p class="text-xs uppercase text-slate-400">Roadmap</p>
+                                                <p class="text-sm font-semibold text-slate-700">Planung & Umsetzung</p>
+                                            </div>
+                                            <div class="flex flex-wrap gap-2">
+                                                <a :href="selectedTicket ? `/roadmap?ticket_id=${selectedTicket.id}` : '/roadmap'" class="rounded-2xl border border-indigo-200 bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700">Board öffnen</a>
+                                                <button x-show="!selectedTicket.roadmap && can('roadmap.manage')" @click="createRoadmapForTicket" class="rounded-2xl border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700">Roadmap anlegen</button>
+                                            </div>
+                                        </div>
+                                        <div class="mt-3 space-y-3" x-show="selectedTicket.roadmap">
+                                            <div class="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                                                <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600" x-text="roadmapStatusLabels[selectedTicket.roadmap.status] || selectedTicket.roadmap.status"></span>
+                                                <span class="inline-flex items-center gap-1"><i data-feather="user-check" class="w-3 h-3"></i><span x-text="selectedTicket.roadmap.owner || 'Kein Owner'"></span></span>
+                                                <span class="inline-flex items-center gap-1"><i data-feather="calendar" class="w-3 h-3"></i><span x-text="selectedTicket.roadmap.target_date || 'Kein Zieltermin'"></span></span>
+                                            </div>
+                                            <div class="grid gap-2 text-xs text-slate-500">
+                                                <template x-for="step in (selectedTicket.roadmap.steps || [])" :key="step.id">
+                                                    <div class="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2">
+                                                        <div class="flex items-center justify-between">
+                                                            <p class="font-semibold text-slate-700" x-text="step.title"></p>
+                                                            <span class="text-[11px] text-slate-500" x-text="roadmapStatusLabels[step.status] || step.status"></span>
+                                                        </div>
+                                                        <p class="text-[11px] text-slate-500" x-text="step.description || 'Keine Beschreibung'"></p>
+                                                    </div>
+                                                </template>
+                                                <p x-show="(selectedTicket.roadmap.steps || []).length === 0" class="text-xs text-slate-400">Noch keine Roadmap-Schritte definiert.</p>
+                                            </div>
+                                        </div>
+                                        <p class="mt-3 text-xs text-slate-400" x-show="!selectedTicket.roadmap">Noch keine Roadmap für dieses Ticket vorhanden.</p>
                                     </div>
 
                                     <div class="mt-5" x-show="can('tickets.watch') || can('tickets.watch_own')">

--- a/templates/users.html
+++ b/templates/users.html
@@ -56,6 +56,17 @@
                     <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
                 </a>
                 {% endif %}
+                {% if 'roadmap.view' in permissions or 'roadmap.manage' in permissions %}
+                <a href="/roadmap" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
+                    <span class="flex items-center">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-xl bg-indigo-50 text-indigo-600 mr-3">
+                            <i data-feather="git-merge" class="w-4 h-4"></i>
+                        </span>
+                        <span class="sidebar-text">Roadmap</span>
+                    </span>
+                    <i data-feather="arrow-up-right" class="w-4 h-4 text-slate-400"></i>
+                </a>
+                {% endif %}
                 {% if 'stats.view' in permissions %}
                 <a href="/stats" class="flex items-center justify-between px-4 py-3 rounded-2xl border border-slate-200 bg-white/70 text-sm font-semibold text-slate-700 hover:text-slate-900 hover:bg-white transition-colors">
                     <span class="flex items-center">


### PR DESCRIPTION
### Motivation

- Provide a professional, deeply integrated roadmap/road‑board feature that ties into the ticket system and is automatically created for improvement-type tickets. 
- Enable teams to plan, track and execute implementation steps per ticket with a board-like UI similar to GitHub Projects.

### Description

- Added roadmap permissions (`roadmap.view`, `roadmap.manage`) and granted them to default roles. 
- Introduced database schema for `roadmaps` and `roadmap_steps` and seeded a new ticket category `Verbesserungen` for improvements. 
- Implemented helpers `should_auto_create_roadmap` and `create_roadmap_for_ticket` to auto-generate a roadmap (with default steps) when relevant tickets are created or updated. 
- Added REST API endpoints to manage roadmaps and steps (`/api/roadmaps`, `/api/roadmaps/<id>`, `/api/roadmaps/<id>/steps`, etc.) and integrated roadmap data into ticket fetch endpoints. 
- Added a new UI: `templates/roadmap.html` plus client logic in `static/roadmap.js`, linked navigation entries across templates, and integrated roadmap controls into the ticket detail UI and `static/tickets.js` (manual create, open board, show roadmap steps). 

### Testing

- Initialized and seeded the database via `init_db()` and created a test user with `create_user('roadmap_tester','Roadmap123!')`; these completed successfully. 
- Inserted sample ticket + roadmap rows using an inline Python script and committed the DB changes; script ran without errors. 
- Started the development server with `python app.py` and performed an automated UI smoke test using Playwright that logged in as the test user, navigated to `/roadmap` and produced a screenshot (`artifacts/roadmap-board.png`); the page loaded and the screenshot was generated successfully. 
- All performed integration/smoke checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6974fd2340688331923f972022676b9d)