### PR TITLE
Revamp roadmap layout for clearer step editing

### DIFF
--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -161,7 +161,7 @@
                     </div>
                 </section>
 
-                <section class="grid gap-6 xl:grid-cols-[0.9fr_1.1fr]">
+                <section class="grid gap-6 xl:grid-cols-[0.85fr_1.15fr]">
                     <div class="space-y-6">
                         <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm">
                             <div class="flex flex-wrap items-center gap-4">
@@ -215,19 +215,19 @@
                     <div class="space-y-6">
                         <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm" x-show="selectedRoadmap">
                             <template x-if="selectedRoadmap">
-                                <div class="space-y-5">
-                                    <div class="flex items-start justify-between gap-4">
-                                        <div>
+                                <div class="space-y-6">
+                                    <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                                        <div class="space-y-1">
                                             <p class="text-xs uppercase text-slate-400">Aktive Roadmap</p>
                                             <h3 class="text-xl font-semibold text-slate-900" x-text="selectedRoadmap.title"></h3>
                                             <p class="text-sm text-slate-500" x-text="selectedRoadmap.objective || 'Kein Ziel definiert.'"></p>
                                         </div>
-                                        <button @click="closeRoadmap" class="text-slate-400 hover:text-slate-700">
+                                        <button @click="closeRoadmap" class="self-end text-slate-400 hover:text-slate-700">
                                             <i data-feather="x" class="w-4 h-4"></i>
                                         </button>
                                     </div>
 
-                                    <div class="grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
+                                    <div class="grid gap-4 rounded-2xl border border-slate-200 bg-slate-50/70 p-4 text-sm text-slate-600 lg:grid-cols-4">
                                         <label class="flex flex-col gap-1">
                                             <span class="text-xs uppercase text-slate-400">Owner</span>
                                             <input type="text" x-model="selectedRoadmap.owner" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
@@ -249,9 +249,10 @@
                                             <input type="date" x-model="selectedRoadmap.target_date" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
                                         </label>
                                     </div>
-                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+
+                                    <div class="grid gap-3 lg:grid-cols-[1fr_auto] lg:items-center">
                                         <input type="text" x-model="selectedRoadmap.title" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
-                                        <button @click="saveRoadmap" class="w-full rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white sm:w-auto" :disabled="!can('roadmap.manage')">Roadmap speichern</button>
+                                        <button @click="saveRoadmap" class="w-full rounded-2xl bg-slate-900 px-5 py-2 text-sm font-semibold text-white shadow-sm lg:w-auto" :disabled="!can('roadmap.manage')">Roadmap speichern</button>
                                     </div>
                                     <textarea x-model="selectedRoadmap.objective" rows="3" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')" placeholder="Ziel / Outcome"></textarea>
                                 </div>
@@ -259,67 +260,76 @@
                         </div>
 
                         <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm" x-show="selectedRoadmap">
-                            <div class="flex flex-col gap-4">
-                                <div class="flex items-center justify-between">
+                            <div class="flex flex-col gap-5">
+                                <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                                     <div>
                                         <p class="text-xs uppercase text-slate-400">Roadmap Board</p>
                                         <p class="text-sm font-semibold text-slate-700">Schritte, Status & Abhängigkeiten</p>
                                     </div>
-                                    <button @click="toggleStepForm" class="rounded-2xl border border-indigo-200 bg-indigo-50 px-4 py-2 text-xs font-semibold text-indigo-700" x-show="can('roadmap.manage')">
+                                    <button @click="toggleStepForm" class="rounded-2xl border border-indigo-200 bg-indigo-50 px-4 py-2 text-xs font-semibold text-indigo-700 shadow-sm" x-show="can('roadmap.manage')">
                                         Schritt hinzufügen
                                     </button>
                                 </div>
 
                                 <div x-show="stepFormOpen" class="rounded-2xl border border-slate-200 bg-slate-50 p-4 space-y-3">
-                                    <div class="grid gap-3 sm:grid-cols-2">
+                                    <div class="grid gap-3 lg:grid-cols-3">
                                         <input type="text" x-model="newStep.title" placeholder="Titel" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
                                         <input type="text" x-model="newStep.owner" placeholder="Owner" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
-                                    </div>
-                                    <textarea x-model="newStep.description" rows="2" placeholder="Beschreibung" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm"></textarea>
-                                    <div class="grid gap-3 sm:grid-cols-2">
                                         <select x-model="newStep.status" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
                                             <template x-for="status in roadmapStatuses" :key="status">
                                                 <option :value="status" x-text="roadmapStatusLabels[status] || status"></option>
                                             </template>
                                         </select>
-                                        <input type="date" x-model="newStep.due_date" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
                                     </div>
-                                    <div class="flex flex-col gap-2 sm:flex-row sm:justify-end">
-                                        <button @click="stepFormOpen = false" class="rounded-2xl border border-slate-200 px-4 py-2 text-xs">Abbrechen</button>
-                                        <button @click="addStep" class="rounded-2xl bg-indigo-600 px-4 py-2 text-xs font-semibold text-white">Schritt speichern</button>
+                                    <textarea x-model="newStep.description" rows="2" placeholder="Beschreibung" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm"></textarea>
+                                    <div class="grid gap-3 sm:grid-cols-2">
+                                        <input type="date" x-model="newStep.due_date" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                        <div class="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                                            <button @click="stepFormOpen = false" class="rounded-2xl border border-slate-200 px-4 py-2 text-xs">Abbrechen</button>
+                                            <button @click="addStep" class="rounded-2xl bg-indigo-600 px-4 py-2 text-xs font-semibold text-white">Schritt speichern</button>
+                                        </div>
                                     </div>
                                 </div>
 
