### PR TITLE
Improve roadmap board layout

### DIFF
--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -215,52 +215,67 @@
                     <div class="space-y-6">
                         <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm" x-show="selectedRoadmap">
                             <template x-if="selectedRoadmap">
-                                <div class="space-y-5">
-                                    <div class="flex items-start justify-between gap-4">
-                                        <div>
+                                <div class="space-y-6">
+                                    <div class="flex flex-wrap items-start justify-between gap-4">
+                                        <div class="min-w-0">
                                             <p class="text-xs uppercase text-slate-400">Aktive Roadmap</p>
-                                            <h3 class="text-xl font-semibold text-slate-900" x-text="selectedRoadmap.title"></h3>
-                                            <p class="text-sm text-slate-500" x-text="selectedRoadmap.objective || 'Kein Ziel definiert.'"></p>
+                                            <h3 class="text-xl font-semibold text-slate-900 break-words" x-text="selectedRoadmap.title"></h3>
+                                            <p class="text-sm text-slate-500 break-words" x-text="selectedRoadmap.objective || 'Kein Ziel definiert.'"></p>
                                         </div>
-                                        <button @click="closeRoadmap" class="text-slate-400 hover:text-slate-700">
+                                        <button @click="closeRoadmap" class="rounded-full border border-slate-200 bg-white p-2 text-slate-400 hover:text-slate-700">
                                             <i data-feather="x" class="w-4 h-4"></i>
                                         </button>
                                     </div>
 
-                                    <div class="grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
-                                        <label class="flex flex-col gap-1">
-                                            <span class="text-xs uppercase text-slate-400">Owner</span>
-                                            <input type="text" x-model="selectedRoadmap.owner" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
-                                        </label>
-                                        <label class="flex flex-col gap-1">
-                                            <span class="text-xs uppercase text-slate-400">Status</span>
-                                            <select x-model="selectedRoadmap.status" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
-                                                <template x-for="status in roadmapStatuses" :key="status">
-                                                    <option :value="status" x-text="roadmapStatusLabels[status] || status"></option>
-                                                </template>
-                                            </select>
-                                        </label>
-                                        <label class="flex flex-col gap-1">
-                                            <span class="text-xs uppercase text-slate-400">Start</span>
-                                            <input type="date" x-model="selectedRoadmap.start_date" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
-                                        </label>
-                                        <label class="flex flex-col gap-1">
-                                            <span class="text-xs uppercase text-slate-400">Ziel</span>
-                                            <input type="date" x-model="selectedRoadmap.target_date" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
-                                        </label>
+                                    <div class="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                                        <div class="space-y-3 rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
+                                            <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Rahmen</p>
+                                            <div class="grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
+                                                <label class="flex flex-col gap-1">
+                                                    <span class="text-[11px] uppercase text-slate-400">Owner</span>
+                                                    <input type="text" x-model="selectedRoadmap.owner" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
+                                                </label>
+                                                <label class="flex flex-col gap-1">
+                                                    <span class="text-[11px] uppercase text-slate-400">Status</span>
+                                                    <select x-model="selectedRoadmap.status" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
+                                                        <template x-for="status in roadmapStatuses" :key="status">
+                                                            <option :value="status" x-text="roadmapStatusLabels[status] || status"></option>
+                                                        </template>
+                                                    </select>
+                                                </label>
+                                                <label class="flex flex-col gap-1">
+                                                    <span class="text-[11px] uppercase text-slate-400">Start</span>
+                                                    <input type="date" x-model="selectedRoadmap.start_date" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
+                                                </label>
+                                                <label class="flex flex-col gap-1">
+                                                    <span class="text-[11px] uppercase text-slate-400">Ziel</span>
+                                                    <input type="date" x-model="selectedRoadmap.target_date" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
+                                                </label>
+                                            </div>
+                                        </div>
+
+                                        <div class="space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+                                            <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Details</p>
+                                            <label class="flex flex-col gap-1">
+                                                <span class="text-[11px] uppercase text-slate-400">Titel</span>
+                                                <input type="text" x-model="selectedRoadmap.title" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
+                                            </label>
+                                            <label class="flex flex-col gap-1">
+                                                <span class="text-[11px] uppercase text-slate-400">Ziel / Outcome</span>
+                                                <textarea x-model="selectedRoadmap.objective" rows="3" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')" placeholder="Ziel / Outcome"></textarea>
+                                            </label>
+                                            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+                                                <button @click="saveRoadmap" class="w-full rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white sm:w-auto" :disabled="!can('roadmap.manage')">Roadmap speichern</button>
+                                            </div>
+                                        </div>
                                     </div>
-                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                                        <input type="text" x-model="selectedRoadmap.title" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')">
-                                        <button @click="saveRoadmap" class="w-full rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white sm:w-auto" :disabled="!can('roadmap.manage')">Roadmap speichern</button>
-                                    </div>
-                                    <textarea x-model="selectedRoadmap.objective" rows="3" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" :disabled="!can('roadmap.manage')" placeholder="Ziel / Outcome"></textarea>
                                 </div>
                             </template>
                         </div>
 
                         <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm" x-show="selectedRoadmap">
