### PR TITLE
Ticket-Kategorien löschen: Referenzen bereinigen und UI-Löschaktion

### DIFF
--- a/app.py
+++ b/app.py
@@ -2137,10 +2137,22 @@ def ticket_category_detail(category_id):
 
     if not user_can('ticket_categories.manage'):
         return jsonify({"error": "Keine Berechtigung"}), 403
+    affected_tickets = db.execute(
+        'SELECT id FROM tickets WHERE category_id = ?',
+        (category_id,)
+    ).fetchall()
+    if affected_tickets:
+        db.execute('UPDATE tickets SET category_id = NULL WHERE category_id = ?', (category_id,))
     result = db.execute('DELETE FROM ticket_categories WHERE id = ?', (category_id,))
     if result.rowcount == 0:
         return jsonify({"error": "Kategorie nicht gefunden"}), 404
-    log_activity(db, "delete", "ticket_category", category_id)
+    log_activity(
+        db,
+        "delete",
+        "ticket_category",
+        category_id,
+        {"updated_tickets": len(affected_tickets)}
+    )
     db.commit()
     return jsonify({"status": "deleted"}), 200
 

--- a/static/tickets.js
+++ b/static/tickets.js
@@ -343,6 +343,27 @@ document.addEventListener('alpine:init', () => {
             }
         },
 
+        async deleteCategory(category) {
+            if (!category) return;
+            const confirmed = window.confirm(
+                `Kategorie "${category.name}" löschen? Tickets werden danach ohne Kategorie geführt.`
+            );
+            if (!confirmed) return;
+            const response = await fetch(`/api/ticket-categories/${category.id}`, {
+                method: 'DELETE'
+            });
+            if (response.ok) {
+                await this.loadCategories();
+                await this.loadTickets();
+                if (this.selectedTicket) {
+                    await this.selectTicket(this.selectedTicket);
+                }
+            } else {
+                const error = await response.json();
+                alert(error.error || 'Kategorie konnte nicht gelöscht werden.');
+            }
+        },
+
         async createAlert() {
             const payload = { ...this.newAlert };
             const response = await fetch('/api/ticket-alerts', {

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -405,7 +405,10 @@
                                                 <p class="font-semibold text-slate-800" x-text="category.name"></p>
                                                 <p class="text-xs text-slate-500" x-text="category.description"></p>
                                             </div>
-                                            <span class="rounded-full px-3 py-1 text-xs font-semibold" :style="`background-color: ${category.color}; color: white;`" x-text="`${category.sla_hours}h SLA`"></span>
+                                            <div class="flex items-center gap-3">
+                                                <span class="rounded-full px-3 py-1 text-xs font-semibold" :style="`background-color: ${category.color}; color: white;`" x-text="`${category.sla_hours}h SLA`"></span>
+                                                <button @click="deleteCategory(category)" class="text-rose-500 text-xs font-semibold">Löschen</button>
+                                            </div>
                                         </div>
                                     </template>
                                 </div>


### PR DESCRIPTION
### Motivation
- Administratoren sollen Ticket-Kategorien im Helpdesk entfernen können, ohne dass verknüpfte Tickets fehlerhaft bleiben.

### Description
- Die DELETE-Logik in `POST /api/ticket-categories/<id>` wurde erweitert, sodass vor dem Löschen alle `tickets` mit dieser Kategorie auf `category_id = NULL` gesetzt werden und die Anzahl betroffener Tickets im Activity-Log unter `updated_tickets` protokolliert wird (`app.py`).
- In der Ticket-Administration wurde in `templates/tickets.html` ein „Löschen“-Button pro Kategorie ergänzt, der die Löschaktion auslöst.
- In `static/tickets.js` wurde die Methode `deleteCategory(category)` hinzugefügt, die eine Bestätigung einholt, die DELETE-API aufruft und anschließend Kategorien sowie Ticket-Listen neu lädt und ggf. das aktuell geöffnete Ticket aktualisiert.

### Testing
- Die Entwicklungs-Instanz wurde gestartet mit `python app.py` und lieferte erwartungsgemäß HTTP-Antworten (Dev-Server läuft, Endpoints antworten mit 200/302), was das Backend erreichbar machte.
- Ein kleines Skript legte einen Admin-Benutzer an und ein Playwright-Skript meldete sich im UI an und erstellte einen Screenshot der Ticket-Admin-Ansicht, wobei die neue Löschschaltfläche sichtbar war; die relevanten API-Requests für Kategorien, Tickets und Alerts gaben 200 zurück.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69750b612e1883319bc314c16a55995b)