-                                <div class="grid gap-4 lg:grid-cols-4">
+                                <div class="grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
                                     <template x-for="status in roadmapStatuses" :key="status">
                                         <div class="rounded-2xl border border-slate-200 bg-slate-50/70 p-3 min-w-0">
-                                            <div class="flex items-center justify-between">
+                                            <div class="flex items-center justify-between pb-2">
                                                 <p class="text-xs uppercase text-slate-400" x-text="roadmapStatusLabels[status] || status"></p>
                                                 <span class="text-xs text-slate-400" x-text="stepsByStatus(status).length"></span>
                                             </div>
                                             <div class="flex flex-col gap-3">
                                                 <template x-for="step in stepsByStatus(status)" :key="step.id">
-                                                    <div class="rounded-2xl border border-slate-200 bg-white p-3 text-sm shadow-sm flex flex-col gap-3 min-w-0">
-                                                    <div class="flex items-start justify-between gap-2">
-                                                        <div>
-                                                            <p class="font-semibold text-slate-800 break-words" x-text="step.title"></p>
-                                                            <p class="text-xs text-slate-500 break-words" x-text="step.description || 'Keine Beschreibung'"></p>
+                                                    <div class="rounded-2xl border border-slate-200 bg-white p-4 text-sm shadow-sm flex flex-col gap-4 min-w-0">
+                                                        <div class="flex items-start justify-between gap-3">
+                                                            <div class="space-y-1 min-w-0">
+                                                                <p class="font-semibold text-slate-800 break-words" x-text="step.title"></p>
+                                                                <p class="text-xs text-slate-500 break-words" x-text="step.description || 'Keine Beschreibung'"></p>
+                                                            </div>
+                                                            <button @click="deleteStep(step)" class="shrink-0 text-slate-400 hover:text-rose-500" x-show="can('roadmap.manage')">
+                                                                <i data-feather="trash-2" class="w-4 h-4"></i>
+                                                            </button>
                                                         </div>
-                                                        <button @click="deleteStep(step)" class="text-slate-400 hover:text-rose-500" x-show="can('roadmap.manage')">
-                                                            <i data-feather="trash-2" class="w-4 h-4"></i>
-                                                        </button>
+                                                        <div class="grid gap-3 text-xs text-slate-500">
+                                                            <label class="space-y-1">
+                                                                <span class="text-[11px] uppercase text-slate-400">Owner</span>
+                                                                <input type="text" x-model="step.owner" placeholder="Owner" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1.5" :disabled="!can('roadmap.manage')">
+                                                            </label>
+                                                            <label class="space-y-1">
+                                                                <span class="text-[11px] uppercase text-slate-400">Fällig</span>
+                                                                <input type="date" x-model="step.due_date" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1.5" :disabled="!can('roadmap.manage')">
+                                                            </label>
+                                                            <label class="space-y-1">
+                                                                <span class="text-[11px] uppercase text-slate-400">Status</span>
+                                                                <select x-model="step.ui_status" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1.5" :disabled="!can('roadmap.manage')">
+                                                                    <template x-for="statusOption in roadmapStatuses" :key="statusOption">
+                                                                        <option :value="statusOption" x-text="roadmapStatusLabels[statusOption] || statusOption"></option>
+                                                                    </template>
+                                                                </select>
+                                                            </label>
+                                                            <button @click="updateStep(step)" class="w-full rounded-xl bg-slate-900 px-3 py-2 text-[11px] font-semibold text-white shadow-sm" :disabled="!can('roadmap.manage')">Speichern</button>
+                                                        </div>
                                                     </div>
-                                                    <div class="grid gap-2 text-xs text-slate-500">
-                                                        <input type="text" x-model="step.owner" placeholder="Owner" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
-                                                        <input type="date" x-model="step.due_date" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
-                                                        <select x-model="step.ui_status" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
-                                                            <template x-for="statusOption in roadmapStatuses" :key="statusOption">
-                                                                <option :value="statusOption" x-text="roadmapStatusLabels[statusOption] || statusOption"></option>
-                                                            </template>
-                                                        </select>
-                                                        <button @click="updateStep(step)" class="rounded-xl bg-slate-900 px-3 py-1 text-[11px] font-semibold text-white" :disabled="!can('roadmap.manage')">Speichern</button>
-                                                    </div>
-                                                </div>
                                                 </template>
                                                 <div x-show="stepsByStatus(status).length === 0" class="rounded-2xl border border-dashed border-slate-200 bg-white px-3 py-6 text-center text-xs text-slate-400">
                                                     Keine Schritte


### PR DESCRIPTION
### Motivation
- Fix layout issues where step input fields and the save button extended beyond the board frame and blocked the workflow. 
- Provide a much more practical, responsive and user-friendly Roadmap UI/UX so step editing is clear, compact and non-obtrusive.

### Description
- Reworked the Roadmap detail panel structure and spacing for clearer grouping of metadata and actions by updating `templates/roadmap.html`.
- Adjusted the page grid (`xl:grid-cols`) to give more room to the detail panel and prevent overflow of form controls.
- Reorganized roadmap metadata into a compact, bordered grid (owner, status, start, target) and moved the title + save action into a responsive two-column layout to avoid buttons overflowing the card.
- Redesigned the step creation form and step cards: inputs are laid out in responsive columns, step cards have increased padding and stacked controls (owner, due date, status, save) to keep everything inside the board columns.

### Testing
- Started the dev server with `python app.py`; server ran and served `/roadmap` successfully.
- Updated a test user password in `inventory.db` and performed an automated login and page navigation with a Playwright script, then captured a screenshot; the Firefox run succeeded and produced `artifacts/roadmap-redesign.png`.
- A Chromium Playwright run failed in this environment due to browser/host constraints (environmental crash), but the Firefox run validated the UI changes visually and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697503a2c9a0833190d88cc67e60d52b)