### PR TITLE
Improve responsiveness of device search filter panel

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -409,7 +409,7 @@
                 </section>
 
                 <section class="grid gap-4 lg:grid-cols-4">
-                    <div class="min-w-0 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm overflow-hidden">
+                    <div class="min-w-0 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm overflow-hidden lg:col-span-2 2xl:col-span-1">
                         <div class="flex items-center justify-between">
                             <div>
                                 <p class="text-sm font-semibold text-slate-900">Geräte durchsuchen</p>
@@ -439,12 +439,12 @@
                                 Filter ein-/ausblenden
                             </button>
                             <div x-show="filtersOpen" class="grid min-w-0 gap-3 rounded-2xl border border-slate-200 bg-white p-3" x-transition>
-                                <div>
+                                <div class="min-w-0">
                                     <label class="text-xs font-semibold text-slate-500">Owner enthält</label>
                                     <input type="text" x-model="ownerQuery" placeholder="z. B. Max Mustermann" class="mt-1 w-full min-w-0 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700 focus:border-blue-500 focus:ring-blue-500">
                                 </div>
-                                <div class="grid min-w-0 gap-3 sm:grid-cols-2">
-                                    <div>
+                                <div class="grid min-w-0 gap-3 sm:grid-cols-1 2xl:grid-cols-2">
+                                    <div class="min-w-0">
                                         <label class="text-xs font-semibold text-slate-500">Kategorie</label>
                                         <select x-model="categoryFilter" class="mt-1 w-full min-w-0 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700 focus:border-blue-500 focus:ring-blue-500">
                                             <option value="">Alle Kategorien</option>
@@ -453,7 +453,7 @@
                                             </template>
                                         </select>
                                     </div>
-                                    <div>
+                                    <div class="min-w-0">
                                         <label class="text-xs font-semibold text-slate-500">Standort</label>
                                         <select x-model="locationFilter" class="mt-1 w-full min-w-0 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700 focus:border-blue-500 focus:ring-blue-500">
                                             <option value="">Alle Standorte</option>
@@ -463,17 +463,17 @@
                                         </select>
                                     </div>
                                 </div>
-                                <div class="grid min-w-0 gap-3 sm:grid-cols-2">
-                                    <div>
+                                <div class="grid min-w-0 gap-3 sm:grid-cols-1 2xl:grid-cols-2">
+                                    <div class="min-w-0">
                                         <label class="text-xs font-semibold text-slate-500">Erstellt von</label>
                                         <input type="date" x-model="createdFrom" class="mt-1 w-full min-w-0 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700 focus:border-blue-500 focus:ring-blue-500">
                                     </div>
-                                    <div>
+                                    <div class="min-w-0">
                                         <label class="text-xs font-semibold text-slate-500">Erstellt bis</label>
                                         <input type="date" x-model="createdTo" class="mt-1 w-full min-w-0 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700 focus:border-blue-500 focus:ring-blue-500">
                                     </div>
                                 </div>
-                                <div>
+                                <div class="min-w-0">
                                     <label class="text-xs font-semibold text-slate-500">Spezifikationen enthalten</label>
                                     <input type="text" x-model="specQuery" placeholder="z. B. i7, 16GB, SSD" class="mt-1 w-full min-w-0 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700 focus:border-blue-500 focus:ring-blue-500">
                                 </div>


### PR DESCRIPTION
### Motivation
- The filter inputs in the “Geräte durchsuchen” card could overflow and break layout on smaller laptop widths, and the previous fix still left the panel too wide on those breakpoints. 
- The intent is to allow inputs to shrink and to make the filter rows collapse to a single column until very large screens so the card no longer overflows.

### Description
- Adjust the device-search card layout in `templates/index.html` so it occupies more horizontal space at laptop breakpoints with `lg:col-span-2 2xl:col-span-1` to improve visual balance. 
- Change the filter rows from two-column at small breakpoints to single-column until very large screens by switching `sm:grid-cols-2 xl:grid-cols-2` to `sm:grid-cols-1 2xl:grid-cols-2` for the filter grids. 
- Ensure individual filter wrappers include `min-w-0` so inputs and selects can shrink inside flex/grid containers and avoid overflow.

### Testing
- Started the dev server with `python app.py` and the server launched successfully. 
- Ran automated Playwright UI scripts to capture the expanded device search card, which initially timed out but was re-run and completed successfully and produced a screenshot artifact (`artifacts/device-search-card-expanded.png`). 
- The screenshot from the automated run was used to visually confirm the filter panel no longer overflows at the targeted breakpoints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697517ab19dc8331a69d7b2ad09aa9c8)