### PR TITLE
Automatically mark devices as 'Verwendet' when linked to assets

### DIFF
--- a/app.py
+++ b/app.py
@@ -1370,6 +1370,26 @@ def summarize_device_info(device_rows):
             locations.append(location_name)
     return serials, locations
 
+def mark_devices_as_used(db, device_ids):
+    unique_ids = [device_id for device_id in dict.fromkeys(device_ids) if device_id]
+    if not unique_ids:
+        return
+    placeholders = ",".join(["?"] * len(unique_ids))
+    rows = db.execute(
+        f"SELECT id, specs FROM devices WHERE id IN ({placeholders})",
+        unique_ids,
+    ).fetchall()
+    for row in rows:
+        try:
+            specs = json.loads(row["specs"] or "{}")
+        except json.JSONDecodeError:
+            specs = {}
+        specs["Status"] = "Verwendet"
+        db.execute(
+            "UPDATE devices SET specs = ? WHERE id = ?",
+            (json.dumps(specs), row["id"]),
+        )
+
 def get_asset_devices_info(db, asset_id):
     rows = db.execute('''
         SELECT d.serial_number, l.name as location_name
@@ -1862,6 +1882,7 @@ def manage_assets():
                     INSERT INTO asset_devices (asset_id, device_id)
                     VALUES (?, ?)
                 ''', (asset_id, device_id))
+            mark_devices_as_used(db, device_ids)
             for relation in relations:
                 related_asset_id = relation.get("related_asset_id")
                 relation_type_id = relation.get("relation_type_id")
@@ -1981,6 +2002,7 @@ def asset_detail(asset_id):
                 INSERT INTO asset_devices (asset_id, device_id)
                 VALUES (?, ?)
             ''', (asset_id, device_id))
+        mark_devices_as_used(db, device_ids)
         db.execute('DELETE FROM asset_relations WHERE asset_id = ?', (asset_id,))
         for relation in relations:
             related_asset_id = relation.get("related_asset_id")


### PR DESCRIPTION
### Motivation
- Beim Verknüpfen von Geräten mit Assets soll der Geräte-Status automatisch auf „Verwendet“ gesetzt werden, damit Inventar und Lebenszyklus-Informationen konsistent bleiben.

### Description
- Neue Hilfsfunktion `mark_devices_as_used(db, device_ids)` ergänzt, die deduplizierte `device_ids` lädt, `specs` als JSON parst und `specs["Status"] = "Verwendet"` schreibt, sowie fehlerhafte JSON-Werte abfängt (Datei: `app.py`).
- Die Funktion wird beim Erstellen von Assets nach Einfügen in `asset_devices` aufgerufen, um verknüpfte Geräte sofort zu markieren (in `manage_assets`).
- Die Funktion wird ebenfalls beim Aktualisieren eines Assets nach dem Eintragen der neuen `asset_devices` aufgerufen, damit Statusänderungen bei Updates angewendet werden (in `asset_detail` PUT-Handler).
- Änderungen sind lokal in `app.py` implementiert und arbeiten mit bestehenden `specs`-Feld-JSONs der `devices`-Tabelle.

### Testing
- Es wurden keine automatisierten Tests ausgeführt for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697514f0abf483319eea4b8ca9c666a1)