-                            <div class="flex flex-col gap-4">
-                                <div class="flex items-center justify-between">
+                            <div class="flex flex-col gap-6">
+                                <div class="flex flex-wrap items-center justify-between gap-4">
                                     <div>
                                         <p class="text-xs uppercase text-slate-400">Roadmap Board</p>
                                         <p class="text-sm font-semibold text-slate-700">Schritte, Status & Abhängigkeiten</p>
@@ -270,19 +285,34 @@
                                     </button>
                                 </div>
 
-                                <div x-show="stepFormOpen" class="rounded-2xl border border-slate-200 bg-slate-50 p-4 space-y-3">
+                                <div x-show="stepFormOpen" class="rounded-2xl border border-slate-200 bg-slate-50 p-4 space-y-4">
                                     <div class="grid gap-3 sm:grid-cols-2">
-                                        <input type="text" x-model="newStep.title" placeholder="Titel" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
-                                        <input type="text" x-model="newStep.owner" placeholder="Owner" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                        <label class="flex flex-col gap-1">
+                                            <span class="text-[11px] uppercase text-slate-400">Titel</span>
+                                            <input type="text" x-model="newStep.title" placeholder="Titel" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                        </label>
+                                        <label class="flex flex-col gap-1">
+                                            <span class="text-[11px] uppercase text-slate-400">Owner</span>
+                                            <input type="text" x-model="newStep.owner" placeholder="Owner" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                        </label>
                                     </div>
-                                    <textarea x-model="newStep.description" rows="2" placeholder="Beschreibung" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm"></textarea>
+                                    <label class="flex flex-col gap-1">
+                                        <span class="text-[11px] uppercase text-slate-400">Beschreibung</span>
+                                        <textarea x-model="newStep.description" rows="2" placeholder="Beschreibung" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm"></textarea>
+                                    </label>
                                     <div class="grid gap-3 sm:grid-cols-2">
-                                        <select x-model="newStep.status" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
-                                            <template x-for="status in roadmapStatuses" :key="status">
-                                                <option :value="status" x-text="roadmapStatusLabels[status] || status"></option>
-                                            </template>
-                                        </select>
-                                        <input type="date" x-model="newStep.due_date" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                        <label class="flex flex-col gap-1">
+                                            <span class="text-[11px] uppercase text-slate-400">Status</span>
+                                            <select x-model="newStep.status" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                                <template x-for="status in roadmapStatuses" :key="status">
+                                                    <option :value="status" x-text="roadmapStatusLabels[status] || status"></option>
+                                                </template>
+                                            </select>
+                                        </label>
+                                        <label class="flex flex-col gap-1">
+                                            <span class="text-[11px] uppercase text-slate-400">Fällig am</span>
+                                            <input type="date" x-model="newStep.due_date" class="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                        </label>
                                     </div>
                                     <div class="flex flex-col gap-2 sm:flex-row sm:justify-end">
                                         <button @click="stepFormOpen = false" class="rounded-2xl border border-slate-200 px-4 py-2 text-xs">Abbrechen</button>
@@ -290,43 +320,54 @@
                                     </div>
                                 </div>
 
