### PR TITLE
Fix roadmap step form overflow

### DIFF
--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -323,7 +323,7 @@
                                 <div class="overflow-x-auto pb-2">
                                     <div class="flex gap-4 min-w-full">
                                         <template x-for="status in roadmapStatuses" :key="status">
-                                            <div class="w-72 flex-shrink-0 rounded-2xl border border-slate-200 bg-slate-50/70 p-3">
+                                            <div class="w-80 flex-shrink-0 rounded-2xl border border-slate-200 bg-slate-50/70 p-3 sm:w-80 lg:w-96">
                                                 <div class="flex items-center justify-between">
                                                     <p class="text-xs uppercase text-slate-400" x-text="roadmapStatusLabels[status] || status"></p>
                                                     <span class="text-xs text-slate-400" x-text="stepsByStatus(status).length"></span>
@@ -341,17 +341,17 @@
                                                                 </button>
                                                             </div>
                                                             <div class="grid gap-2 text-xs text-slate-500 min-w-0">
-                                                                <label class="flex flex-col gap-1 min-w-0">
+                                                                <label class="flex w-full min-w-0 flex-col gap-1 overflow-hidden">
                                                                     <span class="text-[10px] uppercase text-slate-400">Owner</span>
-                                                                    <input type="text" x-model="step.owner" placeholder="Owner" class="w-full min-w-0 rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                                    <input type="text" x-model="step.owner" placeholder="Owner" class="w-full min-w-0 max-w-full rounded-xl border border-slate-200 bg-white px-2 py-1 text-xs leading-tight" :disabled="!can('roadmap.manage')">
                                                                 </label>
-                                                                <label class="flex flex-col gap-1 min-w-0">
+                                                                <label class="flex w-full min-w-0 flex-col gap-1 overflow-hidden">
                                                                     <span class="text-[10px] uppercase text-slate-400">Fällig</span>
-                                                                    <input type="date" x-model="step.due_date" class="w-full min-w-0 rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                                    <input type="date" x-model="step.due_date" class="w-full min-w-0 max-w-full rounded-xl border border-slate-200 bg-white px-2 py-1 text-xs leading-tight" :disabled="!can('roadmap.manage')">
                                                                 </label>
-                                                                <label class="flex flex-col gap-1 min-w-0">
+                                                                <label class="flex w-full min-w-0 flex-col gap-1 overflow-hidden">
                                                                     <span class="text-[10px] uppercase text-slate-400">Status</span>
-                                                                    <select x-model="step.ui_status" class="w-full min-w-0 rounded-xl border border-slate-200 bg-white px-2 py-1" :disabled="!can('roadmap.manage')">
+                                                                    <select x-model="step.ui_status" class="w-full min-w-0 max-w-full rounded-xl border border-slate-200 bg-white px-2 py-1 text-xs leading-tight" :disabled="!can('roadmap.manage')">
                                                                         <template x-for="statusOption in roadmapStatuses" :key="statusOption">
                                                                             <option :value="statusOption" x-text="roadmapStatusLabels[statusOption] || statusOption"></option>
                                                                         </template>


### PR DESCRIPTION
### Motivation
- Roadmap step detail controls (Owner, Fällig, Status, Save) were overflowing and being clipped by the step card, causing a poor UX when adding many steps or using smaller columns.
- The change aims to make the board columns and step controls responsive so the fields shrink and wrap cleanly inside each card without visual clipping.

### Description
- Increased status column base width and added responsive sizes by adjusting the column wrapper to `w-80 sm:w-80 lg:w-96` in `templates/roadmap.html` so controls have more room on larger viewports.
- Constrained step field labels and controls by adding `overflow-hidden`, `w-full`, `max-w-full`, and compact typography (`text-xs leading-tight`) to inputs/selects so they shrink instead of overflowing the card.
- Kept the existing layout and behavior while only changing CSS classes in `templates/roadmap.html` to prevent visual clipping of step controls.

### Testing
- Started the development server with `python app.py` and verified the `/roadmap` page was served successfully via HTTP requests recorded in the server log, which completed without errors.
- Ran an automated Playwright script that logged in, navigated to `/roadmap`, selected a roadmap and captured a screenshot (`artifacts/roadmap-step-card.png`) to verify the fields no longer overflowed, and the script completed successfully.
- No backend/unit tests changed because this is a UI-only template update; the UI verification steps above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6975098d05488331898e977f774772bd)