### PR TITLE
Stabilize roadmap steps and editing flow

### DIFF
--- a/static/roadmap.js
+++ b/static/roadmap.js
@@ -97,7 +97,14 @@ document.addEventListener('alpine:init', () => {
         async selectRoadmap(roadmap) {
             const response = await fetch(`/api/roadmaps/${roadmap.id}`);
             if (response.ok) {
-                this.selectedRoadmap = await response.json();
+                const roadmapData = await response.json();
+                if (Array.isArray(roadmapData.steps)) {
+                    roadmapData.steps = roadmapData.steps.map((step) => ({
+                        ...step,
+                        ui_status: step.status
+                    }));
+                }
+                this.selectedRoadmap = roadmapData;
                 this.stepFormOpen = false;
             }
             this.$nextTick(() => feather.replace());
@@ -160,7 +167,7 @@ document.addEventListener('alpine:init', () => {
             const payload = {
                 title: step.title,
                 description: step.description,
-                status: step.status,
+                status: step.ui_status || step.status,
                 owner: step.owner,
                 due_date: step.due_date,
                 position: step.position

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -292,26 +292,27 @@
 
                                 <div class="grid gap-4 lg:grid-cols-4">
                                     <template x-for="status in roadmapStatuses" :key="status">
-                                        <div class="rounded-2xl border border-slate-200 bg-slate-50/70 p-3 space-y-3">
+                                        <div class="rounded-2xl border border-slate-200 bg-slate-50/70 p-3 min-w-0">
                                             <div class="flex items-center justify-between">
                                                 <p class="text-xs uppercase text-slate-400" x-text="roadmapStatusLabels[status] || status"></p>
                                                 <span class="text-xs text-slate-400" x-text="stepsByStatus(status).length"></span>
                                             </div>
-                                            <template x-for="step in stepsByStatus(status)" :key="step.id">
-                                                <div class="rounded-2xl border border-slate-200 bg-white p-3 text-sm space-y-2">
+                                            <div class="flex flex-col gap-3">
+                                                <template x-for="step in stepsByStatus(status)" :key="step.id">
+                                                    <div class="rounded-2xl border border-slate-200 bg-white p-3 text-sm shadow-sm flex flex-col gap-3 min-w-0">
                                                     <div class="flex items-start justify-between gap-2">
                                                         <div>
-                                                            <p class="font-semibold text-slate-800" x-text="step.title"></p>
-                                                            <p class="text-xs text-slate-500" x-text="step.description || 'Keine Beschreibung'"></p>
+                                                            <p class="font-semibold text-slate-800 break-words" x-text="step.title"></p>
+                                                            <p class="text-xs text-slate-500 break-words" x-text="step.description || 'Keine Beschreibung'"></p>
                                                         </div>
                                                         <button @click="deleteStep(step)" class="text-slate-400 hover:text-rose-500" x-show="can('roadmap.manage')">
                                                             <i data-feather="trash-2" class="w-4 h-4"></i>
                                                         </button>
                                                     </div>
                                                     <div class="grid gap-2 text-xs text-slate-500">
-                                                        <input type="text" x-model="step.owner" placeholder="Owner" class="rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
-                                                        <input type="date" x-model="step.due_date" class="rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
-                                                        <select x-model="step.status" class="rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                        <input type="text" x-model="step.owner" placeholder="Owner" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                        <input type="date" x-model="step.due_date" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                        <select x-model="step.ui_status" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
                                                             <template x-for="statusOption in roadmapStatuses" :key="statusOption">
                                                                 <option :value="statusOption" x-text="roadmapStatusLabels[statusOption] || statusOption"></option>
                                                             </template>
@@ -319,9 +320,10 @@
                                                         <button @click="updateStep(step)" class="rounded-xl bg-slate-900 px-3 py-1 text-[11px] font-semibold text-white" :disabled="!can('roadmap.manage')">Speichern</button>
                                                     </div>
                                                 </div>
-                                            </template>
-                                            <div x-show="stepsByStatus(status).length === 0" class="rounded-2xl border border-dashed border-slate-200 bg-white px-3 py-6 text-center text-xs text-slate-400">
-                                                Keine Schritte
+                                                </template>
+                                                <div x-show="stepsByStatus(status).length === 0" class="rounded-2xl border border-dashed border-slate-200 bg-white px-3 py-6 text-center text-xs text-slate-400">
+                                                    Keine Schritte
+                                                </div>
                                             </div>
                                         </div>
                                     </template>


### PR DESCRIPTION
### Motivation
- Roadmap step cards glitched and jumped between columns while editing, making the board unusable.  
- The intent is to keep a step visually in its current column while the user edits it and only move it after an explicit save.  
- The board layout needed refinement to avoid overlapping cards and improve readability on smaller columns.

### Description
- Introduced a UI-only status field by mapping `step.status` to `ui_status` in `selectRoadmap` inside `static/roadmap.js`.  
- Updated `updateStep` to send `status: step.ui_status || step.status` so edits use the UI-bound value only after save in `static/roadmap.js`.  
- Bound the status select to `step.ui_status` and tightened card layout in `templates/roadmap.html` using `min-w-0`, `flex`/`gap` helpers, `shadow-sm`, `break-words`, and full-width inputs to prevent overlap and improve wrapping.  
- Kept `stepsByStatus` filtering on the server-backed `step.status` so cards remain in their column until the change is persisted.

### Testing
- Started the development server with `python app.py`, which launched successfully.  
- Ran an automated Playwright script that navigated to `/roadmap` and produced a screenshot artifact (`artifacts/roadmap.png`), which completed successfully.  
- No unit tests were added because this is a UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697501d74d1483318df522faa4738360)