-                                <div class="grid gap-4 lg:grid-cols-4">
-                                    <template x-for="status in roadmapStatuses" :key="status">
-                                        <div class="rounded-2xl border border-slate-200 bg-slate-50/70 p-3 min-w-0">
-                                            <div class="flex items-center justify-between">
-                                                <p class="text-xs uppercase text-slate-400" x-text="roadmapStatusLabels[status] || status"></p>
-                                                <span class="text-xs text-slate-400" x-text="stepsByStatus(status).length"></span>
-                                            </div>
-                                            <div class="flex flex-col gap-3">
-                                                <template x-for="step in stepsByStatus(status)" :key="step.id">
-                                                    <div class="rounded-2xl border border-slate-200 bg-white p-3 text-sm shadow-sm flex flex-col gap-3 min-w-0">
-                                                    <div class="flex items-start justify-between gap-2">
-                                                        <div>
-                                                            <p class="font-semibold text-slate-800 break-words" x-text="step.title"></p>
-                                                            <p class="text-xs text-slate-500 break-words" x-text="step.description || 'Keine Beschreibung'"></p>
+                                <div class="overflow-x-auto pb-2">
+                                    <div class="flex gap-4 min-w-full">
+                                        <template x-for="status in roadmapStatuses" :key="status">
+                                            <div class="w-72 flex-shrink-0 rounded-2xl border border-slate-200 bg-slate-50/70 p-3">
+                                                <div class="flex items-center justify-between">
+                                                    <p class="text-xs uppercase text-slate-400" x-text="roadmapStatusLabels[status] || status"></p>
+                                                    <span class="text-xs text-slate-400" x-text="stepsByStatus(status).length"></span>
+                                                </div>
+                                                <div class="flex flex-col gap-3">
+                                                    <template x-for="step in stepsByStatus(status)" :key="step.id">
+                                                        <div class="rounded-2xl border border-slate-200 bg-white p-3 text-sm shadow-sm flex flex-col gap-3 min-w-0 overflow-hidden">
+                                                            <div class="flex items-start justify-between gap-2">
+                                                                <div class="min-w-0">
+                                                                    <p class="font-semibold text-slate-800 break-words" x-text="step.title"></p>
+                                                                    <p class="text-xs text-slate-500 break-words" x-text="step.description || 'Keine Beschreibung'"></p>
+                                                                </div>
+                                                                <button @click="deleteStep(step)" class="text-slate-400 hover:text-rose-500" x-show="can('roadmap.manage')">
+                                                                    <i data-feather="trash-2" class="w-4 h-4"></i>
+                                                                </button>
+                                                            </div>
+                                                            <div class="grid gap-2 text-xs text-slate-500">
+                                                                <label class="flex flex-col gap-1">
+                                                                    <span class="text-[10px] uppercase text-slate-400">Owner</span>
+                                                                    <input type="text" x-model="step.owner" placeholder="Owner" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                                </label>
+                                                                <label class="flex flex-col gap-1">
+                                                                    <span class="text-[10px] uppercase text-slate-400">Fällig</span>
+                                                                    <input type="date" x-model="step.due_date" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                                </label>
+                                                                <label class="flex flex-col gap-1">
+                                                                    <span class="text-[10px] uppercase text-slate-400">Status</span>
+                                                                    <select x-model="step.ui_status" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                                        <template x-for="statusOption in roadmapStatuses" :key="statusOption">
+                                                                            <option :value="statusOption" x-text="roadmapStatusLabels[statusOption] || statusOption"></option>
+                                                                        </template>
+                                                                    </select>
+                                                                </label>
+                                                                <button @click="updateStep(step)" class="w-full rounded-xl bg-slate-900 px-3 py-1 text-[11px] font-semibold text-white" :disabled="!can('roadmap.manage')">Speichern</button>
+                                                            </div>
                                                         </div>
-                                                        <button @click="deleteStep(step)" class="text-slate-400 hover:text-rose-500" x-show="can('roadmap.manage')">
-                                                            <i data-feather="trash-2" class="w-4 h-4"></i>
-                                                        </button>
+                                                    </template>
+                                                    <div x-show="stepsByStatus(status).length === 0" class="rounded-2xl border border-dashed border-slate-200 bg-white px-3 py-6 text-center text-xs text-slate-400">
+                                                        Keine Schritte
                                                     </div>
-                                                    <div class="grid gap-2 text-xs text-slate-500">
-                                                        <input type="text" x-model="step.owner" placeholder="Owner" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
-                                                        <input type="date" x-model="step.due_date" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
-                                                        <select x-model="step.ui_status" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
-                                                            <template x-for="statusOption in roadmapStatuses" :key="statusOption">
-                                                                <option :value="statusOption" x-text="roadmapStatusLabels[statusOption] || statusOption"></option>
-                                                            </template>
-                                                        </select>
-                                                        <button @click="updateStep(step)" class="rounded-xl bg-slate-900 px-3 py-1 text-[11px] font-semibold text-white" :disabled="!can('roadmap.manage')">Speichern</button>
-                                                    </div>
-                                                </div>
-                                                </template>
-                                                <div x-show="stepsByStatus(status).length === 0" class="rounded-2xl border border-dashed border-slate-200 bg-white px-3 py-6 text-center text-xs text-slate-400">
-                                                    Keine Schritte
                                                 </div>
                                             </div>
-                                        </div>
-                                    </template>
+                                        </template>
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
### Motivation
- Fix cramped and overflowing inputs and save button in the Roadmap view to improve usability and prevent controls from rendering outside their container.
- Create a clearer, more practical layout so roadmap details and step management are faster and less error-prone in typical workflows.
- Improve overall UI/UX on the roadmap board so it works well across viewports and provides a superior editing experience.

### Description
- Reworked the roadmap detail panel into two clearer sections labeled `Rahmen` and `Details`, added spacing and `break-words`/`min-w-0` to avoid overflow and improve hierarchy in `templates/roadmap.html`.
- Re-styled the close/save buttons and reorganized inputs into a responsive `grid` layout with consistent rounded controls and compact labels to avoid elements extending past their container.
- Rebuilt the step creation form with explicit labeled fields and improved spacing, and converted the status columns to a horizontally scrollable layout with fixed column widths (`w-72` / `flex-shrink-0`) to prevent input controls from overflowing the board.

### Testing
- Started the Flask development server with `python app.py` to verify the app loads and templates render, which launched successfully.
- Attempted an automated Playwright screenshot to verify the UI, but the Playwright/Chromium run failed with a `TargetClosedError` / SIGSEGV in this environment.
- No unit tests were added or run for this UI-only change; the file `templates/roadmap.html` was updated and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697503a2c9a0833190d88cc67e60d52b)