### PR TITLE
Mark linked devices as "Lager" when deleting an asset

### DIFF
--- a/app.py
+++ b/app.py
@@ -1390,6 +1390,26 @@ def mark_devices_as_used(db, device_ids):
             (json.dumps(specs), row["id"]),
         )
 
+def mark_devices_as_in_stock(db, device_ids):
+    unique_ids = [device_id for device_id in dict.fromkeys(device_ids) if device_id]
+    if not unique_ids:
+        return
+    placeholders = ",".join(["?"] * len(unique_ids))
+    rows = db.execute(
+        f"SELECT id, specs FROM devices WHERE id IN ({placeholders})",
+        unique_ids,
+    ).fetchall()
+    for row in rows:
+        try:
+            specs = json.loads(row["specs"] or "{}")
+        except json.JSONDecodeError:
+            specs = {}
+        specs["Status"] = "Lager"
+        db.execute(
+            "UPDATE devices SET specs = ? WHERE id = ?",
+            (json.dumps(specs), row["id"]),
+        )
+
 def get_asset_devices_info(db, asset_id):
     rows = db.execute('''
         SELECT d.serial_number, l.name as location_name
@@ -2019,6 +2039,12 @@ def asset_detail(asset_id):
 
     if not user_can('assets.manage'):
         return jsonify({"error": "Keine Berechtigung"}), 403
+    device_rows = db.execute(
+        'SELECT device_id FROM asset_devices WHERE asset_id = ?',
+        (asset_id,),
+    ).fetchall()
+    device_ids = [row["device_id"] for row in device_rows]
+    mark_devices_as_in_stock(db, device_ids)
     db.execute('DELETE FROM ticket_assets WHERE asset_id = ?', (asset_id,))
     db.execute('DELETE FROM asset_devices WHERE asset_id = ?', (asset_id,))
     db.execute('DELETE FROM asset_relations WHERE asset_id = ? OR related_asset_id = ?', (asset_id, asset_id))


### PR DESCRIPTION
### Motivation
- Ensure device status reflects that they are back in stock when their parent asset is removed, keeping inventory state consistent.

### Description
- Added a new helper `mark_devices_as_in_stock(db, device_ids)` in `app.py` that sets `specs["Status"] = "Lager"` for the given devices.
- Updated the asset deletion flow in the `DELETE /api/assets/<int:asset_id>` path to fetch linked device IDs and call `mark_devices_as_in_stock` before removing `asset_devices` links and the asset itself.
- Reused the existing pattern from `mark_devices_as_used` for JSON `specs` parsing and update to maintain consistency.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697516602fe8833183341483bceaaf10)