### PR TITLE
Abhängigkeits- & Impact-Graph mit Software‑Inventar hinzufügen

### DIFF
--- a/app.py
+++ b/app.py
@@ -229,6 +229,54 @@ PERMISSIONS = [
         "label": "Roadmaps verwalten",
         "description": "Roadmaps erstellen, bearbeiten und löschen.",
         "group": "Roadmap"
+    },
+    {
+        "key": "dependencies.view",
+        "label": "Abhängigkeits-Graph anzeigen",
+        "description": "Dependency- und Impact-Graph einsehen.",
+        "group": "Abhängigkeiten"
+    },
+    {
+        "key": "dependencies.manage",
+        "label": "Abhängigkeits-Graph verwalten",
+        "description": "Abhängigkeiten modellieren und Impact-Regeln pflegen.",
+        "group": "Abhängigkeiten"
+    },
+    {
+        "key": "software.view",
+        "label": "Software-Inventar anzeigen",
+        "description": "Software-Inventar und Installationen einsehen.",
+        "group": "Software"
+    },
+    {
+        "key": "software.manage",
+        "label": "Software-Inventar verwalten",
+        "description": "Software, Installationen und Eigentümer verwalten.",
+        "group": "Software"
+    },
+    {
+        "key": "teams.view",
+        "label": "Teams anzeigen",
+        "description": "Teams und Verantwortlichkeiten einsehen.",
+        "group": "Organisation"
+    },
+    {
+        "key": "teams.manage",
+        "label": "Teams verwalten",
+        "description": "Teams und Zuordnungen pflegen.",
+        "group": "Organisation"
+    },
+    {
+        "key": "departments.view",
+        "label": "Abteilungen anzeigen",
+        "description": "Abteilungen und Strukturen einsehen.",
+        "group": "Organisation"
+    },
+    {
+        "key": "departments.manage",
+        "label": "Abteilungen verwalten",
+        "description": "Abteilungen erstellen und pflegen.",
+        "group": "Organisation"
     }
 ]
 
