### PR TITLE
Expand category and device filtering options

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -10,7 +10,15 @@ document.addEventListener('alpine:init', () => {
         relationTypes: [],
         activeCategory: null,
         searchQuery: '',
+        categorySearchQuery: '',
+        ownerQuery: '',
+        locationFilter: '',
+        categoryFilter: '',
+        createdFrom: '',
+        createdTo: '',
+        specQuery: '',
         sortDropdownOpen: false,
+        filtersOpen: true,
         featureFlags: {
             pro_enabled: false,
             pro_features: [],
@@ -93,6 +101,13 @@ document.addEventListener('alpine:init', () => {
             await this.loadActivityFeed();
             this.loadIconCatalog();
             this.$watch('searchQuery', () => this.searchDevices());
+            this.$watch('categorySearchQuery', () => this.filterCategories());
+            this.$watch('ownerQuery', () => this.searchDevices());
+            this.$watch('locationFilter', () => this.searchDevices());
+            this.$watch('categoryFilter', () => this.searchDevices());
+            this.$watch('createdFrom', () => this.searchDevices());
+            this.$watch('createdTo', () => this.searchDevices());
+            this.$watch('specQuery', () => this.searchDevices());
             feather.replace();
             this.startLiveRefresh();
         },
@@ -161,7 +176,7 @@ document.addEventListener('alpine:init', () => {
             const response = await fetch(url);
             if (response.ok) {
                 this.devices = await response.json();
-                this.filteredDevices = this.devices;
+                this.searchDevices();
             }
             if (this.selectedDevice) {
                 const updated = this.devices.find(device => device.id === this.selectedDevice.id);
@@ -202,21 +217,86 @@ document.addEventListener('alpine:init', () => {
 
         // Search and Sort
         searchDevices() {
+            const matchesCreatedRange = (deviceDate) => {
+                if (!deviceDate) return !this.createdFrom && !this.createdTo;
+                const value = new Date(deviceDate);
+                if (Number.isNaN(value.getTime())) return true;
+                if (this.createdFrom) {
+                    const fromDate = new Date(this.createdFrom);
+                    if (!Number.isNaN(fromDate.getTime()) && value < fromDate) return false;
+                }
+                if (this.createdTo) {
+                    const toDate = new Date(this.createdTo);
+                    if (!Number.isNaN(toDate.getTime())) {
+                        const endOfDay = new Date(toDate);
+                        endOfDay.setHours(23, 59, 59, 999);
+                        if (value > endOfDay) return false;
+                    }
+                }
+                return true;
+            };
+            const normalize = (value) => (value || '').toString().toLowerCase();
+            const query = normalize(this.searchQuery).trim();
+            const ownerQuery = normalize(this.ownerQuery).trim();
+            const specQuery = normalize(this.specQuery).trim();
+            const locationFilter = this.locationFilter ? String(this.locationFilter) : '';
+            const categoryFilter = this.categoryFilter ? String(this.categoryFilter) : '';
+
             if (!this.searchQuery) {
                 this.filteredDevices = [...this.devices];
-            } else {
-                const query = this.searchQuery.toLowerCase();
-                this.filteredDevices = this.devices.filter(device => 
-                    device.name.toLowerCase().includes(query) ||
-                    (device.serial_number && device.serial_number.toLowerCase().includes(query)) ||
-                    JSON.stringify(device.specs).toLowerCase().includes(query)
-                );
             }
+            this.filteredDevices = this.devices.filter(device => {
+                const deviceName = normalize(device.name);
+                const ownerName = normalize(device.serial_number);
+                const categoryName = normalize(device.category_name);
+                const locationName = normalize(device.location_name);
+                const specsString = normalize(JSON.stringify(device.specs || {}));
+                const createdAt = device.created_at;
+
+                const matchesQuery = !query ||
+                    deviceName.includes(query) ||
+                    ownerName.includes(query) ||
+                    categoryName.includes(query) ||
+                    locationName.includes(query) ||
+                    specsString.includes(query);
+
+                const matchesOwner = !ownerQuery || ownerName.includes(ownerQuery);
+                const matchesLocation = !locationFilter || String(device.location_id || '') === locationFilter;
+                const matchesCategory = !categoryFilter || String(device.category_id || '') === categoryFilter;
+                const matchesSpecs = !specQuery || specsString.includes(specQuery);
+
+                return matchesQuery && matchesOwner && matchesLocation && matchesCategory && matchesSpecs && matchesCreatedRange(createdAt);
+            });
             
             // Apply current sort if one is active
             if (this.currentSort.field) {
                 this.sortDevices(this.currentSort.field, this.currentSort.direction);
             }
+        },
+
+        filterCategories() {
+            return this.filteredCategories();
+        },
+
+        filteredCategories() {
+            const query = (this.categorySearchQuery || '').toLowerCase().trim();
+            if (!query) {
+                return this.categories;
+            }
+            return this.categories.filter(category =>
+                (category.name || '').toLowerCase().includes(query)
+            );
+        },
+
+        resetDeviceFilters() {
+            this.searchQuery = '';
+            this.ownerQuery = '';
+            this.locationFilter = '';
+            this.categoryFilter = '';
+            this.createdFrom = '';
+            this.createdTo = '';
+            this.specQuery = '';
+            this.searchDevices();
         },
 
         toggleSortDropdown() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -105,22 +105,30 @@
                     </div>
                 </div>
 
-                <div class="border border-slate-200 rounded-2xl overflow-hidden shadow-sm bg-white sidebar-compact-hidden">
-                    <button @click="categoriesOpen = !categoriesOpen"
+                    <div class="border border-slate-200 rounded-2xl overflow-hidden shadow-sm bg-white sidebar-compact-hidden">
+                        <button @click="categoriesOpen = !categoriesOpen"
                             class="w-full flex items-center justify-between px-4 py-3 bg-white hover:bg-slate-50 transition-colors">
-                        <span class="flex items-center gap-3">
-                            <span class="flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-600">
-                                <i data-feather="layers" class="w-4 h-4"></i>
+                            <span class="flex items-center gap-3">
+                                <span class="flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-600">
+                                    <i data-feather="layers" class="w-4 h-4"></i>
+                                </span>
+                                <span class="text-sm font-semibold text-slate-800 sidebar-text">Kategorien</span>
                             </span>
-                            <span class="text-sm font-semibold text-slate-800 sidebar-text">Kategorien</span>
-                        </span>
-                        <svg :class="{ 'rotate-180': categoriesOpen }" class="w-4 h-4 text-slate-500 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-                        </svg>
-                    </button>
+                            <svg :class="{ 'rotate-180': categoriesOpen }" class="w-4 h-4 text-slate-500 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                            </svg>
+                        </button>
 
                     <div x-show="categoriesOpen" x-transition class="bg-slate-50 px-2 py-2 space-y-1 text-sm text-slate-800">
-                        <template x-for="category in categories" :key="category.id">
+                        <div class="px-3 pb-2">
+                            <div class="relative">
+                                <input type="text" x-model="categorySearchQuery" placeholder="Kategorien filtern..." class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 pr-9 text-xs text-slate-600 focus:border-blue-500 focus:ring-blue-500">
+                                <span class="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400">
+                                    <i data-feather="search" class="w-3 h-3"></i>
+                                </span>
+                            </div>
+                        </div>
+                        <template x-for="category in filteredCategories()" :key="category.id">
                             <div class="group flex items-center justify-between px-3 py-2 rounded-xl hover:bg-white transition-colors">
                                 <button @click="loadDevices(category.id)" class="flex items-center gap-2 flex-1 min-w-0 text-left">
                                     <div x-html="feather.icons[category.icon]?.toSvg({ class: 'w-4 h-4 text-slate-500' })"></div>
@@ -405,15 +413,15 @@
                         <div class="flex items-center justify-between">
                             <div>
                                 <p class="text-sm font-semibold text-slate-900">Geräte durchsuchen</p>
-                                <p class="text-xs text-slate-500">Schneller Zugriff auf Assets</p>
+                                <p class="text-xs text-slate-500">Mehr Kriterien & Filter</p>
                             </div>
                             <span class="inline-flex items-center justify-center rounded-full bg-blue-50 p-2 text-blue-500">
                                 <i data-feather="search" class="h-4 w-4"></i>
                             </span>
                         </div>
-                        <div class="mt-4">
+                        <div class="mt-4 space-y-3 text-xs text-slate-500">
                             <div class="relative w-full">
-                                <input type="text" placeholder="Gerät, Owner oder Spezifikation suchen..." class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 pr-12 text-sm text-slate-700 shadow-inner focus:border-blue-500 focus:ring-blue-500" x-model="searchQuery" @input.debounce.300ms="searchDevices()">
+                                <input type="text" placeholder="Freitext (Gerät, Owner, Kategorie, Standort, Specs...)" class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 pr-12 text-sm text-slate-700 shadow-inner focus:border-blue-500 focus:ring-blue-500" x-model="searchQuery" @input.debounce.300ms="searchDevices()">
                                 <button @click="toggleSortDropdown()" aria-label="Sort options" class="absolute right-2 top-1/2 -translate-y-1/2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-slate-600 shadow-sm hover:bg-slate-50">
                                     <i data-feather="filter" class="w-4 h-4"></i>
                                 </button>
@@ -424,6 +432,54 @@
                                         <a href="#" @click.prevent="sortDevices('serial_number', 'asc')" class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">Owner (aufsteigend)</a>
                                         <a href="#" @click.prevent="sortDevices('serial_number', 'desc')" class="block px-5 py-3 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900 transition-colors">Owner (absteigend)</a>
                                     </div>
+                                </div>
+                            </div>
+                            <button type="button" @click="filtersOpen = !filtersOpen" class="inline-flex items-center gap-2 text-xs font-semibold text-slate-600">
+                                <i data-feather="sliders" class="w-4 h-4"></i>
+                                Filter ein-/ausblenden
+                            </button>
+                            <div x-show="filtersOpen" class="grid gap-3 rounded-2xl border border-slate-200 bg-white p-3" x-transition>
+                                <div>
+                                    <label class="text-xs font-semibold text-slate-500">Owner enthält</label>
+                                    <input type="text" x-model="ownerQuery" placeholder="z. B. Max Mustermann" class="mt-1 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700 focus:border-blue-500 focus:ring-blue-500">
+                                </div>
+                                <div class="grid gap-3 sm:grid-cols-2">
+                                    <div>
+                                        <label class="text-xs font-semibold text-slate-500">Kategorie</label>
+                                        <select x-model="categoryFilter" class="mt-1 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700 focus:border-blue-500 focus:ring-blue-500">
+                                            <option value="">Alle Kategorien</option>
+                                            <template x-for="category in categories" :key="category.id">
+                                                <option :value="category.id" x-text="category.name"></option>
+                                            </template>
+                                        </select>
+                                    </div>
+                                    <div>
+                                        <label class="text-xs font-semibold text-slate-500">Standort</label>
+                                        <select x-model="locationFilter" class="mt-1 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700 focus:border-blue-500 focus:ring-blue-500">
+                                            <option value="">Alle Standorte</option>
+                                            <template x-for="location in locations" :key="location.id">
+                                                <option :value="location.id" x-text="location.name"></option>
+                                            </template>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="grid gap-3 sm:grid-cols-2">
+                                    <div>
+                                        <label class="text-xs font-semibold text-slate-500">Erstellt von</label>
+                                        <input type="date" x-model="createdFrom" class="mt-1 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700 focus:border-blue-500 focus:ring-blue-500">
+                                    </div>
+                                    <div>
+                                        <label class="text-xs font-semibold text-slate-500">Erstellt bis</label>
+                                        <input type="date" x-model="createdTo" class="mt-1 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700 focus:border-blue-500 focus:ring-blue-500">
+                                    </div>
+                                </div>
+                                <div>
+                                    <label class="text-xs font-semibold text-slate-500">Spezifikationen enthalten</label>
+                                    <input type="text" x-model="specQuery" placeholder="z. B. i7, 16GB, SSD" class="mt-1 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700 focus:border-blue-500 focus:ring-blue-500">
+                                </div>
+                                <div class="flex flex-wrap items-center gap-2 pt-1">
+                                    <button type="button" @click="resetDeviceFilters()" class="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-50">Filter zurücksetzen</button>
+                                    <span class="text-[11px] text-slate-400">Treffer: <span class="font-semibold text-slate-600" x-text="filteredDevices.length"></span></span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
### Motivation
- Erweitern der Suchleiste für Kategorien und Geräte, damit Anwender viele zusätzliche Suchkriterien und Filter kombinieren können.
- Bessere Auffindbarkeit durch Owner-, Standort-, Kategorie-, Datumsbereich- und Spezifikationsfilter sowie eine ein-/ausblendbare Filtersektion.
- Möglichkeit, Kategorien direkt in der Sidebar zu filtern, um große Kategorie-Listen schneller zu durchsuchen.

### Description
- Ergänzt das Alpine-Frontend in `static/script.js` um neue Zustände: `categorySearchQuery`, `ownerQuery`, `locationFilter`, `categoryFilter`, `createdFrom`, `createdTo`, `specQuery` und `filtersOpen`, sowie zugehörige `$watch`-Handler.
- Erweitert `searchDevices()` um Normalisierung, kombinierbare Filter (Freitext, Owner, Kategorie, Standort, Specs) und eine Datumsbereichsprüfung (`matchesCreatedRange`), plus `resetDeviceFilters()` zum Zurücksetzen aller Filter.
- Fügt `filteredCategories()`/`filterCategories()` hinzu und nutzt `categorySearchQuery` zur Sidebar-Filterung von Kategorien.
- Aktualisiert `templates/index.html` und ergänzt die UI mit einem Sidebar-Filterfeld für Kategorien sowie einer erweiterten Geräte-Suchkarte mit Freitextsuche, ein-/ausblendbaren Filtern (Owner, Kategorie-Select, Standort-Select, Erstellungs-Datum von/bis, Spezifikationsfeld) und einem Button zum Zurücksetzen.

### Testing
- Dev-Server mit `python app.py` gestartet erfolgreich und die Anwendung lief lokal im Entwicklungsmodus.
- Ein Playwright-basiertes UI-Screenshot-Skript wurde ausgeführt, schlug aber in dieser Umgebung fehl wegen eines Headless-Chromium-Absturzes, daher keine browsergestützte Screenshot-Verifikation möglich; es wurden keine weiteren automatisierten Tests ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69750ff2b7a0833183e1b88cf0fc0ba3)