### PR TITLE
Fix roadmap step form overflow

### DIFF
--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -340,24 +340,24 @@
                                                                     <i data-feather="trash-2" class="w-4 h-4"></i>
                                                                 </button>
                                                             </div>
-                                                            <div class="grid gap-2 text-xs text-slate-500">
-                                                                <label class="flex flex-col gap-1">
+                                                            <div class="grid gap-2 text-xs text-slate-500 min-w-0">
+                                                                <label class="flex flex-col gap-1 min-w-0">
                                                                     <span class="text-[10px] uppercase text-slate-400">Owner</span>
-                                                                    <input type="text" x-model="step.owner" placeholder="Owner" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                                    <input type="text" x-model="step.owner" placeholder="Owner" class="w-full min-w-0 rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
                                                                 </label>
-                                                                <label class="flex flex-col gap-1">
+                                                                <label class="flex flex-col gap-1 min-w-0">
                                                                     <span class="text-[10px] uppercase text-slate-400">Fällig</span>
-                                                                    <input type="date" x-model="step.due_date" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                                    <input type="date" x-model="step.due_date" class="w-full min-w-0 rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
                                                                 </label>
-                                                                <label class="flex flex-col gap-1">
+                                                                <label class="flex flex-col gap-1 min-w-0">
                                                                     <span class="text-[10px] uppercase text-slate-400">Status</span>
-                                                                    <select x-model="step.ui_status" class="w-full rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                                    <select x-model="step.ui_status" class="w-full min-w-0 rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
                                                                         <template x-for="statusOption in roadmapStatuses" :key="statusOption">
                                                                             <option :value="statusOption" x-text="roadmapStatusLabels[statusOption] || statusOption"></option>
                                                                         </template>
                                                                     </select>
                                                                 </label>
-                                                                <button @click="updateStep(step)" class="w-full rounded-xl bg-slate-900 px-3 py-1 text-[11px] font-semibold text-white" :disabled="!can('roadmap.manage')">Speichern</button>
+                                                                <button @click="updateStep(step)" class="w-full min-w-0 rounded-xl bg-slate-900 px-3 py-1 text-[11px] font-semibold text-white" :disabled="!can('roadmap.manage')">Speichern</button>
                                                             </div>
                                                         </div>
                                                     </template>


### PR DESCRIPTION
### Motivation
- Roadmap step input fields and action button could overflow and be clipped inside the step card when titles are long or the container is narrow, causing UI elements like `Owner`, `Fällig`, `Status` and the `Speichern` button to be cut off.

### Description
- Constrained the step form grid and individual controls by adding `min-w-0` to the container, labels, inputs, selects and the action button in `templates/roadmap.html` so they properly shrink inside flex/overflow contexts.
- This is a small UI-only change that keeps the existing styling and layout but allows elements to wrap/clip correctly inside the roadmap cards.

### Testing
- Started the dev server with `python app.py` which launched successfully (Flask dev server in debug mode). 
- Ran a Playwright script to capture a screenshot of the `/roadmap` page which produced `artifacts/roadmap-step-form.png`, although the automated run stopped at the login screen due to required credentials; the script executed successfully and produced the artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697508390c3883319bce94a6b308e7aa)