@@ -269,7 +317,15 @@ DEFAULT_ROLES = [
             "stats.view",
             "activity.view",
             "roadmap.view",
-            "roadmap.manage"
+            "roadmap.manage",
+            "dependencies.view",
+            "dependencies.manage",
+            "software.view",
+            "software.manage",
+            "teams.view",
+            "teams.manage",
+            "departments.view",
+            "departments.manage"
         ]
     },
     {
@@ -826,6 +882,77 @@ def init_db():
         ''')
 
         c.execute('''
+            CREATE TABLE IF NOT EXISTS departments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS teams (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                department_id INTEGER,
+                lead_user TEXT,
+                notes TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (department_id) REFERENCES departments(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS software (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                vendor TEXT,
+                version TEXT,
+                license_type TEXT,
+                criticality TEXT DEFAULT 'medium',
+                description TEXT,
+                owner_team_id INTEGER,
+                support_contact TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(name, vendor, version),
+                FOREIGN KEY (owner_team_id) REFERENCES teams(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS software_installations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                software_id INTEGER NOT NULL,
+                device_id INTEGER,
+                asset_id INTEGER,
+                installed_version TEXT,
+                environment TEXT DEFAULT 'production',
+                status TEXT DEFAULT 'active',
+                notes TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (software_id) REFERENCES software(id),
+                FOREIGN KEY (device_id) REFERENCES devices(id),
+                FOREIGN KEY (asset_id) REFERENCES assets(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS dependency_links (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_type TEXT NOT NULL,
+                source_id INTEGER NOT NULL,
+                target_type TEXT NOT NULL,
+                target_id INTEGER NOT NULL,
+                relation TEXT DEFAULT 'depends_on',
+                criticality TEXT DEFAULT 'medium',
+                redundancy_group TEXT,
+                notes TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(source_type, source_id, target_type, target_id, relation)
+            )
+        ''')
+
+        c.execute('''
             CREATE TABLE IF NOT EXISTS rule_overrides (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 rule_key TEXT NOT NULL,
@@ -1078,6 +1205,404 @@ def log_activity(db, action, entity_type, entity_id=None, details=None):
         INSERT INTO activity_log (username, action, entity_type, entity_id, details)
         VALUES (?, ?, ?, ?, ?)
     ''', (username, action, entity_type, entity_id, json.dumps(details or {})))
+
+DEPENDENCY_ENTITY_TYPES = {
+    "asset": {"table": "assets", "label": "Asset", "name_col": "name"},
+    "device": {"table": "devices", "label": "Gerät", "name_col": "name"},
+    "software": {"table": "software", "label": "Software", "name_col": "name"},
+    "service": {"table": "services", "label": "Service", "name_col": "name"},
+    "team": {"table": "teams", "label": "Team", "name_col": "name"},
+    "department": {"table": "departments", "label": "Abteilung", "name_col": "name"},
+    "location": {"table": "locations", "label": "Standort", "name_col": "name"},
+    "user": {"table": "users", "label": "Benutzer", "name_col": "username"},
+    "ticket": {"table": "tickets", "label": "Ticket", "name_col": "title"},
+    "roadmap": {"table": "roadmaps", "label": "Roadmap", "name_col": "title"},
+    "roadmap_step": {"table": "roadmap_steps", "label": "Roadmap-Schritt", "name_col": "title"}
+}
+
+def fetch_entity_label(db, entity_type, entity_id):
+    meta = DEPENDENCY_ENTITY_TYPES.get(entity_type)
+    if not meta:
+        return None
+    row = db.execute(
+        f"SELECT {meta['name_col']} AS name FROM {meta['table']} WHERE id = ?",
+        (entity_id,)
+    ).fetchone()
+    return row["name"] if row else None
+
+def fetch_entity_options(db):
+    options = {}
+    for entity_type, meta in DEPENDENCY_ENTITY_TYPES.items():
+        rows = db.execute(
+            f"SELECT id, {meta['name_col']} AS name FROM {meta['table']} ORDER BY {meta['name_col']}"
+        ).fetchall()
+        options[entity_type] = [dict(row) for row in rows]
+    return options
+
+def build_dependency_edges(db):
+    edges = []
+    link_rows = db.execute('''
+        SELECT id, source_type, source_id, target_type, target_id, relation, criticality, redundancy_group, notes
+        FROM dependency_links
+        ORDER BY created_at DESC
+    ''').fetchall()
+    for row in link_rows:
+        edges.append({
+            "id": row["id"],
+            "source_type": row["source_type"],
+            "source_id": row["source_id"],
+            "target_type": row["target_type"],
+            "target_id": row["target_id"],
+            "relation": row["relation"],
+            "criticality": row["criticality"],
+            "redundancy_group": row["redundancy_group"],
+            "notes": row["notes"],
+            "implicit": False
+        })
+
+    asset_device_rows = db.execute('SELECT asset_id, device_id FROM asset_devices').fetchall()
+    for row in asset_device_rows:
+        edges.append({
+            "source_type": "asset",
+            "source_id": row["asset_id"],
+            "target_type": "device",
+            "target_id": row["device_id"],
+            "relation": "uses_device",
+            "criticality": "medium",
+            "redundancy_group": None,
+            "notes": None,
+            "implicit": True
+        })
+
+    asset_service_rows = db.execute('SELECT asset_id, service_id FROM asset_services').fetchall()
+    for row in asset_service_rows:
+        edges.append({
+            "source_type": "asset",
+            "source_id": row["asset_id"],
+            "target_type": "service",
+            "target_id": row["service_id"],
+            "relation": "consumes_service",
+            "criticality": "medium",
+            "redundancy_group": None,
+            "notes": None,
+            "implicit": True
+        })
+
+    assignment_rows = db.execute('''
+        SELECT asset_id, user_identifier, location_id
+        FROM asset_assignments
+        WHERE released_at IS NULL OR released_at = ''
+    ''').fetchall()
+    for row in assignment_rows:
+        if row["location_id"]:
+            edges.append({
+                "source_type": "asset",
+                "source_id": row["asset_id"],
+                "target_type": "location",
+                "target_id": row["location_id"],
+                "relation": "located_at",
+                "criticality": "low",
+                "redundancy_group": None,
+                "notes": None,
+                "implicit": True
+            })
+        if row["user_identifier"]:
+            user_row = db.execute('SELECT id FROM users WHERE username = ?', (row["user_identifier"],)).fetchone()
+            if user_row:
+                edges.append({
+                    "source_type": "asset",
+                    "source_id": row["asset_id"],
+                    "target_type": "user",
+                    "target_id": user_row["id"],
+                    "relation": "assigned_to",
+                    "criticality": "low",
+                    "redundancy_group": None,
+                    "notes": None,
+                    "implicit": True
+                })
+
+    installation_rows = db.execute('''
+        SELECT software_id, device_id, asset_id
+        FROM software_installations
+    ''').fetchall()
+    for row in installation_rows:
+        if row["device_id"]:
+            edges.append({
+                "source_type": "device",
+                "source_id": row["device_id"],
+                "target_type": "software",
+                "target_id": row["software_id"],
+                "relation": "runs_software",
+                "criticality": "medium",
+                "redundancy_group": None,
+                "notes": None,
+                "implicit": True
+            })
+        if row["asset_id"]:
+            edges.append({
+                "source_type": "asset",
+                "source_id": row["asset_id"],
+                "target_type": "software",
+                "target_id": row["software_id"],
+                "relation": "runs_software",
+                "criticality": "medium",
+                "redundancy_group": None,
+                "notes": None,
+                "implicit": True
+            })
+
+    software_rows = db.execute('SELECT id, owner_team_id FROM software WHERE owner_team_id IS NOT NULL').fetchall()
+    for row in software_rows:
+        edges.append({
+            "source_type": "software",
+            "source_id": row["id"],
+            "target_type": "team",
+            "target_id": row["owner_team_id"],
+            "relation": "maintained_by",
+            "criticality": "medium",
+            "redundancy_group": None,
+            "notes": None,
+            "implicit": True
+        })
+
+    team_rows = db.execute('SELECT id, department_id FROM teams WHERE department_id IS NOT NULL').fetchall()
+    for row in team_rows:
+        edges.append({
+            "source_type": "team",
+            "source_id": row["id"],
+            "target_type": "department",
+            "target_id": row["department_id"],
+            "relation": "part_of",
+            "criticality": "low",
+            "redundancy_group": None,
+            "notes": None,
+            "implicit": True
+        })
+
+    ticket_asset_rows = db.execute('SELECT ticket_id, asset_id FROM ticket_assets').fetchall()
+    for row in ticket_asset_rows:
+        edges.append({
+            "source_type": "ticket",
+            "source_id": row["ticket_id"],
+            "target_type": "asset",
+            "target_id": row["asset_id"],
+            "relation": "related_asset",
+            "criticality": "medium",
+            "redundancy_group": None,
+            "notes": None,
+            "implicit": True
+        })
+
+    roadmap_step_rows = db.execute('SELECT id, roadmap_id FROM roadmap_steps WHERE roadmap_id IS NOT NULL').fetchall()
+    for row in roadmap_step_rows:
+        edges.append({
+            "source_type": "roadmap_step",
+            "source_id": row["id"],
+            "target_type": "roadmap",
+            "target_id": row["roadmap_id"],
+            "relation": "part_of",
+            "criticality": "low",
+            "redundancy_group": None,
+            "notes": None,
+            "implicit": True
+        })
+
+    return edges
+
+def dependency_node_key(entity_type, entity_id):
+    return f"{entity_type}:{entity_id}"
+
+def build_dependency_nodes(db):
+    nodes = []
+    for entity_type, meta in DEPENDENCY_ENTITY_TYPES.items():
+        rows = db.execute(
+            f"SELECT id, {meta['name_col']} AS name FROM {meta['table']} ORDER BY {meta['name_col']}"
+        ).fetchall()
+        for row in rows:
+            nodes.append({
+                "key": dependency_node_key(entity_type, row["id"]),
+                "id": row["id"],
+                "type": entity_type,
+                "label": row["name"]
+            })
+    return nodes
+
+def build_dependency_graph_data(db):
+    nodes = build_dependency_nodes(db)
+    node_map = {node["key"]: node for node in nodes}
+    edges = build_dependency_edges(db)
+    for edge in edges:
+        source_key = dependency_node_key(edge["source_type"], edge["source_id"])
+        target_key = dependency_node_key(edge["target_type"], edge["target_id"])
+        if source_key not in node_map:
+            label = fetch_entity_label(db, edge["source_type"], edge["source_id"]) or f"{edge['source_type']} #{edge['source_id']}"
+            node_map[source_key] = {
+                "key": source_key,
+                "id": edge["source_id"],
+                "type": edge["source_type"],
+                "label": label
+            }
+        if target_key not in node_map:
+            label = fetch_entity_label(db, edge["target_type"], edge["target_id"]) or f"{edge['target_type']} #{edge['target_id']}"
+            node_map[target_key] = {
+                "key": target_key,
+                "id": edge["target_id"],
+                "type": edge["target_type"],
+                "label": label
+            }
+    return list(node_map.values()), edges
+
+def find_tickets_for_node(db, entity_type, entity_id):
+    ticket_ids = set()
+    if entity_type == "ticket":
+        ticket_ids.add(entity_id)
+    if entity_type == "asset":
+        rows = db.execute('SELECT ticket_id FROM ticket_assets WHERE asset_id = ?', (entity_id,)).fetchall()
+        ticket_ids.update(row["ticket_id"] for row in rows)
+    if entity_type == "device":
+        asset_rows = db.execute('SELECT asset_id FROM asset_devices WHERE device_id = ?', (entity_id,)).fetchall()
+        for asset_row in asset_rows:
+            rows = db.execute('SELECT ticket_id FROM ticket_assets WHERE asset_id = ?', (asset_row["asset_id"],)).fetchall()
+            ticket_ids.update(row["ticket_id"] for row in rows)
+    if entity_type == "software":
+        install_rows = db.execute('''
+            SELECT asset_id, device_id
+            FROM software_installations
+            WHERE software_id = ?
+        ''', (entity_id,)).fetchall()
+        for install in install_rows:
+            if install["asset_id"]:
+                rows = db.execute('SELECT ticket_id FROM ticket_assets WHERE asset_id = ?', (install["asset_id"],)).fetchall()
+                ticket_ids.update(row["ticket_id"] for row in rows)
+            if install["device_id"]:
+                asset_rows = db.execute('SELECT asset_id FROM asset_devices WHERE device_id = ?', (install["device_id"],)).fetchall()
+                for asset_row in asset_rows:
+                    rows = db.execute('SELECT ticket_id FROM ticket_assets WHERE asset_id = ?', (asset_row["asset_id"],)).fetchall()
+                    ticket_ids.update(row["ticket_id"] for row in rows)
+    if entity_type == "service":
+        asset_rows = db.execute('SELECT asset_id FROM asset_services WHERE service_id = ?', (entity_id,)).fetchall()
+        for asset_row in asset_rows:
+            rows = db.execute('SELECT ticket_id FROM ticket_assets WHERE asset_id = ?', (asset_row["asset_id"],)).fetchall()
+            ticket_ids.update(row["ticket_id"] for row in rows)
+    if entity_type == "location":
+        asset_rows = db.execute('SELECT asset_id FROM asset_assignments WHERE location_id = ?', (entity_id,)).fetchall()
+        for asset_row in asset_rows:
+            rows = db.execute('SELECT ticket_id FROM ticket_assets WHERE asset_id = ?', (asset_row["asset_id"],)).fetchall()
+            ticket_ids.update(row["ticket_id"] for row in rows)
+    if entity_type == "user":
+        user_row = db.execute('SELECT username FROM users WHERE id = ?', (entity_id,)).fetchone()
+        if user_row:
+            asset_rows = db.execute('SELECT asset_id FROM asset_assignments WHERE user_identifier = ?', (user_row["username"],)).fetchall()
+            for asset_row in asset_rows:
+                rows = db.execute('SELECT ticket_id FROM ticket_assets WHERE asset_id = ?', (asset_row["asset_id"],)).fetchall()
+                ticket_ids.update(row["ticket_id"] for row in rows)
+    if not ticket_ids:
+        return []
+    placeholders = ",".join("?" for _ in ticket_ids)
+    rows = db.execute(f'''
+        SELECT id, title, status, priority, escalation_level, due_date
+        FROM tickets
+        WHERE id IN ({placeholders})
+        ORDER BY created_at DESC
+    ''', tuple(ticket_ids)).fetchall()
+    return [dict(row) for row in rows]
+
+def analyze_dependency_impact(db, source_type, source_id, max_depth=None):
+    nodes, edges = build_dependency_graph_data(db)
+    node_map = {node["key"]: node for node in nodes}
+    reverse_adj = {}
+    for edge in edges:
+        source_key = dependency_node_key(edge["source_type"], edge["source_id"])
+        target_key = dependency_node_key(edge["target_type"], edge["target_id"])
+        reverse_adj.setdefault(target_key, []).append({
+            "key": source_key,
+            "relation": edge["relation"],
+            "criticality": edge["criticality"]
+        })
+
+    start_key = dependency_node_key(source_type, source_id)
+    visited = {start_key}
+    impact = []
+    queue = [(start_key, 0)]
+    while queue:
+        current_key, depth = queue.pop(0)
+        if max_depth is not None and depth >= max_depth:
+            continue
+        for neighbor in reverse_adj.get(current_key, []):
+            neighbor_key = neighbor["key"]
+            if neighbor_key in visited:
+                continue
+            visited.add(neighbor_key)
+            node = node_map.get(neighbor_key, {
+                "key": neighbor_key,
+                "type": neighbor_key.split(":")[0],
+                "id": int(neighbor_key.split(":")[1]),
+                "label": neighbor_key
+            })
+            impact.append({
+                "key": neighbor_key,
+                "type": node["type"],
+                "id": node["id"],
+                "label": node["label"],
+                "depth": depth + 1,
+                "relation": neighbor["relation"],
+                "criticality": neighbor["criticality"]
+            })
+            queue.append((neighbor_key, depth + 1))
+
+    impacted_ticket_ids = set()
+    for item in impact:
+        ticket_rows = find_tickets_for_node(db, item["type"], item["id"])
+        impacted_ticket_ids.update(ticket["id"] for ticket in ticket_rows)
+    direct_ticket_rows = find_tickets_for_node(db, source_type, source_id)
+    impacted_ticket_ids.update(ticket["id"] for ticket in direct_ticket_rows)
+
+    tickets = []
+    if impacted_ticket_ids:
+        placeholders = ",".join("?" for _ in impacted_ticket_ids)
+        ticket_rows = db.execute(f'''
+            SELECT id, title, status, priority, escalation_level, due_date
+            FROM tickets
+            WHERE id IN ({placeholders})
+            ORDER BY created_at DESC
+        ''', tuple(impacted_ticket_ids)).fetchall()
+        tickets = [dict(row) for row in ticket_rows]
+
+    critical_tickets = [
+        ticket for ticket in tickets
+        if (ticket.get("priority") or "").lower() in {"high", "urgent", "critical"}
+        or (ticket.get("escalation_level") or 0) > 0
+    ]
+    return impact, tickets, critical_tickets
+
+def calculate_spof_nodes(db):
+    rows = db.execute('''
+        SELECT source_type, source_id, target_type, target_id, redundancy_group
+        FROM dependency_links
+    ''').fetchall()
+    dependents = {}
+    redundancy_targets = set()
+    for row in rows:
+        target_key = dependency_node_key(row["target_type"], row["target_id"])
+        source_key = dependency_node_key(row["source_type"], row["source_id"])
+        dependents.setdefault(target_key, set()).add(source_key)
+        if row["redundancy_group"]:
+            redundancy_targets.add(target_key)
+    spof = []
+    for target_key, sources in dependents.items():
+        if target_key in redundancy_targets:
+            continue
+        entity_type, entity_id = target_key.split(":")
+        label = fetch_entity_label(db, entity_type, int(entity_id)) or target_key
+        spof.append({
+            "key": target_key,
+            "type": entity_type,
+            "id": int(entity_id),
+            "label": label,
+            "dependent_count": len(sources)
+        })
+    spof.sort(key=lambda item: item["dependent_count"], reverse=True)
+    return spof
 
 def pro_required(f):
     @wraps(f)
@@ -1676,6 +2201,13 @@ def tickets_page():
 def roadmap_page():
     access = get_user_access(get_db())
     return render_template('roadmap.html', username=session.get('username'), permissions=sorted(access["permissions"]), is_superuser=access["is_superuser"])
+
+@app.route('/dependencies')
+@login_required
+@require_permissions('dependencies.view', 'dependencies.manage')
+def dependencies_page():
+    access = get_user_access(get_db())
+    return render_template('dependencies.html', username=session.get('username'), permissions=sorted(access["permissions"]), is_superuser=access["is_superuser"])
 
 @app.route('/api/categories/<int:category_id>', methods=['PUT', 'DELETE'])
 @login_required
@@ -2441,6 +2973,462 @@ def roadmap_steps_detail(roadmap_id, step_id):
     log_activity(db, "delete", "roadmap_step", step_id, {"roadmap_id": roadmap_id})
     db.commit()
     return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/departments', methods=['GET', 'POST'])
+@login_required
+def departments():
+    db = get_db()
+    if request.method == 'POST':
+        if not user_can('departments.manage'):
+            return jsonify({"error": "Keine Berechtigung"}), 403
+        data = request.get_json() or {}
+        name = (data.get('name') or '').strip()
+        description = (data.get('description') or '').strip()
+        if not name:
+            return jsonify({"error": "Name ist erforderlich"}), 400
+        try:
+            cursor = db.execute('''
+                INSERT INTO departments (name, description)
+                VALUES (?, ?)
+            ''', (name, description))
+            log_activity(db, "create", "department", cursor.lastrowid, {"name": name})
+            db.commit()
+            return jsonify({"status": "created", "id": cursor.lastrowid}), 201
+        except sqlite3.IntegrityError:
+            return jsonify({"error": "Abteilung existiert bereits"}), 400
+
+    if not (user_can('departments.view') or user_can('departments.manage')):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    rows = db.execute('SELECT * FROM departments ORDER BY name').fetchall()
+    return jsonify([dict(row) for row in rows])
+
+@app.route('/api/departments/<int:department_id>', methods=['PUT', 'DELETE'])
+@login_required
+def department_detail(department_id):
+    db = get_db()
+    if not user_can('departments.manage'):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    department = db.execute('SELECT * FROM departments WHERE id = ?', (department_id,)).fetchone()
+    if not department:
+        return jsonify({"error": "Abteilung nicht gefunden"}), 404
+
+    if request.method == 'PUT':
+        data = request.get_json() or {}
+        name = (data.get('name') or department["name"] or '').strip()
+        description = (data.get('description') or department["description"] or '').strip()
+        if not name:
+            return jsonify({"error": "Name ist erforderlich"}), 400
+        db.execute('''
+            UPDATE departments
+            SET name = ?, description = ?
+            WHERE id = ?
+        ''', (name, description, department_id))
+        log_activity(db, "update", "department", department_id, {"name": name})
+        db.commit()
+        return jsonify({"status": "updated"}), 200
+
+    db.execute('DELETE FROM departments WHERE id = ?', (department_id,))
+    log_activity(db, "delete", "department", department_id, {"name": department["name"]})
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/teams', methods=['GET', 'POST'])
+@login_required
+def teams():
+    db = get_db()
+    if request.method == 'POST':
+        if not user_can('teams.manage'):
+            return jsonify({"error": "Keine Berechtigung"}), 403
+        data = request.get_json() or {}
+        name = (data.get('name') or '').strip()
+        department_id = data.get('department_id')
+        lead_user = (data.get('lead_user') or '').strip()
+        notes = (data.get('notes') or '').strip()
+        if not name:
+            return jsonify({"error": "Name ist erforderlich"}), 400
+        try:
+            cursor = db.execute('''
+                INSERT INTO teams (name, department_id, lead_user, notes)
+                VALUES (?, ?, ?, ?)
+            ''', (name, department_id, lead_user, notes))
+            log_activity(db, "create", "team", cursor.lastrowid, {"name": name})
+            db.commit()
+            return jsonify({"status": "created", "id": cursor.lastrowid}), 201
+        except sqlite3.IntegrityError:
+            return jsonify({"error": "Team existiert bereits"}), 400
+
+    if not (user_can('teams.view') or user_can('teams.manage')):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    rows = db.execute('''
+        SELECT t.*, d.name as department_name
+        FROM teams t
+        LEFT JOIN departments d ON t.department_id = d.id
+        ORDER BY t.name
+    ''').fetchall()
+    return jsonify([dict(row) for row in rows])
+
+@app.route('/api/teams/<int:team_id>', methods=['PUT', 'DELETE'])
+@login_required
+def team_detail(team_id):
+    db = get_db()
+    if not user_can('teams.manage'):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    team = db.execute('SELECT * FROM teams WHERE id = ?', (team_id,)).fetchone()
+    if not team:
+        return jsonify({"error": "Team nicht gefunden"}), 404
+
+    if request.method == 'PUT':
+        data = request.get_json() or {}
+        name = (data.get('name') or team["name"] or '').strip()
+        department_id = data.get('department_id')
+        lead_user = (data.get('lead_user') or team["lead_user"] or '').strip()
+        notes = (data.get('notes') or team["notes"] or '').strip()
+        if not name:
+            return jsonify({"error": "Name ist erforderlich"}), 400
+        db.execute('''
+            UPDATE teams
+            SET name = ?, department_id = ?, lead_user = ?, notes = ?
+            WHERE id = ?
+        ''', (name, department_id, lead_user, notes, team_id))
+        log_activity(db, "update", "team", team_id, {"name": name})
+        db.commit()
+        return jsonify({"status": "updated"}), 200
+
+    db.execute('DELETE FROM teams WHERE id = ?', (team_id,))
+    log_activity(db, "delete", "team", team_id, {"name": team["name"]})
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/software', methods=['GET', 'POST'])
+@login_required
+def software_inventory():
+    db = get_db()
+    if request.method == 'POST':
+        if not user_can('software.manage'):
+            return jsonify({"error": "Keine Berechtigung"}), 403
+        data = request.get_json() or {}
+        name = (data.get('name') or '').strip()
+        vendor = (data.get('vendor') or '').strip()
+        version = (data.get('version') or '').strip()
+        license_type = (data.get('license_type') or '').strip()
+        criticality = (data.get('criticality') or 'medium').strip()
+        description = (data.get('description') or '').strip()
+        owner_team_id = data.get('owner_team_id')
+        support_contact = (data.get('support_contact') or '').strip()
+        if not name:
+            return jsonify({"error": "Name ist erforderlich"}), 400
+        try:
+            cursor = db.execute('''
+                INSERT INTO software (name, vendor, version, license_type, criticality, description, owner_team_id, support_contact)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ''', (name, vendor, version, license_type, criticality, description, owner_team_id, support_contact))
+            log_activity(db, "create", "software", cursor.lastrowid, {"name": name})
+            db.commit()
+            return jsonify({"status": "created", "id": cursor.lastrowid}), 201
+        except sqlite3.IntegrityError:
+            return jsonify({"error": "Software existiert bereits"}), 400
+
+    if not (user_can('software.view') or user_can('software.manage')):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    rows = db.execute('''
+        SELECT s.*, t.name as owner_team_name
+        FROM software s
+        LEFT JOIN teams t ON s.owner_team_id = t.id
+        ORDER BY s.name
+    ''').fetchall()
+    return jsonify([dict(row) for row in rows])
+
+@app.route('/api/software/<int:software_id>', methods=['PUT', 'DELETE'])
+@login_required
+def software_detail(software_id):
+    db = get_db()
+    if not user_can('software.manage'):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    software_row = db.execute('SELECT * FROM software WHERE id = ?', (software_id,)).fetchone()
+    if not software_row:
+        return jsonify({"error": "Software nicht gefunden"}), 404
+
+    if request.method == 'PUT':
+        data = request.get_json() or {}
+        name = (data.get('name') or software_row["name"] or '').strip()
+        vendor = (data.get('vendor') or software_row["vendor"] or '').strip()
+        version = (data.get('version') or software_row["version"] or '').strip()
+        license_type = (data.get('license_type') or software_row["license_type"] or '').strip()
+        criticality = (data.get('criticality') or software_row["criticality"] or 'medium').strip()
+        description = (data.get('description') or software_row["description"] or '').strip()
+        owner_team_id = data.get('owner_team_id')
+        support_contact = (data.get('support_contact') or software_row["support_contact"] or '').strip()
+        if not name:
+            return jsonify({"error": "Name ist erforderlich"}), 400
+        db.execute('''
+            UPDATE software
+            SET name = ?, vendor = ?, version = ?, license_type = ?, criticality = ?, description = ?, owner_team_id = ?, support_contact = ?
+            WHERE id = ?
+        ''', (name, vendor, version, license_type, criticality, description, owner_team_id, support_contact, software_id))
+        log_activity(db, "update", "software", software_id, {"name": name})
+        db.commit()
+        return jsonify({"status": "updated"}), 200
+
+    db.execute('DELETE FROM software WHERE id = ?', (software_id,))
+    log_activity(db, "delete", "software", software_id, {"name": software_row["name"]})
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/software-installations', methods=['GET', 'POST'])
+@login_required
+def software_installations():
+    db = get_db()
+    if request.method == 'POST':
+        if not user_can('software.manage'):
+            return jsonify({"error": "Keine Berechtigung"}), 403
+        data = request.get_json() or {}
+        software_id = data.get('software_id')
+        device_id = data.get('device_id')
+        asset_id = data.get('asset_id')
+        if not software_id or not (device_id or asset_id):
+            return jsonify({"error": "Software sowie Gerät oder Asset sind erforderlich"}), 400
+        installed_version = (data.get('installed_version') or '').strip()
+        environment = (data.get('environment') or 'production').strip()
+        status = (data.get('status') or 'active').strip()
+        notes = (data.get('notes') or '').strip()
+        cursor = db.execute('''
+            INSERT INTO software_installations (
+                software_id, device_id, asset_id, installed_version, environment, status, notes
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        ''', (software_id, device_id, asset_id, installed_version, environment, status, notes))
+        log_activity(db, "create", "software_installation", cursor.lastrowid, {
+            "software_id": software_id,
+            "device_id": device_id,
+            "asset_id": asset_id
+        })
+        db.commit()
+        return jsonify({"status": "created", "id": cursor.lastrowid}), 201
+
+    if not (user_can('software.view') or user_can('software.manage')):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    software_id = request.args.get('software_id')
+    device_id = request.args.get('device_id')
+    asset_id = request.args.get('asset_id')
+    query = '''
+        SELECT si.*, s.name as software_name, d.name as device_name, a.name as asset_name
+        FROM software_installations si
+        JOIN software s ON si.software_id = s.id
+        LEFT JOIN devices d ON si.device_id = d.id
+        LEFT JOIN assets a ON si.asset_id = a.id
+    '''
+    conditions = []
+    params = []
+    if software_id:
+        conditions.append('si.software_id = ?')
+        params.append(software_id)
+    if device_id:
+        conditions.append('si.device_id = ?')
+        params.append(device_id)
+    if asset_id:
+        conditions.append('si.asset_id = ?')
+        params.append(asset_id)
+    if conditions:
+        query += ' WHERE ' + ' AND '.join(conditions)
+    query += ' ORDER BY si.created_at DESC'
+    rows = db.execute(query, params).fetchall()
+    return jsonify([dict(row) for row in rows])
+
+@app.route('/api/software-installations/<int:installation_id>', methods=['PUT', 'DELETE'])
+@login_required
+def software_installation_detail(installation_id):
+    db = get_db()
+    if not user_can('software.manage'):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    installation = db.execute('SELECT * FROM software_installations WHERE id = ?', (installation_id,)).fetchone()
+    if not installation:
+        return jsonify({"error": "Installation nicht gefunden"}), 404
+
+    if request.method == 'PUT':
+        data = request.get_json() or {}
+        installed_version = (data.get('installed_version') or installation["installed_version"] or '').strip()
+        environment = (data.get('environment') or installation["environment"] or 'production').strip()
+        status = (data.get('status') or installation["status"] or 'active').strip()
+        notes = (data.get('notes') or installation["notes"] or '').strip()
+        db.execute('''
+            UPDATE software_installations
+            SET installed_version = ?, environment = ?, status = ?, notes = ?
+            WHERE id = ?
+        ''', (installed_version, environment, status, notes, installation_id))
+        log_activity(db, "update", "software_installation", installation_id, {"software_id": installation["software_id"]})
+        db.commit()
+        return jsonify({"status": "updated"}), 200
+
+    db.execute('DELETE FROM software_installations WHERE id = ?', (installation_id,))
+    log_activity(db, "delete", "software_installation", installation_id, {"software_id": installation["software_id"]})
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/dependency-links', methods=['GET', 'POST'])
+@login_required
+def dependency_links():
+    db = get_db()
+    if request.method == 'POST':
+        if not user_can('dependencies.manage'):
+            return jsonify({"error": "Keine Berechtigung"}), 403
+        data = request.get_json() or {}
+        source_type = (data.get('source_type') or '').strip()
+        source_id = data.get('source_id')
+        target_type = (data.get('target_type') or '').strip()
+        target_id = data.get('target_id')
+        relation = (data.get('relation') or 'depends_on').strip()
+        criticality = (data.get('criticality') or 'medium').strip()
+        redundancy_group = (data.get('redundancy_group') or '').strip() or None
+        notes = (data.get('notes') or '').strip()
+        if source_type not in DEPENDENCY_ENTITY_TYPES or target_type not in DEPENDENCY_ENTITY_TYPES:
+            return jsonify({"error": "Ungültiger Entity-Typ"}), 400
+        if not source_id or not target_id:
+            return jsonify({"error": "Quelle und Ziel sind erforderlich"}), 400
+        try:
+            source_id = int(source_id)
+            target_id = int(target_id)
+        except (TypeError, ValueError):
+            return jsonify({"error": "Ungültige IDs"}), 400
+        if not fetch_entity_label(db, source_type, source_id) or not fetch_entity_label(db, target_type, target_id):
+            return jsonify({"error": "Quelle oder Ziel existiert nicht"}), 400
+        try:
+            cursor = db.execute('''
+                INSERT INTO dependency_links (
+                    source_type, source_id, target_type, target_id, relation, criticality, redundancy_group, notes
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ''', (source_type, source_id, target_type, target_id, relation, criticality, redundancy_group, notes))
+            log_activity(db, "create", "dependency_link", cursor.lastrowid, {
+                "source_type": source_type,
+                "source_id": source_id,
+                "target_type": target_type,
+                "target_id": target_id
+            })
+            db.commit()
+            return jsonify({"status": "created", "id": cursor.lastrowid}), 201
+        except sqlite3.IntegrityError:
+            return jsonify({"error": "Abhängigkeit existiert bereits"}), 400
+
+    if not (user_can('dependencies.view') or user_can('dependencies.manage')):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    rows = db.execute('''
+        SELECT *
+        FROM dependency_links
+        ORDER BY created_at DESC
+    ''').fetchall()
+    links = []
+    for row in rows:
+        source_label = fetch_entity_label(db, row["source_type"], row["source_id"]) or f"{row['source_type']} #{row['source_id']}"
+        target_label = fetch_entity_label(db, row["target_type"], row["target_id"]) or f"{row['target_type']} #{row['target_id']}"
+        links.append({
+            **dict(row),
+            "source_label": source_label,
+            "target_label": target_label
+        })
+    return jsonify(links)
+
+@app.route('/api/dependency-links/<int:link_id>', methods=['PUT', 'DELETE'])
+@login_required
+def dependency_link_detail(link_id):
+    db = get_db()
+    if not user_can('dependencies.manage'):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    link_row = db.execute('SELECT * FROM dependency_links WHERE id = ?', (link_id,)).fetchone()
+    if not link_row:
+        return jsonify({"error": "Abhängigkeit nicht gefunden"}), 404
+
+    if request.method == 'PUT':
+        data = request.get_json() or {}
+        relation = (data.get('relation') or link_row["relation"] or 'depends_on').strip()
+        criticality = (data.get('criticality') or link_row["criticality"] or 'medium').strip()
+        redundancy_group = (data.get('redundancy_group') or link_row["redundancy_group"] or '').strip() or None
+        notes = (data.get('notes') or link_row["notes"] or '').strip()
+        db.execute('''
+            UPDATE dependency_links
+            SET relation = ?, criticality = ?, redundancy_group = ?, notes = ?
+            WHERE id = ?
+        ''', (relation, criticality, redundancy_group, notes, link_id))
+        log_activity(db, "update", "dependency_link", link_id, {
+            "source_type": link_row["source_type"],
+            "source_id": link_row["source_id"]
+        })
+        db.commit()
+        return jsonify({"status": "updated"}), 200
+
+    db.execute('DELETE FROM dependency_links WHERE id = ?', (link_id,))
+    log_activity(db, "delete", "dependency_link", link_id, {
+        "source_type": link_row["source_type"],
+        "source_id": link_row["source_id"]
+    })
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
+
+@app.route('/api/dependency-nodes', methods=['GET'])
+@login_required
+def dependency_nodes():
+    db = get_db()
+    if not (user_can('dependencies.view') or user_can('dependencies.manage')):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    return jsonify(fetch_entity_options(db))
+
+@app.route('/api/dependency-graph', methods=['GET'])
+@login_required
+def dependency_graph():
+    db = get_db()
+    if not (user_can('dependencies.view') or user_can('dependencies.manage')):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    nodes, edges = build_dependency_graph_data(db)
+    graph_edges = []
+    for edge in edges:
+        source_key = dependency_node_key(edge["source_type"], edge["source_id"])
+        target_key = dependency_node_key(edge["target_type"], edge["target_id"])
+        graph_edges.append({
+            "source": source_key,
+            "target": target_key,
+            "relation": edge["relation"],
+            "criticality": edge["criticality"],
+            "implicit": edge["implicit"]
+        })
+    return jsonify({
+        "nodes": nodes,
+        "edges": graph_edges
+    })
+
+@app.route('/api/impact-analysis', methods=['GET'])
+@login_required
+def impact_analysis():
+    db = get_db()
+    if not (user_can('dependencies.view') or user_can('dependencies.manage')):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    source_type = (request.args.get('source_type') or '').strip()
+    source_id = request.args.get('source_id')
+    max_depth = request.args.get('depth')
+    if source_type not in DEPENDENCY_ENTITY_TYPES or not source_id:
+        return jsonify({"error": "Quelle ist erforderlich"}), 400
+    label = fetch_entity_label(db, source_type, int(source_id))
+    if not label:
+        return jsonify({"error": "Quelle nicht gefunden"}), 404
+    depth_value = int(max_depth) if max_depth is not None and str(max_depth).isdigit() else None
+    impact, tickets, critical_tickets = analyze_dependency_impact(db, source_type, int(source_id), depth_value)
+    return jsonify({
+        "source": {
+            "type": source_type,
+            "id": int(source_id),
+            "label": label
+        },
+        "impact": impact,
+        "tickets": tickets,
+        "critical_tickets": critical_tickets,
+        "spof": calculate_spof_nodes(db)
+    })
+
+@app.route('/api/single-points', methods=['GET'])
+@login_required
+def single_points():
+    db = get_db()
+    if not (user_can('dependencies.view') or user_can('dependencies.manage')):
+        return jsonify({"error": "Keine Berechtigung"}), 403
+    return jsonify(calculate_spof_nodes(db))
 
 @app.route('/api/tickets', methods=['GET', 'POST'])
 @login_required

--- a/templates/dependencies.html
+++ b/templates/dependencies.html
@@ -1,0 +1,814 @@
+<!DOCTYPE html>
+<html lang="de" x-data="dependencyApp()" x-init="init()">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Inventory Pro - Dependency & Impact Graph</title>
+    <script src="/static/theme.js"></script>
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+    <script src="https://unpkg.com/cytoscape@3.26.0/dist/cytoscape.min.js"></script>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body class="app-body bg-slate-950/5 text-slate-900">
+    <div class="app-shell">
+        <aside class="app-sidebar sidebar bg-white/90 backdrop-blur-xl border-r border-slate-200 shadow-sm">
+            <div class="sidebar-header p-6 border-b border-slate-200">
+                <a href="/" class="flex items-center gap-3">
+                    <span class="inline-flex items-center justify-center w-10 h-10 rounded-2xl bg-gradient-to-br from-blue-500 via-indigo-500 to-purple-500 text-white shadow-lg">
+                        <i data-feather="cpu" class="w-5 h-5"></i>
+                    </span>
+                    <div>
+                        <p class="text-lg font-semibold text-slate-900 sidebar-text">Inventory Pro</p>
+                        <p class="text-xs text-slate-500 sidebar-text">Smart Asset Hub</p>
+                    </div>
+                </a>
+            </div>
+            <nav x-data="{ appsOpen: true }" class="p-4 space-y-4 sidebar-scroll sidebar-primary-links">
+                <div class="rounded-2xl border border-slate-200 bg-white/80 shadow-sm">
+                    <button @click="appsOpen = !appsOpen" class="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-slate-50 transition-colors">
+                        <span class="flex items-center gap-3">
+                            <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-slate-100 text-slate-600">
+                                <i data-feather="grid" class="h-4 w-4"></i>
+                            </span>
+                            <span>
+                                <span class="block text-sm font-semibold text-slate-800 sidebar-text">Apps</span>
+                                <span class="block text-xs text-slate-400 sidebar-text">Verwaltung & Services</span>
+                            </span>
+                        </span>
+                        <svg :class="{ 'rotate-180': appsOpen }" class="h-4 w-4 text-slate-500 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                        </svg>
+                    </button>
+                    <div x-show="appsOpen" x-transition class="bg-slate-50/80 px-3 py-3 space-y-4">
+                        <div>
+                            <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Verwaltung</p>
+                            <div class="mt-2 space-y-1">
+                                {% if 'categories.view' in permissions or 'categories.manage' in permissions %}
+                                <a href="/" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="layers" class="h-4 w-4 text-slate-400"></i>
+                                        Kategorien
+                                    </span>
+                                </a>
+                                <a href="/" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="package" class="h-4 w-4 text-slate-400"></i>
+                                        Assets
+                                    </span>
+                                </a>
+                                {% endif %}
+                                {% if 'users.manage' in permissions %}
+                                <a href="/users" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="users" class="h-4 w-4 text-slate-400"></i>
+                                        Benutzer
+                                    </span>
+                                </a>
+                                {% endif %}
+                                {% if 'locations.view' in permissions or 'locations.manage' in permissions %}
+                                <a href="/locations" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="map-pin" class="h-4 w-4 text-slate-400"></i>
+                                        Standorte
+                                    </span>
+                                </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                        <div>
+                            <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Services</p>
+                            <div class="mt-2 space-y-1">
+                                {% if 'tickets.view_all' in permissions or 'tickets.view_own' in permissions or 'tickets.create' in permissions %}
+                                <a href="/tickets" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="life-buoy" class="h-4 w-4 text-slate-400"></i>
+                                        Ticketsystem
+                                    </span>
+                                </a>
+                                {% endif %}
+                                {% if 'roadmap.view' in permissions or 'roadmap.manage' in permissions %}
+                                <a href="/roadmap" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="git-merge" class="h-4 w-4 text-slate-400"></i>
+                                        Roadmap
+                                    </span>
+                                </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                        <div>
+                            <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Auswertung</p>
+                            <div class="mt-2 space-y-1">
+                                {% if 'stats.view' in permissions %}
+                                <a href="/stats" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="bar-chart-2" class="h-4 w-4 text-slate-400"></i>
+                                        Statistiken
+                                    </span>
+                                </a>
+                                {% endif %}
+                                {% if 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
+                                <a href="/dependencies" class="flex items-center justify-between rounded-xl bg-white px-3 py-2 text-sm font-semibold text-indigo-700 shadow-sm">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="share-2" class="h-4 w-4 text-indigo-500"></i>
+                                        Dependency-Graph
+                                    </span>
+                                </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </nav>
+        </aside>
+
+        <div class="app-main app-main--fixed">
+            <header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 z-30 h-[82px]">
+                <div class="flex items-center gap-4">
+                    <button type="button" data-sidebar-toggle aria-label="Navigation umschalten" class="inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white p-2 text-slate-600 shadow-sm hover:bg-slate-50">
+                        <i data-feather="menu" class="w-4 h-4"></i>
+                    </button>
+                    <div>
+                        <p class="text-xs uppercase tracking-widest text-slate-400">Dependency & Impact</p>
+                        <h1 class="text-xl font-semibold text-slate-900">Abhängigkeits- & Impact-Graph</h1>
+                    </div>
+                </div>
+                <div class="flex items-center gap-4">
+                    <div class="hidden sm:block text-right">
+                        <p class="text-xs text-slate-400">Angemeldet als</p>
+                        <p class="text-sm font-semibold text-slate-800">{{ username }}</p>
+                    </div>
+                    <form action="/logout" method="post">
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold text-white shadow-lg hover:bg-slate-800">
+                            <i data-feather="log-out" class="h-4 w-4"></i>
+                            Logout
+                        </button>
+                    </form>
+                </div>
+            </header>
+
+            <main class="app-content app-content--padded pt-[110px] pb-16">
+                <section class="grid gap-6 lg:grid-cols-4">
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                        <p class="text-xs uppercase tracking-widest text-slate-400">Software</p>
+                        <p class="mt-3 text-3xl font-semibold text-slate-900" x-text="overview.software"></p>
+                        <p class="mt-1 text-sm text-slate-500">Inventarisierte Produkte</p>
+                    </div>
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                        <p class="text-xs uppercase tracking-widest text-slate-400">Teams</p>
+                        <p class="mt-3 text-3xl font-semibold text-slate-900" x-text="overview.teams"></p>
+                        <p class="mt-1 text-sm text-slate-500">Betreuende Einheiten</p>
+                    </div>
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                        <p class="text-xs uppercase tracking-widest text-slate-400">Abhängigkeiten</p>
+                        <p class="mt-3 text-3xl font-semibold text-slate-900" x-text="overview.links"></p>
+                        <p class="mt-1 text-sm text-slate-500">Explizite Links</p>
+                    </div>
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                        <p class="text-xs uppercase tracking-widest text-slate-400">Single Points</p>
+                        <p class="mt-3 text-3xl font-semibold text-slate-900" x-text="overview.spof"></p>
+                        <p class="mt-1 text-sm text-slate-500">Kritische Engpässe</p>
+                    </div>
+                </section>
+
+                <section class="mt-8 grid gap-6 xl:grid-cols-3">
+                    <div class="xl:col-span-2 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <h2 class="text-lg font-semibold text-slate-900">Graph-Visualisierung</h2>
+                                <p class="text-sm text-slate-500">Asset, Software, Teams, Tickets und Roadmaps in einem Graph.</p>
+                            </div>
+                            <div class="flex gap-2">
+                                <button @click="refreshGraph()" class="rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-semibold text-slate-600 hover:bg-slate-50">Neu laden</button>
+                                <button @click="fitGraph()" class="rounded-full bg-indigo-600 px-4 py-2 text-xs font-semibold text-white hover:bg-indigo-500">Fit</button>
+                            </div>
+                        </div>
+                        <div id="dependencyGraph" class="mt-6 h-[520px] w-full rounded-2xl border border-slate-200"></div>
+                        <div class="mt-4 flex flex-wrap gap-3 text-xs text-slate-500">
+                            <span class="rounded-full bg-slate-100 px-3 py-1">Durchgezogene Kanten = explizit</span>
+                            <span class="rounded-full bg-slate-100 px-3 py-1">Gestrichelt = automatisch (Assets, Installationen, Roadmaps)</span>
+                        </div>
+                    </div>
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                        <h2 class="text-lg font-semibold text-slate-900">Impact-Analyse</h2>
+                        <p class="text-sm text-slate-500">Szenarien simulieren: “Was fällt alles aus, wenn …?”</p>
+                        <div class="mt-4 space-y-3">
+                            <label class="block text-xs font-semibold text-slate-500">Quelle</label>
+                            <select x-model="impactQuery.sourceKey" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                <option value="">Quelle auswählen</option>
+                                <template x-for="(items, type) in nodeOptions" :key="type">
+                                    <optgroup :label="typeLabels[type] || type">
+                                        <template x-for="item in items" :key="`${type}-${item.id}`">
+                                            <option :value="`${type}:${item.id}`" x-text="item.name"></option>
+                                        </template>
+                                    </optgroup>
+                                </template>
+                            </select>
+                            <label class="block text-xs font-semibold text-slate-500">Tiefe (optional)</label>
+                            <input x-model="impactQuery.depth" type="number" min="1" placeholder="z.B. 3" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                            <button @click="runImpactAnalysis()" class="w-full rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold text-white hover:bg-slate-800">Analyse starten</button>
+                        </div>
+                        <div class="mt-6">
+                            <h3 class="text-sm font-semibold text-slate-800">Betroffene Assets & Services</h3>
+                            <div class="mt-2 space-y-2 max-h-48 overflow-auto">
+                                <template x-for="item in impactResult.impact" :key="item.key">
+                                    <div class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs">
+                                        <p class="font-semibold text-slate-800" x-text="item.label"></p>
+                                        <p class="text-slate-500" x-text="`${typeLabels[item.type] || item.type} • Tiefe ${item.depth} • ${item.relation}`"></p>
+                                    </div>
+                                </template>
+                                <p x-show="impactResult.impact.length === 0" class="text-xs text-slate-400">Noch keine Analyse.</p>
+                            </div>
+                        </div>
+                        <div class="mt-6">
+                            <h3 class="text-sm font-semibold text-slate-800">Kritische Tickets</h3>
+                            <div class="mt-2 space-y-2 max-h-40 overflow-auto">
+                                <template x-for="ticket in impactResult.criticalTickets" :key="ticket.id">
+                                    <div class="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-xs">
+                                        <p class="font-semibold text-rose-800" x-text="`#${ticket.id} ${ticket.title}`"></p>
+                                        <p class="text-rose-600" x-text="`${ticket.priority || 'normal'} • ${ticket.status || 'open'}`"></p>
+                                    </div>
+                                </template>
+                                <p x-show="impactResult.criticalTickets.length === 0" class="text-xs text-slate-400">Keine kritischen Tickets erkannt.</p>
+                            </div>
+                        </div>
+                        <div class="mt-6">
+                            <h3 class="text-sm font-semibold text-slate-800">Single Points of Failure</h3>
+                            <div class="mt-2 space-y-2 max-h-40 overflow-auto">
+                                <template x-for="node in impactResult.spof" :key="node.key">
+                                    <div class="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs">
+                                        <p class="font-semibold text-amber-900" x-text="node.label"></p>
+                                        <p class="text-amber-700" x-text="`${node.dependent_count} abhängige Knoten`"></p>
+                                    </div>
+                                </template>
+                                <p x-show="impactResult.spof.length === 0" class="text-xs text-slate-400">Noch keine SPOFs definiert.</p>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="mt-10 grid gap-6 lg:grid-cols-2">
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                        <h2 class="text-lg font-semibold text-slate-900">Software-Inventar</h2>
+                        <p class="text-sm text-slate-500">Inventarisierung mit Owner-Team, Kritikalität und Support.</p>
+                        <div class="mt-4 grid gap-3 md:grid-cols-2">
+                            <input x-model="newSoftware.name" placeholder="Software-Name" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                            <input x-model="newSoftware.vendor" placeholder="Hersteller" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                            <input x-model="newSoftware.version" placeholder="Version" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                            <input x-model="newSoftware.license_type" placeholder="Lizenztyp" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                            <select x-model="newSoftware.criticality" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                <option value="low">Niedrig</option>
+                                <option value="medium">Mittel</option>
+                                <option value="high">Hoch</option>
+                                <option value="critical">Kritisch</option>
+                            </select>
+                            <select x-model="newSoftware.owner_team_id" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                <option value="">Owner-Team auswählen</option>
+                                <template x-for="team in teams" :key="team.id">
+                                    <option :value="team.id" x-text="team.name"></option>
+                                </template>
+                            </select>
+                            <input x-model="newSoftware.support_contact" placeholder="Support Kontakt" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm md:col-span-2">
+                            <textarea x-model="newSoftware.description" placeholder="Beschreibung" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm md:col-span-2"></textarea>
+                        </div>
+                        <button @click="createSoftware()" class="mt-4 rounded-full bg-indigo-600 px-4 py-2 text-xs font-semibold text-white hover:bg-indigo-500">Software anlegen</button>
+
+                        <div class="mt-6 space-y-3 max-h-72 overflow-auto">
+                            <template x-for="item in software" :key="item.id">
+                                <div class="rounded-2xl border border-slate-200 p-4 text-sm">
+                                    <div class="flex items-start justify-between gap-4">
+                                        <div>
+                                            <p class="font-semibold text-slate-900" x-text="item.name"></p>
+                                            <p class="text-xs text-slate-500" x-text="`${item.vendor || '-'} • ${item.version || 'n/a'} • ${item.criticality}`"></p>
+                                            <p class="text-xs text-slate-500" x-text="item.owner_team_name ? `Owner: ${item.owner_team_name}` : 'Kein Team zugeordnet'"></p>
+                                        </div>
+                                        <button @click="deleteSoftware(item.id)" class="text-xs font-semibold text-rose-600 hover:text-rose-700">Löschen</button>
+                                    </div>
+                                </div>
+                            </template>
+                            <p x-show="software.length === 0" class="text-xs text-slate-400">Noch keine Software erfasst.</p>
+                        </div>
+                    </div>
+
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                        <h2 class="text-lg font-semibold text-slate-900">Software-Installationen</h2>
+                        <p class="text-sm text-slate-500">Verknüpfung zu Geräten, Assets und Umgebungen.</p>
+                        <div class="mt-4 grid gap-3 md:grid-cols-2">
+                            <select x-model="newInstallation.software_id" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                <option value="">Software auswählen</option>
+                                <template x-for="item in software" :key="item.id">
+                                    <option :value="item.id" x-text="item.name"></option>
+                                </template>
+                            </select>
+                            <select x-model="newInstallation.asset_id" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                <option value="">Asset auswählen</option>
+                                <template x-for="asset in nodeOptions.asset || []" :key="`asset-${asset.id}`">
+                                    <option :value="asset.id" x-text="asset.name"></option>
+                                </template>
+                            </select>
+                            <select x-model="newInstallation.device_id" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                <option value="">Gerät auswählen</option>
+                                <template x-for="device in nodeOptions.device || []" :key="`device-${device.id}`">
+                                    <option :value="device.id" x-text="device.name"></option>
+                                </template>
+                            </select>
+                            <input x-model="newInstallation.installed_version" placeholder="Installierte Version" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                            <select x-model="newInstallation.environment" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                <option value="production">Production</option>
+                                <option value="staging">Staging</option>
+                                <option value="dev">Development</option>
+                            </select>
+                            <select x-model="newInstallation.status" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                <option value="active">Aktiv</option>
+                                <option value="maintenance">Wartung</option>
+                                <option value="deprecated">Veraltet</option>
+                            </select>
+                            <textarea x-model="newInstallation.notes" placeholder="Notizen" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm md:col-span-2"></textarea>
+                        </div>
+                        <button @click="createInstallation()" class="mt-4 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold text-white hover:bg-slate-800">Installation hinzufügen</button>
+
+                        <div class="mt-6 space-y-3 max-h-72 overflow-auto">
+                            <template x-for="item in installations" :key="item.id">
+                                <div class="rounded-2xl border border-slate-200 p-4 text-sm">
+                                    <div class="flex items-start justify-between gap-4">
+                                        <div>
+                                            <p class="font-semibold text-slate-900" x-text="item.software_name"></p>
+                                            <p class="text-xs text-slate-500" x-text="`${item.device_name || item.asset_name || 'Unbekannt'} • ${item.environment}`"></p>
+                                            <p class="text-xs text-slate-500" x-text="`${item.status} • ${item.installed_version || 'Version n/a'}`"></p>
+                                        </div>
+                                        <button @click="deleteInstallation(item.id)" class="text-xs font-semibold text-rose-600 hover:text-rose-700">Löschen</button>
+                                    </div>
+                                </div>
+                            </template>
+                            <p x-show="installations.length === 0" class="text-xs text-slate-400">Noch keine Installationen.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="mt-10 grid gap-6 lg:grid-cols-2">
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                        <h2 class="text-lg font-semibold text-slate-900">Teams & Abteilungen</h2>
+                        <div class="mt-4 grid gap-3 md:grid-cols-2">
+                            <input x-model="newDepartment.name" placeholder="Abteilung" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                            <input x-model="newDepartment.description" placeholder="Beschreibung" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                        </div>
+                        <button @click="createDepartment()" class="mt-4 rounded-full bg-indigo-600 px-4 py-2 text-xs font-semibold text-white hover:bg-indigo-500">Abteilung anlegen</button>
+
+                        <div class="mt-6 space-y-2">
+                            <template x-for="department in departments" :key="department.id">
+                                <div class="flex items-center justify-between rounded-2xl border border-slate-200 px-4 py-2 text-sm">
+                                    <div>
+                                        <p class="font-semibold text-slate-900" x-text="department.name"></p>
+                                        <p class="text-xs text-slate-500" x-text="department.description || 'Keine Beschreibung'"></p>
+                                    </div>
+                                    <button @click="deleteDepartment(department.id)" class="text-xs font-semibold text-rose-600 hover:text-rose-700">Löschen</button>
+                                </div>
+                            </template>
+                            <p x-show="departments.length === 0" class="text-xs text-slate-400">Keine Abteilungen erfasst.</p>
+                        </div>
+
+                        <div class="mt-6 grid gap-3 md:grid-cols-2">
+                            <input x-model="newTeam.name" placeholder="Team" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                            <select x-model="newTeam.department_id" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                <option value="">Abteilung wählen</option>
+                                <template x-for="department in departments" :key="`dept-${department.id}`">
+                                    <option :value="department.id" x-text="department.name"></option>
+                                </template>
+                            </select>
+                            <input x-model="newTeam.lead_user" placeholder="Team Lead" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                            <input x-model="newTeam.notes" placeholder="Notizen" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                        </div>
+                        <button @click="createTeam()" class="mt-4 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold text-white hover:bg-slate-800">Team anlegen</button>
+
+                        <div class="mt-6 space-y-2">
+                            <template x-for="team in teams" :key="team.id">
+                                <div class="flex items-center justify-between rounded-2xl border border-slate-200 px-4 py-2 text-sm">
+                                    <div>
+                                        <p class="font-semibold text-slate-900" x-text="team.name"></p>
+                                        <p class="text-xs text-slate-500" x-text="team.department_name ? `Abteilung: ${team.department_name}` : 'Ohne Abteilung'"></p>
+                                    </div>
+                                    <button @click="deleteTeam(team.id)" class="text-xs font-semibold text-rose-600 hover:text-rose-700">Löschen</button>
+                                </div>
+                            </template>
+                            <p x-show="teams.length === 0" class="text-xs text-slate-400">Noch keine Teams angelegt.</p>
+                        </div>
+                    </div>
+
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                        <h2 class="text-lg font-semibold text-slate-900">Abhängigkeiten modellieren</h2>
+                        <p class="text-sm text-slate-500">Verknüpfen Sie Assets, Software, Teams, Tickets und Roadmaps.</p>
+                        <div class="mt-4 grid gap-3 md:grid-cols-2">
+                            <select x-model="newLink.sourceKey" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                <option value="">Quelle</option>
+                                <template x-for="(items, type) in nodeOptions" :key="`source-${type}`">
+                                    <optgroup :label="typeLabels[type] || type">
+                                        <template x-for="item in items" :key="`source-${type}-${item.id}`">
+                                            <option :value="`${type}:${item.id}`" x-text="item.name"></option>
+                                        </template>
+                                    </optgroup>
+                                </template>
+                            </select>
+                            <select x-model="newLink.targetKey" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                <option value="">Ziel</option>
+                                <template x-for="(items, type) in nodeOptions" :key="`target-${type}`">
+                                    <optgroup :label="typeLabels[type] || type">
+                                        <template x-for="item in items" :key="`target-${type}-${item.id}`">
+                                            <option :value="`${type}:${item.id}`" x-text="item.name"></option>
+                                        </template>
+                                    </optgroup>
+                                </template>
+                            </select>
+                            <input x-model="newLink.relation" placeholder="Relation (z.B. depends_on)" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                            <select x-model="newLink.criticality" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                                <option value="low">Niedrig</option>
+                                <option value="medium">Mittel</option>
+                                <option value="high">Hoch</option>
+                                <option value="critical">Kritisch</option>
+                            </select>
+                            <input x-model="newLink.redundancy_group" placeholder="Redundanz-Gruppe" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                            <input x-model="newLink.notes" placeholder="Notizen" class="rounded-2xl border border-slate-200 px-3 py-2 text-sm">
+                        </div>
+                        <button @click="createDependencyLink()" class="mt-4 rounded-full bg-indigo-600 px-4 py-2 text-xs font-semibold text-white hover:bg-indigo-500">Abhängigkeit anlegen</button>
+
+                        <div class="mt-6 space-y-2 max-h-80 overflow-auto">
+                            <template x-for="link in dependencyLinks" :key="link.id">
+                                <div class="rounded-2xl border border-slate-200 p-4 text-sm">
+                                    <div class="flex items-start justify-between gap-4">
+                                        <div>
+                                            <p class="font-semibold text-slate-900" x-text="`${link.source_label} → ${link.target_label}`"></p>
+                                            <p class="text-xs text-slate-500" x-text="`${link.relation} • ${link.criticality}`"></p>
+                                            <p class="text-xs text-slate-500" x-text="link.redundancy_group ? `Redundanz: ${link.redundancy_group}` : 'Keine Redundanz'"></p>
+                                        </div>
+                                        <button @click="deleteDependencyLink(link.id)" class="text-xs font-semibold text-rose-600 hover:text-rose-700">Löschen</button>
+                                    </div>
+                                </div>
+                            </template>
+                            <p x-show="dependencyLinks.length === 0" class="text-xs text-slate-400">Noch keine Abhängigkeiten modelliert.</p>
+                        </div>
+                    </div>
+                </section>
+            </main>
+        </div>
+    </div>
+
+    <script>
+        function dependencyApp() {
+            return {
+                graph: null,
+                graphData: { nodes: [], edges: [] },
+                nodeOptions: {},
+                departments: [],
+                teams: [],
+                software: [],
+                installations: [],
+                dependencyLinks: [],
+                overview: { software: 0, teams: 0, links: 0, spof: 0 },
+                impactResult: { impact: [], tickets: [], criticalTickets: [], spof: [] },
+                newDepartment: { name: '', description: '' },
+                newTeam: { name: '', department_id: '', lead_user: '', notes: '' },
+                newSoftware: { name: '', vendor: '', version: '', license_type: '', criticality: 'medium', description: '', owner_team_id: '', support_contact: '' },
+                newInstallation: { software_id: '', asset_id: '', device_id: '', installed_version: '', environment: 'production', status: 'active', notes: '' },
+                newLink: { sourceKey: '', targetKey: '', relation: 'depends_on', criticality: 'medium', redundancy_group: '', notes: '' },
+                impactQuery: { sourceKey: '', depth: '' },
+                typeLabels: {
+                    asset: 'Asset',
+                    device: 'Gerät',
+                    software: 'Software',
+                    service: 'Service',
+                    team: 'Team',
+                    department: 'Abteilung',
+                    location: 'Standort',
+                    user: 'Benutzer',
+                    ticket: 'Ticket',
+                    roadmap: 'Roadmap',
+                    roadmap_step: 'Roadmap-Schritt'
+                },
+                async init() {
+                    await this.loadAll();
+                    await this.refreshGraph();
+                    this.$nextTick(() => {
+                        if (window.feather) {
+                            feather.replace();
+                        }
+                    });
+                },
+                async loadAll() {
+                    await Promise.all([
+                        this.loadNodeOptions(),
+                        this.loadDepartments(),
+                        this.loadTeams(),
+                        this.loadSoftware(),
+                        this.loadInstallations(),
+                        this.loadDependencyLinks(),
+                        this.loadSpof()
+                    ]);
+                    this.updateOverview();
+                },
+                updateOverview() {
+                    this.overview.software = this.software.length;
+                    this.overview.teams = this.teams.length;
+                    this.overview.links = this.dependencyLinks.length;
+                    this.overview.spof = this.impactResult.spof.length;
+                },
+                async loadNodeOptions() {
+                    const response = await fetch('/api/dependency-nodes');
+                    if (response.ok) {
+                        this.nodeOptions = await response.json();
+                    }
+                },
+                async loadDepartments() {
+                    const response = await fetch('/api/departments');
+                    if (response.ok) {
+                        this.departments = await response.json();
+                    }
+                },
+                async loadTeams() {
+                    const response = await fetch('/api/teams');
+                    if (response.ok) {
+                        this.teams = await response.json();
+                    }
+                },
+                async loadSoftware() {
+                    const response = await fetch('/api/software');
+                    if (response.ok) {
+                        this.software = await response.json();
+                    }
+                },
+                async loadInstallations() {
+                    const response = await fetch('/api/software-installations');
+                    if (response.ok) {
+                        this.installations = await response.json();
+                    }
+                },
+                async loadDependencyLinks() {
+                    const response = await fetch('/api/dependency-links');
+                    if (response.ok) {
+                        this.dependencyLinks = await response.json();
+                    }
+                },
+                async loadSpof() {
+                    const response = await fetch('/api/single-points');
+                    if (response.ok) {
+                        this.impactResult.spof = await response.json();
+                    }
+                },
+                async refreshGraph() {
+                    const response = await fetch('/api/dependency-graph');
+                    if (!response.ok) {
+                        return;
+                    }
+                    this.graphData = await response.json();
+                    this.renderGraph();
+                },
+                renderGraph() {
+                    const elements = [
+                        ...this.graphData.nodes.map(node => ({
+                            data: { id: node.key, label: node.label, type: node.type }
+                        })),
+                        ...this.graphData.edges.map((edge, index) => ({
+                            data: {
+                                id: `edge-${index}`,
+                                source: edge.source,
+                                target: edge.target,
+                                label: edge.relation,
+                                criticality: edge.criticality,
+                                implicit: edge.implicit
+                            }
+                        }))
+                    ];
+                    if (this.graph) {
+                        this.graph.destroy();
+                    }
+                    this.graph = cytoscape({
+                        container: document.getElementById('dependencyGraph'),
+                        elements,
+                        layout: { name: 'cose', animate: false, padding: 20 },
+                        style: [
+                            {
+                                selector: 'node',
+                                style: {
+                                    'background-color': '#6366F1',
+                                    'label': 'data(label)',
+                                    'font-size': 10,
+                                    'color': '#0f172a',
+                                    'text-valign': 'center',
+                                    'text-halign': 'center',
+                                    'text-wrap': 'wrap',
+                                    'width': 48,
+                                    'height': 48
+                                }
+                            },
+                            {
+                                selector: 'edge',
+                                style: {
+                                    'width': 2,
+                                    'line-color': '#94a3b8',
+                                    'target-arrow-color': '#94a3b8',
+                                    'target-arrow-shape': 'triangle',
+                                    'curve-style': 'bezier',
+                                    'label': 'data(label)',
+                                    'font-size': 8,
+                                    'text-background-opacity': 1,
+                                    'text-background-color': '#ffffff',
+                                    'text-background-padding': 2
+                                }
+                            },
+                            {
+                                selector: 'edge[implicit = "true"]',
+                                style: {
+                                    'line-style': 'dashed',
+                                    'line-color': '#cbd5f5',
+                                    'target-arrow-color': '#cbd5f5'
+                                }
+                            },
+                            {
+                                selector: 'node[type = "software"]',
+                                style: { 'background-color': '#0ea5e9' }
+                            },
+                            {
+                                selector: 'node[type = "team"]',
+                                style: { 'background-color': '#14b8a6' }
+                            },
+                            {
+                                selector: 'node[type = "department"]',
+                                style: { 'background-color': '#f97316' }
+                            },
+                            {
+                                selector: 'node[type = "ticket"]',
+                                style: { 'background-color': '#ef4444' }
+                            }
+                        ]
+                    });
+                },
+                fitGraph() {
+                    if (this.graph) {
+                        this.graph.fit();
+                    }
+                },
+                parseNodeKey(key) {
+                    if (!key) {
+                        return { type: null, id: null };
+                    }
+                    const [type, id] = key.split(':');
+                    return { type, id: parseInt(id, 10) };
+                },
+                async runImpactAnalysis() {
+                    const { type, id } = this.parseNodeKey(this.impactQuery.sourceKey);
+                    if (!type || !id) {
+                        alert('Bitte eine Quelle auswählen.');
+                        return;
+                    }
+                    const params = new URLSearchParams({ source_type: type, source_id: id });
+                    if (this.impactQuery.depth) {
+                        params.append('depth', this.impactQuery.depth);
+                    }
+                    const response = await fetch(`/api/impact-analysis?${params.toString()}`);
+                    if (response.ok) {
+                        const data = await response.json();
+                        this.impactResult.impact = data.impact || [];
+                        this.impactResult.criticalTickets = data.critical_tickets || [];
+                        this.impactResult.spof = data.spof || [];
+                        this.updateOverview();
+                    }
+                },
+                async createDepartment() {
+                    const response = await fetch('/api/departments', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(this.newDepartment)
+                    });
+                    if (response.ok) {
+                        this.newDepartment = { name: '', description: '' };
+                        await this.loadDepartments();
+                        await this.loadNodeOptions();
+                    }
+                },
+                async deleteDepartment(id) {
+                    if (!confirm('Abteilung wirklich löschen?')) return;
+                    const response = await fetch(`/api/departments/${id}`, { method: 'DELETE' });
+                    if (response.ok) {
+                        await this.loadDepartments();
+                        await this.loadNodeOptions();
+                    }
+                },
+                async createTeam() {
+                    const response = await fetch('/api/teams', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(this.newTeam)
+                    });
+                    if (response.ok) {
+                        this.newTeam = { name: '', department_id: '', lead_user: '', notes: '' };
+                        await this.loadTeams();
+                        await this.loadNodeOptions();
+                    }
+                },
+                async deleteTeam(id) {
+                    if (!confirm('Team wirklich löschen?')) return;
+                    const response = await fetch(`/api/teams/${id}`, { method: 'DELETE' });
+                    if (response.ok) {
+                        await this.loadTeams();
+                        await this.loadNodeOptions();
+                    }
+                },
+                async createSoftware() {
+                    const response = await fetch('/api/software', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(this.newSoftware)
+                    });
+                    if (response.ok) {
+                        this.newSoftware = { name: '', vendor: '', version: '', license_type: '', criticality: 'medium', description: '', owner_team_id: '', support_contact: '' };
+                        await this.loadSoftware();
+                        await this.loadNodeOptions();
+                        await this.refreshGraph();
+                        this.updateOverview();
+                    }
+                },
+                async deleteSoftware(id) {
+                    if (!confirm('Software wirklich löschen?')) return;
+                    const response = await fetch(`/api/software/${id}`, { method: 'DELETE' });
+                    if (response.ok) {
+                        await this.loadSoftware();
+                        await this.loadNodeOptions();
+                        await this.refreshGraph();
+                        this.updateOverview();
+                    }
+                },
+                async createInstallation() {
+                    const response = await fetch('/api/software-installations', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(this.newInstallation)
+                    });
+                    if (response.ok) {
+                        this.newInstallation = { software_id: '', asset_id: '', device_id: '', installed_version: '', environment: 'production', status: 'active', notes: '' };
+                        await this.loadInstallations();
+                        await this.refreshGraph();
+                    }
+                },
+                async deleteInstallation(id) {
+                    if (!confirm('Installation wirklich löschen?')) return;
+                    const response = await fetch(`/api/software-installations/${id}`, { method: 'DELETE' });
+                    if (response.ok) {
+                        await this.loadInstallations();
+                        await this.refreshGraph();
+                    }
+                },
+                async createDependencyLink() {
+                    const source = this.parseNodeKey(this.newLink.sourceKey);
+                    const target = this.parseNodeKey(this.newLink.targetKey);
+                    if (!source.type || !target.type) {
+                        alert('Quelle und Ziel auswählen.');
+                        return;
+                    }
+                    const payload = {
+                        source_type: source.type,
+                        source_id: source.id,
+                        target_type: target.type,
+                        target_id: target.id,
+                        relation: this.newLink.relation,
+                        criticality: this.newLink.criticality,
+                        redundancy_group: this.newLink.redundancy_group,
+                        notes: this.newLink.notes
+                    };
+                    const response = await fetch('/api/dependency-links', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(payload)
+                    });
+                    if (response.ok) {
+                        this.newLink = { sourceKey: '', targetKey: '', relation: 'depends_on', criticality: 'medium', redundancy_group: '', notes: '' };
+                        await this.loadDependencyLinks();
+                        await this.refreshGraph();
+                        await this.loadSpof();
+                        this.updateOverview();
+                    }
+                },
+                async deleteDependencyLink(id) {
+                    if (!confirm('Abhängigkeit wirklich löschen?')) return;
+                    const response = await fetch(`/api/dependency-links/${id}`, { method: 'DELETE' });
+                    if (response.ok) {
+                        await this.loadDependencyLinks();
+                        await this.refreshGraph();
+                        await this.loadSpof();
+                        this.updateOverview();
+                    }
+                }
+            }
+        }
+    </script>
+    <script src="https://unpkg.com/feather-icons"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            feather.replace();
+        });
+    </script>
+    <script src="/static/ui.js"></script>
+    <script src="/static/theme.js"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -261,16 +261,26 @@
                                 {% endif %}
                             </div>
                         </div>
-                        {% if 'stats.view' in permissions %}
+                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
                         <div>
                             <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Auswertung</p>
                             <div class="mt-2 space-y-1">
+                                {% if 'stats.view' in permissions %}
                                 <a href="/stats" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
                                     <span class="flex items-center gap-2">
                                         <i data-feather="bar-chart-2" class="h-4 w-4 text-slate-400"></i>
                                         Statistiken
                                     </span>
                                 </a>
+                                {% endif %}
+                                {% if 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
+                                <a href="/dependencies" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="share-2" class="h-4 w-4 text-slate-400"></i>
+                                        Dependency-Graph
+                                    </span>
+                                </a>
+                                {% endif %}
                             </div>
                         </div>
                         {% endif %}

--- a/templates/locations.html
+++ b/templates/locations.html
@@ -101,16 +101,26 @@
                                 {% endif %}
                             </div>
                         </div>
-                        {% if 'stats.view' in permissions %}
+                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
                         <div>
                             <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Auswertung</p>
                             <div class="mt-2 space-y-1">
+                                {% if 'stats.view' in permissions %}
                                 <a href="/stats" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
                                     <span class="flex items-center gap-2">
                                         <i data-feather="bar-chart-2" class="h-4 w-4 text-slate-400"></i>
                                         Statistiken
                                     </span>
                                 </a>
+                                {% endif %}
+                                {% if 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
+                                <a href="/dependencies" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="share-2" class="h-4 w-4 text-slate-400"></i>
+                                        Dependency-Graph
+                                    </span>
+                                </a>
+                                {% endif %}
                             </div>
                         </div>
                         {% endif %}

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -105,16 +105,26 @@
                                 {% endif %}
                             </div>
                         </div>
-                        {% if 'stats.view' in permissions %}
+                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
                         <div>
                             <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Auswertung</p>
                             <div class="mt-2 space-y-1">
+                                {% if 'stats.view' in permissions %}
                                 <a href="/stats" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
                                     <span class="flex items-center gap-2">
                                         <i data-feather="bar-chart-2" class="h-4 w-4 text-slate-400"></i>
                                         Statistiken
                                     </span>
                                 </a>
+                                {% endif %}
+                                {% if 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
+                                <a href="/dependencies" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="share-2" class="h-4 w-4 text-slate-400"></i>
+                                        Dependency-Graph
+                                    </span>
+                                </a>
+                                {% endif %}
                             </div>
                         </div>
                         {% endif %}

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -125,6 +125,14 @@
                                         Statistiken
                                     </span>
                                 </a>
+                                {% if 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
+                                <a href="/dependencies" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="share-2" class="h-4 w-4 text-slate-400"></i>
+                                        Dependency-Graph
+                                    </span>
+                                </a>
+                                {% endif %}
                             </div>
                         </div>
                     </div>

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -105,16 +105,26 @@
                                 {% endif %}
                             </div>
                         </div>
-                        {% if 'stats.view' in permissions %}
+                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
                         <div>
                             <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Auswertung</p>
                             <div class="mt-2 space-y-1">
+                                {% if 'stats.view' in permissions %}
                                 <a href="/stats" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
                                     <span class="flex items-center gap-2">
                                         <i data-feather="bar-chart-2" class="h-4 w-4 text-slate-400"></i>
                                         Statistiken
                                     </span>
                                 </a>
+                                {% endif %}
+                                {% if 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
+                                <a href="/dependencies" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="share-2" class="h-4 w-4 text-slate-400"></i>
+                                        Dependency-Graph
+                                    </span>
+                                </a>
+                                {% endif %}
                             </div>
                         </div>
                         {% endif %}

--- a/templates/users.html
+++ b/templates/users.html
@@ -104,16 +104,26 @@
                                 {% endif %}
                             </div>
                         </div>
-                        {% if 'stats.view' in permissions %}
+                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
                         <div>
                             <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Auswertung</p>
                             <div class="mt-2 space-y-1">
+                                {% if 'stats.view' in permissions %}
                                 <a href="/stats" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
                                     <span class="flex items-center gap-2">
                                         <i data-feather="bar-chart-2" class="h-4 w-4 text-slate-400"></i>
                                         Statistiken
                                     </span>
                                 </a>
+                                {% endif %}
+                                {% if 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
+                                <a href="/dependencies" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="share-2" class="h-4 w-4 text-slate-400"></i>
+                                        Dependency-Graph
+                                    </span>
+                                </a>
+                                {% endif %}
                             </div>
                         </div>
                         {% endif %}


### PR DESCRIPTION
### Motivation
- Provide a comprehensive dependency & impact analysis system that links assets, devices, software, teams, departments, tickets and roadmaps to answer questions like “Was fällt aus, wenn X down ist?” for planning and incident response. 
- Integrate the new system into the existing inventory, ticket, roadmap, user and location models so the graph reflects current data sources.

### Description
- Added new permission keys for dependencies, software, teams and departments and wired them into `PERMISSIONS` and default role permissions (`app.py`).
- Extended schema via `init_db()` with new tables: `departments`, `teams`, `software`, `software_installations`, and `dependency_links`, and kept `CREATE TABLE IF NOT EXISTS` semantics for safe migration (`app.py`).
- Implemented server-side graph and analysis logic in `app.py`: entity metadata (`DEPENDENCY_ENTITY_TYPES`), node/edge builders (`build_dependency_nodes`, `build_dependency_edges`, `build_dependency_graph_data`), impact analysis (`analyze_dependency_impact`), ticket lookup helpers (`find_tickets_for_node`) and SPOF calculation (`calculate_spof_nodes`).
- Added CRUD API endpoints for departments, teams, software, software-installations and dependency links plus graph/analysis endpoints: `/api/departments`, `/api/teams`, `/api/software`, `/api/software-installations`, `/api/dependency-links`, `/api/dependency-nodes`, `/api/dependency-graph`, `/api/impact-analysis`, `/api/single-points` (`app.py`).
- New UI: full dashboard template `templates/dependencies.html` (Alpine.js + Cytoscape) with graph visualization, impact analysis, software inventory, installations, teams/departments and dependency modelling features, and integrated navigation links across existing templates (`index.html`, `stats.html`, `locations.html`, `users.html`, `tickets.html`, `roadmap.html`).

### Testing
- Performed a manual/integration smoke run by starting the Flask app with `python app.py`, creating a demo admin user and exercising the new UI and APIs. The server served `/dependencies` and returned `200` for these endpoints during the smoke run: `/api/dependency-nodes`, `/api/dependency-links`, `/api/dependency-graph`, `/api/departments`, `/api/teams`, `/api/software`, `/api/single-points`, `/api/software-installations` (observed in server logs).
- Executed an automated browser script (Playwright) to log in as the demo user, open `http://127.0.0.1:5000/dependencies` and capture a screenshot; the script completed and produced `artifacts/dependencies.png` showing the dashboard.
- Database migration approach validated by `init_db()` creating new tables without destructive changes (used `CREATE TABLE IF NOT EXISTS` and `ALTER TABLE` guards); no failing automated tests were present or run beyond the smoke/integration checks above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69751f72aa708331988ed2984d64a5a3)