### PR TITLE
Add Zeitmaschine (time-machine) module with timeline, branching and API

### DIFF
--- a/app.py
+++ b/app.py
@@ -243,6 +243,12 @@ PERMISSIONS = [
         "group": "Abhängigkeiten"
     },
     {
+        "key": "timemachine.view",
+        "label": "Zeitmaschine anzeigen",
+        "description": "Zeitachsen, Zustände und Simulationen einsehen.",
+        "group": "Zeitmaschine"
+    },
+    {
         "key": "software.view",
         "label": "Software-Inventar anzeigen",
         "description": "Software-Inventar und Installationen einsehen.",
@@ -320,6 +326,7 @@ DEFAULT_ROLES = [
             "roadmap.manage",
             "dependencies.view",
             "dependencies.manage",
+            "timemachine.view",
             "software.view",
             "software.manage",
             "teams.view",
@@ -520,6 +527,7 @@ def get_post_login_redirect(access):
         (("categories.view", "categories.manage"), "index"),
         (("tickets.view_all", "tickets.view_own", "tickets.create"), "tickets_page"),
         (("stats.view",), "stats"),
+        (("timemachine.view",), "time_machine_page"),
         (("users.manage",), "users_page"),
         (("locations.view", "locations.manage"), "locations_page")
     ]
@@ -1205,6 +1213,29 @@ def log_activity(db, action, entity_type, entity_id=None, details=None):
         INSERT INTO activity_log (username, action, entity_type, entity_id, details)
         VALUES (?, ?, ?, ?, ?)
     ''', (username, action, entity_type, entity_id, json.dumps(details or {})))
+
+def parse_time_machine_timestamp(value):
+    if not value:
+        return None
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(value.replace("Z", ""))
+    except ValueError:
+        return None
+
+def format_time_machine_change(entity_label, action_label, details):
+    suffix = ""
+    if details:
+        for key in ("title", "name", "id"):
+            value = details.get(key)
+            if value:
+                suffix = f" · {value}"
+                break
+    return f"{entity_label} {action_label}{suffix}"
 
 DEPENDENCY_ENTITY_TYPES = {
     "asset": {"table": "assets", "label": "Asset", "name_col": "name"},
@@ -2248,6 +2279,13 @@ def roadmap_page():
 def dependencies_page():
     access = get_user_access(get_db())
     return render_template('dependencies.html', username=session.get('username'), permissions=sorted(access["permissions"]), is_superuser=access["is_superuser"])
+
+@app.route('/time-machine')
+@login_required
+@require_permission('timemachine.view')
+def time_machine_page():
+    access = get_user_access(get_db())
+    return render_template('time_machine.html', username=session.get('username'), permissions=sorted(access["permissions"]), is_superuser=access["is_superuser"])
 
 @app.route('/api/categories/<int:category_id>', methods=['PUT', 'DELETE'])
 @login_required
@@ -3965,6 +4003,268 @@ def feature_flags():
         "pro_enabled": PRO_ENABLED,
         "pro_features": PRO_FEATURES,
         "free_features": FREE_FEATURES
+    })
+
+@app.route('/api/time-machine/changes', methods=['GET'])
+@login_required
+@require_permission('timemachine.view')
+def time_machine_changes():
+    db = get_db()
+    activity_rows = db.execute('''
+        SELECT id, action, entity_type, entity_id, details, created_at, username
+        FROM activity_log
+        ORDER BY created_at ASC
+    ''').fetchall()
+
+    action_labels = {
+        "create": "erstellt",
+        "update": "aktualisiert",
+        "delete": "gelöscht",
+        "comment": "kommentiert",
+        "watch": "beobachtet",
+        "unwatch": "Beobachtung beendet",
+        "login": "angemeldet",
+        "logout": "abgemeldet"
+    }
+    entity_labels = {
+        "asset": "Asset",
+        "device": "Gerät",
+        "ticket": "Ticket",
+        "roadmap": "Roadmap",
+        "roadmap_step": "Roadmap-Schritt",
+        "dependency_link": "Dependency",
+        "team": "Team",
+        "department": "Abteilung",
+        "software": "Software",
+        "location": "Standort",
+        "user": "Benutzer"
+    }
+    layer_map = {
+        "asset": "assets",
+        "device": "devices",
+        "ticket": "tickets",
+        "roadmap": "roadmaps",
+        "roadmap_step": "roadmaps",
+        "dependency_link": "dependencies",
+        "team": "organisation",
+        "department": "organisation",
+        "software": "assets",
+        "location": "assets",
+        "user": "organisation"
+    }
+
+    changes = []
+    for row in activity_rows:
+        try:
+            details = json.loads(row["details"]) if row["details"] else {}
+        except json.JSONDecodeError:
+            details = {}
+        action_label = action_labels.get(row["action"], row["action"])
+        entity_label = entity_labels.get(row["entity_type"], row["entity_type"])
+        timestamp = parse_time_machine_timestamp(row["created_at"])
+        if not timestamp:
+            continue
+        changes.append({
+            "key": f"activity-{row['id']}",
+            "timestamp": timestamp.isoformat(),
+            "title": format_time_machine_change(entity_label, action_label, details),
+            "description": details.get("description") or details.get("notes") or row["action"],
+            "layer": layer_map.get(row["entity_type"], "events"),
+            "layer_label": entity_label,
+            "source": "Aktivitätslog",
+            "entity_type": row["entity_type"],
+            "entity_id": row["entity_id"],
+            "impact": details.get("impact", "n/a"),
+            "is_planned": False
+        })
+
+    roadmap_rows = db.execute('''
+        SELECT id, title, status, start_date, target_date, owner, created_at
+        FROM roadmaps
+        ORDER BY created_at ASC
+    ''').fetchall()
+    roadmap_step_rows = db.execute('''
+        SELECT id, roadmap_id, title, status, due_date, created_at
+        FROM roadmap_steps
+        ORDER BY created_at ASC
+    ''').fetchall()
+
+    roadmaps = []
+    for row in roadmap_rows:
+        roadmaps.append({
+            "id": row["id"],
+            "title": row["title"],
+            "status": row["status"],
+            "start_date": row["start_date"],
+            "target_date": row["target_date"],
+            "owner": row["owner"]
+        })
+
+        start_timestamp = parse_time_machine_timestamp(row["start_date"]) or parse_time_machine_timestamp(row["created_at"])
+        if start_timestamp:
+            changes.append({
+                "key": f"roadmap-start-{row['id']}",
+                "timestamp": start_timestamp.isoformat(),
+                "title": f"Roadmap gestartet · {row['title']}",
+                "description": "Roadmap-Start geplant oder umgesetzt.",
+                "layer": "roadmaps",
+                "layer_label": "Roadmap",
+                "source": "Roadmap",
+                "entity_type": "roadmap",
+                "entity_id": row["id"],
+                "roadmap_id": row["id"],
+                "impact": row["status"] or "planned",
+                "is_planned": True
+            })
+        target_timestamp = parse_time_machine_timestamp(row["target_date"])
+        if target_timestamp:
+            changes.append({
+                "key": f"roadmap-target-{row['id']}",
+                "timestamp": target_timestamp.isoformat(),
+                "title": f"Roadmap Zieltermin · {row['title']}",
+                "description": "Geplanter Abschluss oder Meilenstein.",
+                "layer": "roadmaps",
+                "layer_label": "Roadmap",
+                "source": "Roadmap",
+                "entity_type": "roadmap",
+                "entity_id": row["id"],
+                "roadmap_id": row["id"],
+                "impact": "target",
+                "is_planned": True
+            })
+
+    for row in roadmap_step_rows:
+        step_timestamp = parse_time_machine_timestamp(row["due_date"]) or parse_time_machine_timestamp(row["created_at"])
+        if not step_timestamp:
+            continue
+        changes.append({
+            "key": f"roadmap-step-{row['id']}",
+            "timestamp": step_timestamp.isoformat(),
+            "title": f"Roadmap-Schritt · {row['title']}",
+            "description": "Geplanter Change aus Roadmap.",
+            "layer": "roadmaps",
+            "layer_label": "Roadmap",
+            "source": "Roadmap",
+            "entity_type": "roadmap_step",
+            "entity_id": row["id"],
+            "roadmap_id": row["roadmap_id"],
+            "impact": row["status"] or "planned",
+            "is_planned": True
+        })
+
+    ticket_rows = db.execute('''
+        SELECT id, title, status, created_at, resolved_at
+        FROM tickets
+        ORDER BY created_at DESC
+    ''').fetchall()
+    tickets = [dict(row) for row in ticket_rows]
+
+    timestamps = [parse_time_machine_timestamp(change["timestamp"]) for change in changes]
+    timestamps = [ts for ts in timestamps if ts]
+    now = datetime.utcnow()
+    range_start = min(timestamps) if timestamps else now
+    range_end = max(timestamps) if timestamps else now
+
+    return jsonify({
+        "changes": changes,
+        "roadmaps": roadmaps,
+        "tickets": tickets,
+        "range": {
+            "start": range_start.isoformat(),
+            "end": range_end.isoformat()
+        }
+    })
+
+@app.route('/api/time-machine/state', methods=['GET'])
+@login_required
+@require_permission('timemachine.view')
+def time_machine_state():
+    db = get_db()
+    timestamp_raw = request.args.get('timestamp')
+    timestamp = parse_time_machine_timestamp(timestamp_raw) or datetime.utcnow()
+    timestamp_str = timestamp.strftime("%Y-%m-%d %H:%M:%S")
+
+    assets = db.execute('''
+        SELECT COUNT(*) as total
+        FROM assets
+        WHERE created_at <= ?
+          AND (retirement_date IS NULL OR retirement_date = '' OR retirement_date > ?)
+    ''', (timestamp_str, timestamp_str)).fetchone()["total"]
+    devices = db.execute('''
+        SELECT COUNT(*) as total
+        FROM devices
+        WHERE created_at <= ?
+    ''', (timestamp_str,)).fetchone()["total"]
+    tickets_total = db.execute('''
+        SELECT COUNT(*) as total
+        FROM tickets
+        WHERE created_at <= ?
+    ''', (timestamp_str,)).fetchone()["total"]
+    tickets_open = db.execute('''
+        SELECT COUNT(*) as total
+        FROM tickets
+        WHERE created_at <= ?
+          AND (resolved_at IS NULL OR resolved_at = '' OR resolved_at > ?)
+    ''', (timestamp_str, timestamp_str)).fetchone()["total"]
+    roadmaps_total = db.execute('''
+        SELECT COUNT(*) as total
+        FROM roadmaps
+        WHERE created_at <= ?
+    ''', (timestamp_str,)).fetchone()["total"]
+    dependencies_total = db.execute('''
+        SELECT COUNT(*) as total
+        FROM dependency_links
+        WHERE created_at <= ?
+    ''', (timestamp_str,)).fetchone()["total"]
+    last_change_row = db.execute('''
+        SELECT action, entity_type, details, created_at
+        FROM activity_log
+        WHERE created_at <= ?
+        ORDER BY created_at DESC
+        LIMIT 1
+    ''', (timestamp_str,)).fetchone()
+    last_change_label = "—"
+    if last_change_row:
+        entity_labels = {
+            "asset": "Asset",
+            "device": "Gerät",
+            "ticket": "Ticket",
+            "roadmap": "Roadmap",
+            "roadmap_step": "Roadmap-Schritt",
+            "dependency_link": "Dependency",
+            "team": "Team",
+            "department": "Abteilung",
+            "software": "Software",
+            "location": "Standort",
+            "user": "Benutzer"
+        }
+        action_labels = {
+            "create": "erstellt",
+            "update": "aktualisiert",
+            "delete": "gelöscht",
+            "comment": "kommentiert",
+            "watch": "beobachtet",
+            "unwatch": "Beobachtung beendet",
+            "login": "angemeldet",
+            "logout": "abgemeldet"
+        }
+        try:
+            details = json.loads(last_change_row["details"]) if last_change_row["details"] else {}
+        except json.JSONDecodeError:
+            details = {}
+        entity_label = entity_labels.get(last_change_row["entity_type"], last_change_row["entity_type"])
+        action_label = action_labels.get(last_change_row["action"], last_change_row["action"])
+        last_change_label = format_time_machine_change(entity_label, action_label, details)
+
+    return jsonify({
+        "timestamp": timestamp.isoformat(),
+        "assets": assets,
+        "devices": devices,
+        "tickets": tickets_total,
+        "tickets_open": tickets_open,
+        "roadmaps": roadmaps_total,
+        "dependencies": dependencies_total,
+        "last_change": last_change_label
     })
 
 @app.route('/api/activity', methods=['GET'])

--- a/templates/dependencies.html
+++ b/templates/dependencies.html
@@ -119,6 +119,14 @@
                                     </span>
                                 </a>
                                 {% endif %}
+                                {% if 'timemachine.view' in permissions %}
+                                <a href="/time-machine" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="clock" class="h-4 w-4 text-slate-400"></i>
+                                        Zeitmaschine
+                                    </span>
+                                </a>
+                                {% endif %}
                             </div>
                         </div>
                     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -261,7 +261,7 @@
                                 {% endif %}
                             </div>
                         </div>
-                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
+                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions or 'timemachine.view' in permissions %}
                         <div>
                             <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Auswertung</p>
                             <div class="mt-2 space-y-1">
@@ -278,6 +278,14 @@
                                     <span class="flex items-center gap-2">
                                         <i data-feather="share-2" class="h-4 w-4 text-slate-400"></i>
                                         Dependency-Graph
+                                    </span>
+                                </a>
+                                {% endif %}
+                                {% if 'timemachine.view' in permissions %}
+                                <a href="/time-machine" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="clock" class="h-4 w-4 text-slate-400"></i>
+                                        Zeitmaschine
                                     </span>
                                 </a>
                                 {% endif %}

--- a/templates/locations.html
+++ b/templates/locations.html
@@ -101,7 +101,7 @@
                                 {% endif %}
                             </div>
                         </div>
-                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
+                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions or 'timemachine.view' in permissions %}
                         <div>
                             <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Auswertung</p>
                             <div class="mt-2 space-y-1">
@@ -118,6 +118,14 @@
                                     <span class="flex items-center gap-2">
                                         <i data-feather="share-2" class="h-4 w-4 text-slate-400"></i>
                                         Dependency-Graph
+                                    </span>
+                                </a>
+                                {% endif %}
+                                {% if 'timemachine.view' in permissions %}
+                                <a href="/time-machine" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="clock" class="h-4 w-4 text-slate-400"></i>
+                                        Zeitmaschine
                                     </span>
                                 </a>
                                 {% endif %}

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -105,7 +105,7 @@
                                 {% endif %}
                             </div>
                         </div>
-                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
+                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions or 'timemachine.view' in permissions %}
                         <div>
                             <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Auswertung</p>
                             <div class="mt-2 space-y-1">
@@ -122,6 +122,14 @@
                                     <span class="flex items-center gap-2">
                                         <i data-feather="share-2" class="h-4 w-4 text-slate-400"></i>
                                         Dependency-Graph
+                                    </span>
+                                </a>
+                                {% endif %}
+                                {% if 'timemachine.view' in permissions %}
+                                <a href="/time-machine" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="clock" class="h-4 w-4 text-slate-400"></i>
+                                        Zeitmaschine
                                     </span>
                                 </a>
                                 {% endif %}

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -133,6 +133,14 @@
                                     </span>
                                 </a>
                                 {% endif %}
+                                {% if 'timemachine.view' in permissions %}
+                                <a href="/time-machine" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="clock" class="h-4 w-4 text-slate-400"></i>
+                                        Zeitmaschine
+                                    </span>
+                                </a>
+                                {% endif %}
                             </div>
                         </div>
                     </div>

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -105,7 +105,7 @@
                                 {% endif %}
                             </div>
                         </div>
-                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
+                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions or 'timemachine.view' in permissions %}
                         <div>
                             <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Auswertung</p>
                             <div class="mt-2 space-y-1">
@@ -122,6 +122,14 @@
                                     <span class="flex items-center gap-2">
                                         <i data-feather="share-2" class="h-4 w-4 text-slate-400"></i>
                                         Dependency-Graph
+                                    </span>
+                                </a>
+                                {% endif %}
+                                {% if 'timemachine.view' in permissions %}
+                                <a href="/time-machine" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="clock" class="h-4 w-4 text-slate-400"></i>
+                                        Zeitmaschine
                                     </span>
                                 </a>
                                 {% endif %}

--- a/templates/time_machine.html
+++ b/templates/time_machine.html
@@ -1,0 +1,556 @@
+<!DOCTYPE html>
+<html lang="de" x-data="timeMachineApp()" x-init="init()">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Inventory Pro - Zeitmaschine</title>
+    <script src="/static/theme.js"></script>
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body class="app-body bg-slate-950/5 text-slate-900">
+    <div class="app-shell">
+        <aside class="app-sidebar sidebar bg-white/90 backdrop-blur-xl border-r border-slate-200 shadow-sm">
+            <div class="sidebar-header p-6 border-b border-slate-200">
+                <a href="/" class="flex items-center gap-3">
+                    <span class="inline-flex items-center justify-center w-10 h-10 rounded-2xl bg-gradient-to-br from-blue-500 via-indigo-500 to-purple-500 text-white shadow-lg">
+                        <i data-feather="cpu" class="w-5 h-5"></i>
+                    </span>
+                    <div>
+                        <p class="text-lg font-semibold text-slate-900 sidebar-text">Inventory Pro</p>
+                        <p class="text-xs text-slate-500 sidebar-text">Smart Asset Hub</p>
+                    </div>
+                </a>
+            </div>
+            <nav x-data="{ appsOpen: true }" class="p-4 space-y-4 sidebar-scroll sidebar-primary-links">
+                <div class="rounded-2xl border border-slate-200 bg-white/80 shadow-sm">
+                    <button @click="appsOpen = !appsOpen" class="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-slate-50 transition-colors">
+                        <span class="flex items-center gap-3">
+                            <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-slate-100 text-slate-600">
+                                <i data-feather="grid" class="h-4 w-4"></i>
+                            </span>
+                            <span>
+                                <span class="block text-sm font-semibold text-slate-800 sidebar-text">Apps</span>
+                                <span class="block text-xs text-slate-400 sidebar-text">Verwaltung & Services</span>
+                            </span>
+                        </span>
+                        <svg :class="{ 'rotate-180': appsOpen }" class="h-4 w-4 text-slate-500 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                        </svg>
+                    </button>
+                    <div x-show="appsOpen" x-transition class="bg-slate-50/80 px-3 py-3 space-y-4">
+                        <div>
+                            <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Verwaltung</p>
+                            <div class="mt-2 space-y-1">
+                                {% if 'categories.view' in permissions or 'categories.manage' in permissions %}
+                                <a href="/" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="layers" class="h-4 w-4 text-slate-400"></i>
+                                        Kategorien
+                                    </span>
+                                </a>
+                                <a href="/" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="package" class="h-4 w-4 text-slate-400"></i>
+                                        Assets
+                                    </span>
+                                </a>
+                                {% endif %}
+                                {% if 'users.manage' in permissions %}
+                                <a href="/users" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="users" class="h-4 w-4 text-slate-400"></i>
+                                        Benutzer
+                                    </span>
+                                </a>
+                                {% endif %}
+                                {% if 'locations.view' in permissions or 'locations.manage' in permissions %}
+                                <a href="/locations" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="map-pin" class="h-4 w-4 text-slate-400"></i>
+                                        Standorte
+                                    </span>
+                                </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                        <div>
+                            <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Services</p>
+                            <div class="mt-2 space-y-1">
+                                {% if 'tickets.view_all' in permissions or 'tickets.view_own' in permissions or 'tickets.create' in permissions %}
+                                <a href="/tickets" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="life-buoy" class="h-4 w-4 text-slate-400"></i>
+                                        Ticketsystem
+                                    </span>
+                                </a>
+                                {% endif %}
+                                {% if 'roadmap.view' in permissions or 'roadmap.manage' in permissions %}
+                                <a href="/roadmap" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="git-merge" class="h-4 w-4 text-slate-400"></i>
+                                        Roadmap
+                                    </span>
+                                </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions or 'timemachine.view' in permissions %}
+                        <div>
+                            <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Auswertung</p>
+                            <div class="mt-2 space-y-1">
+                                {% if 'stats.view' in permissions %}
+                                <a href="/stats" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="bar-chart-2" class="h-4 w-4 text-slate-400"></i>
+                                        Statistiken
+                                    </span>
+                                </a>
+                                {% endif %}
+                                {% if 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
+                                <a href="/dependencies" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="share-2" class="h-4 w-4 text-slate-400"></i>
+                                        Dependency-Graph
+                                    </span>
+                                </a>
+                                {% endif %}
+                                {% if 'timemachine.view' in permissions %}
+                                <a href="/time-machine" class="flex items-center justify-between rounded-xl bg-white px-3 py-2 text-sm font-semibold text-cyan-700 shadow-sm">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="clock" class="h-4 w-4 text-cyan-500"></i>
+                                        Zeitmaschine
+                                    </span>
+                                </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                        {% endif %}
+                    </div>
+                </div>
+            </nav>
+        </aside>
+
+        <div class="app-main app-main--fixed">
+            <header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 z-30 h-[82px]">
+                <div class="flex items-center gap-4">
+                    <button type="button" data-sidebar-toggle aria-label="Navigation umschalten" class="inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white p-2 text-slate-600 shadow-sm hover:bg-slate-50">
+                        <i data-feather="menu" class="w-4 h-4"></i>
+                    </button>
+                    <div>
+                        <p class="text-xs uppercase tracking-widest text-slate-400">Change Simulation</p>
+                        <h1 class="text-xl font-semibold text-slate-900">Zeitmaschine</h1>
+                    </div>
+                </div>
+                <div class="flex items-center gap-4">
+                    <div class="hidden sm:block text-right">
+                        <p class="text-xs text-slate-400">Angemeldet als</p>
+                        <p class="text-sm font-semibold text-slate-800">{{ username }}</p>
+                    </div>
+                    <form action="/logout" method="post">
+                        <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold text-white shadow-lg hover:bg-slate-800">
+                            <i data-feather="log-out" class="h-4 w-4"></i>
+                            Logout
+                        </button>
+                    </form>
+                </div>
+            </header>
+
+            <main class="app-content app-content--padded pt-[110px] pb-16 space-y-10">
+                <section class="rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-cyan-900 px-8 py-8 text-white shadow-2xl shadow-slate-300/40">
+                    <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                        <div class="max-w-2xl">
+                            <p class="text-xs uppercase tracking-[0.3em] text-cyan-200">Zeit als erste Klasse</p>
+                            <h2 class="mt-2 text-3xl font-semibold">Versionskontrolle für deine komplette Realität.</h2>
+                            <p class="mt-3 text-sm text-cyan-100/80">Rendere den Systemzustand zu jedem Zeitpunkt, simuliere Roadmaps und vergleiche alternative Zukünfte wie einen Git-Diff.</p>
+                        </div>
+                        <div class="grid gap-3 sm:grid-cols-2">
+                            <div class="rounded-2xl bg-white/10 px-4 py-3">
+                                <p class="text-xs uppercase text-cyan-100">Changes</p>
+                                <p class="text-2xl font-semibold" x-text="changes.length"></p>
+                            </div>
+                            <div class="rounded-2xl bg-white/10 px-4 py-3">
+                                <p class="text-xs uppercase text-cyan-100">Branches</p>
+                                <p class="text-2xl font-semibold" x-text="branchOptions.length"></p>
+                            </div>
+                            <div class="rounded-2xl bg-white/10 px-4 py-3">
+                                <p class="text-xs uppercase text-cyan-100">Roadmaps</p>
+                                <p class="text-2xl font-semibold" x-text="roadmaps.length"></p>
+                            </div>
+                            <div class="rounded-2xl bg-white/10 px-4 py-3">
+                                <p class="text-xs uppercase text-cyan-100">Timeline-Range</p>
+                                <p class="text-2xl font-semibold" x-text="rangeLabel"></p>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-6">
+                        <div class="flex flex-wrap items-center justify-between gap-4">
+                            <div>
+                                <h3 class="text-lg font-semibold text-slate-900">Zustand zu Zeitpunkt T</h3>
+                                <p class="text-sm text-slate-500">Ändere die Zeit und erhalte den vollständigen Systemzustand.</p>
+                            </div>
+                            <div class="flex flex-wrap items-center gap-3">
+                                <input type="date" x-model="timelineDate" @change="loadState()" class="rounded-full border border-slate-200 px-3 py-2 text-sm">
+                                <button @click="setDateOffset(-6)" class="rounded-full border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-600 hover:bg-slate-100">-6 Monate</button>
+                                <button @click="setDateOffset(0)" class="rounded-full border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-600 hover:bg-slate-100">Heute</button>
+                                <button @click="setDateOffset(3)" class="rounded-full border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-600 hover:bg-slate-100">+3 Monate</button>
+                            </div>
+                        </div>
+
+                        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                            <div class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+                                <p class="text-xs uppercase tracking-widest text-slate-400">Assets</p>
+                                <p class="mt-2 text-2xl font-semibold text-slate-900" x-text="state.assets"></p>
+                                <p class="text-xs text-slate-500">Aktive Assets</p>
+                            </div>
+                            <div class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+                                <p class="text-xs uppercase tracking-widest text-slate-400">Geräte</p>
+                                <p class="mt-2 text-2xl font-semibold text-slate-900" x-text="state.devices"></p>
+                                <p class="text-xs text-slate-500">Inventarisierte Geräte</p>
+                            </div>
+                            <div class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+                                <p class="text-xs uppercase tracking-widest text-slate-400">Tickets</p>
+                                <p class="mt-2 text-2xl font-semibold text-slate-900" x-text="state.tickets"></p>
+                                <p class="text-xs text-slate-500">Davon offen: <span class="font-semibold" x-text="state.tickets_open"></span></p>
+                            </div>
+                            <div class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+                                <p class="text-xs uppercase tracking-widest text-slate-400">Roadmaps</p>
+                                <p class="mt-2 text-2xl font-semibold text-slate-900" x-text="state.roadmaps"></p>
+                                <p class="text-xs text-slate-500">Strategische Changes</p>
+                            </div>
+                            <div class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+                                <p class="text-xs uppercase tracking-widest text-slate-400">Dependencies</p>
+                                <p class="mt-2 text-2xl font-semibold text-slate-900" x-text="state.dependencies"></p>
+                                <p class="text-xs text-slate-500">Graph-Verbindungen</p>
+                            </div>
+                            <div class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+                                <p class="text-xs uppercase tracking-widest text-slate-400">Letztes Change</p>
+                                <p class="mt-2 text-sm font-semibold text-slate-900" x-text="state.last_change"></p>
+                                <p class="text-xs text-slate-500">Geschichte bis zu T</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-6">
+                        <div>
+                            <h3 class="text-lg font-semibold text-slate-900">Branches & Simulation</h3>
+                            <p class="text-sm text-slate-500">Alternative Zukünfte auf Basis echter Changes durchspielen.</p>
+                        </div>
+                        <div class="space-y-4">
+                            <label class="block text-xs font-semibold text-slate-500">Branch auswählen</label>
+                            <select x-model="branch" @change="applyBranch()" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                <template x-for="option in branchOptions" :key="option.value">
+                                    <option :value="option.value" x-text="option.label"></option>
+                                </template>
+                            </select>
+
+                            <div class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 space-y-3">
+                                <p class="text-xs uppercase tracking-widest text-slate-400">What-if Regeln</p>
+                                <div class="space-y-2">
+                                    <label class="block text-xs font-semibold text-slate-500">Ticket ignorieren</label>
+                                    <select x-model="branchTicketId" @change="applyBranch()" class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                                        <option value="">Kein Ticket</option>
+                                        <template x-for="ticket in tickets" :key="ticket.id">
+                                            <option :value="String(ticket.id)" x-text="`#${ticket.id} ${ticket.title}`"></option>
+                                        </template>
+                                    </select>
+                                </div>
+                                <div class="space-y-2">
+                                    <label class="block text-xs font-semibold text-slate-500">Roadmap-Simulation</label>
+                                    <div class="space-y-2 max-h-40 overflow-auto">
+                                        <template x-for="roadmap in roadmaps" :key="roadmap.id">
+                                            <label class="flex items-center gap-2 text-xs text-slate-600">
+                                                <input type="checkbox" class="rounded border-slate-300 text-cyan-600" :value="String(roadmap.id)" x-model="selectedRoadmaps" @change="applyBranch()">
+                                                <span x-text="roadmap.title"></span>
+                                            </label>
+                                        </template>
+                                        <p x-show="roadmaps.length === 0" class="text-xs text-slate-400">Noch keine Roadmaps.</p>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="rounded-2xl border border-cyan-100 bg-cyan-50 px-4 py-4">
+                                <p class="text-xs font-semibold text-cyan-700">Branch-Effekt</p>
+                                <p class="text-xs text-cyan-700/80 mt-2" x-text="branchSummary"></p>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-6">
+                    <div class="flex flex-wrap items-center justify-between gap-4">
+                        <div>
+                            <h3 class="text-lg font-semibold text-slate-900">Timeline-View</h3>
+                            <p class="text-sm text-slate-500">Horizontale Zeitachse mit Ebenen für Assets, Geräte, Tickets und Roadmaps.</p>
+                        </div>
+                        <div class="flex flex-wrap items-center gap-3">
+                            <select x-model="selectedLayer" class="rounded-full border border-slate-200 bg-white px-3 py-2 text-xs">
+                                <option value="all">Alle Ebenen</option>
+                                <template x-for="layer in layers" :key="layer.key">
+                                    <option :value="layer.key" x-text="layer.label"></option>
+                                </template>
+                            </select>
+                            <button @click="toggleCompare()" class="rounded-full border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-600 hover:bg-slate-100" x-text="compareEnabled ? 'Vergleich schließen' : 'Vergleich aktivieren'"></button>
+                        </div>
+                    </div>
+
+                    <div class="space-y-6">
+                        <template x-for="layer in filteredLayers()" :key="layer.key">
+                            <div class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+                                <div class="flex items-center justify-between gap-3">
+                                    <p class="text-xs font-semibold uppercase tracking-widest text-slate-500" x-text="layer.label"></p>
+                                    <span class="text-xs text-slate-400" x-text="`${layerChanges(layer.key).length} Changes`"></span>
+                                </div>
+                                <div class="mt-4 flex gap-3 overflow-x-auto pb-2">
+                                    <template x-for="change in layerChanges(layer.key)" :key="change.key">
+                                        <button @click="selectChange(change)" class="min-w-[220px] rounded-2xl border border-slate-200 bg-white px-4 py-3 text-left shadow-sm hover:border-cyan-300">
+                                            <div class="flex items-center justify-between gap-2">
+                                                <span class="text-xs font-semibold text-slate-700" x-text="change.title"></span>
+                                                <span class="text-[10px] uppercase tracking-widest" :class="change.is_planned ? 'text-cyan-600' : 'text-slate-400'" x-text="change.is_planned ? 'geplant' : 'live'"></span>
+                                            </div>
+                                            <p class="mt-1 text-xs text-slate-500" x-text="change.description"></p>
+                                            <p class="mt-2 text-xs font-semibold text-slate-700" x-text="formatDate(change.timestamp)"></p>
+                                        </button>
+                                    </template>
+                                    <p x-show="layerChanges(layer.key).length === 0" class="text-xs text-slate-400">Keine Changes für diese Ebene.</p>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+                </section>
+
+                <section class="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4">
+                        <div class="flex items-center justify-between">
+                            <h3 class="text-lg font-semibold text-slate-900">Change-Details</h3>
+                            <span class="text-xs text-slate-400">Klick auf ein Event in der Timeline</span>
+                        </div>
+                        <div class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 space-y-2" x-show="selectedChange">
+                            <p class="text-xs uppercase tracking-widest text-slate-400" x-text="selectedChange?.layer_label"></p>
+                            <h4 class="text-lg font-semibold text-slate-900" x-text="selectedChange?.title"></h4>
+                            <p class="text-sm text-slate-600" x-text="selectedChange?.description"></p>
+                            <div class="flex flex-wrap gap-2 text-xs text-slate-500">
+                                <span class="rounded-full bg-white px-2 py-1" x-text="`Zeitpunkt: ${formatDate(selectedChange?.timestamp)}`"></span>
+                                <span class="rounded-full bg-white px-2 py-1" x-text="`Quelle: ${selectedChange?.source}`"></span>
+                                <span class="rounded-full bg-white px-2 py-1" x-text="`Impact: ${selectedChange?.impact}`"></span>
+                            </div>
+                        </div>
+                        <p x-show="!selectedChange" class="text-sm text-slate-400">Noch kein Change ausgewählt.</p>
+                        <div class="rounded-2xl border border-cyan-100 bg-cyan-50 px-4 py-4">
+                            <h4 class="text-sm font-semibold text-cyan-800">Rückwärts verstehen</h4>
+                            <p class="mt-2 text-xs text-cyan-700/80">Springe von jedem Change zur Ursache (Ticket, Roadmap, Entscheidung) und sieh die Historie eines Assets in Sekunden.</p>
+                        </div>
+                    </div>
+
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4">
+                        <div class="flex items-center justify-between">
+                            <h3 class="text-lg font-semibold text-slate-900">Vergleichsmodus</h3>
+                            <span class="text-xs text-slate-400">Realität vs. Simulation</span>
+                        </div>
+                        <div class="space-y-3">
+                            <label class="block text-xs font-semibold text-slate-500">Vergleichsdatum</label>
+                            <input type="date" x-model="compareDate" @change="loadComparisonState()" :disabled="!compareEnabled" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                        </div>
+                        <div class="grid gap-3 sm:grid-cols-2">
+                            <template x-for="metric in comparisonMetrics" :key="metric.key">
+                                <div class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+                                    <p class="text-xs uppercase tracking-widest text-slate-400" x-text="metric.label"></p>
+                                    <p class="mt-2 text-lg font-semibold text-slate-900" x-text="metric.value"></p>
+                                    <p class="text-xs" :class="metric.deltaClass" x-text="metric.delta"></p>
+                                </div>
+                            </template>
+                        </div>
+                        <div class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-xs text-slate-500">
+                            <p>Nutze den Vergleich, um neue Risiken, zusätzliche Abhängigkeiten oder den Impact der Roadmaps sichtbar zu machen.</p>
+                        </div>
+                    </div>
+                </section>
+            </main>
+        </div>
+    </div>
+
+    <script>
+        function timeMachineApp() {
+            return {
+                changes: [],
+                roadmaps: [],
+                tickets: [],
+                range: { start: null, end: null },
+                state: {
+                    assets: 0,
+                    devices: 0,
+                    tickets: 0,
+                    tickets_open: 0,
+                    roadmaps: 0,
+                    dependencies: 0,
+                    last_change: '—'
+                },
+                comparisonState: null,
+                selectedChange: null,
+                timelineDate: '',
+                compareDate: '',
+                compareEnabled: false,
+                branch: 'main',
+                branchTicketId: '',
+                selectedRoadmaps: [],
+                selectedLayer: 'all',
+                layers: [
+                    { key: 'devices', label: 'Geräte', color: 'slate' },
+                    { key: 'assets', label: 'Assets', color: 'indigo' },
+                    { key: 'tickets', label: 'Tickets', color: 'amber' },
+                    { key: 'roadmaps', label: 'Roadmaps', color: 'cyan' },
+                    { key: 'dependencies', label: 'Dependencies', color: 'purple' },
+                    { key: 'organisation', label: 'Organisation', color: 'emerald' }
+                ],
+                branchOptions: [
+                    { value: 'main', label: 'Realität (Main)' },
+                    { value: 'no-ticket', label: 'Branch: Ticket ignorieren' },
+                    { value: 'roadmap-sim', label: 'Branch: Roadmap-Simulation' }
+                ],
+                async init() {
+                    await this.loadChanges();
+                    this.setToday();
+                    await this.loadState();
+                    this.applyBranch();
+                },
+                setToday() {
+                    const today = new Date();
+                    this.timelineDate = today.toISOString().slice(0, 10);
+                    this.compareDate = new Date(today.setMonth(today.getMonth() + 3)).toISOString().slice(0, 10);
+                },
+                async loadChanges() {
+                    const response = await fetch('/api/time-machine/changes');
+                    if (!response.ok) return;
+                    const data = await response.json();
+                    this.changes = data.changes || [];
+                    this.roadmaps = data.roadmaps || [];
+                    this.tickets = data.tickets || [];
+                    this.range = data.range || { start: null, end: null };
+                },
+                async loadState() {
+                    if (!this.timelineDate) return;
+                    const response = await fetch(`/api/time-machine/state?timestamp=${this.timelineDate}`);
+                    if (!response.ok) return;
+                    const data = await response.json();
+                    this.state = data;
+                    this.state.last_change = data.last_change || '—';
+                    this.loadComparisonState();
+                },
+                async loadComparisonState() {
+                    if (!this.compareEnabled || !this.compareDate) {
+                        this.comparisonState = null;
+                        return;
+                    }
+                    const response = await fetch(`/api/time-machine/state?timestamp=${this.compareDate}`);
+                    if (!response.ok) return;
+                    this.comparisonState = await response.json();
+                },
+                setDateOffset(months) {
+                    const base = new Date();
+                    base.setMonth(base.getMonth() + months);
+                    this.timelineDate = base.toISOString().slice(0, 10);
+                    this.loadState();
+                },
+                applyBranch() {
+                    if (this.branch !== 'roadmap-sim') {
+                        this.selectedRoadmaps = [];
+                    }
+                },
+                toggleCompare() {
+                    this.compareEnabled = !this.compareEnabled;
+                    if (this.compareEnabled) {
+                        this.loadComparisonState();
+                    } else {
+                        this.comparisonState = null;
+                    }
+                },
+                filteredLayers() {
+                    if (this.selectedLayer === 'all') {
+                        return this.layers;
+                    }
+                    return this.layers.filter(layer => layer.key === this.selectedLayer);
+                },
+                layerChanges(layerKey) {
+                    return this.filteredChanges().filter(change => change.layer === layerKey);
+                },
+                filteredChanges() {
+                    let result = [...this.changes];
+                    if (this.branch === 'no-ticket' && this.branchTicketId) {
+                        result = result.filter(change => !(change.entity_type === 'ticket' && String(change.entity_id) === String(this.branchTicketId)));
+                    }
+                    if (this.branch === 'roadmap-sim') {
+                        if (this.selectedRoadmaps.length > 0) {
+                            result = result.filter(change => !change.is_planned || this.selectedRoadmaps.includes(String(change.roadmap_id || '')));
+                        }
+                    }
+                    return result.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+                },
+                selectChange(change) {
+                    this.selectedChange = change;
+                },
+                formatDate(value) {
+                    if (!value) return '—';
+                    const date = new Date(value);
+                    return date.toLocaleString('de-DE');
+                },
+                get rangeLabel() {
+                    if (!this.range.start || !this.range.end) return '—';
+                    const start = new Date(this.range.start).getFullYear();
+                    const end = new Date(this.range.end).getFullYear();
+                    return `${start}–${end}`;
+                },
+                get branchSummary() {
+                    if (this.branch === 'no-ticket' && this.branchTicketId) {
+                        return `Ticket #${this.branchTicketId} wird aus der Historie entfernt. Alle Folgewirkungen sind nicht mehr sichtbar.`;
+                    }
+                    if (this.branch === 'roadmap-sim') {
+                        if (this.selectedRoadmaps.length === 0) {
+                            return 'Wähle Roadmaps aus, um nur diese Zukunft zu simulieren.';
+                        }
+                        return `${this.selectedRoadmaps.length} Roadmap(s) werden als Zukunfts-Changes simuliert.`;
+                    }
+                    return 'Main-Branch zeigt die aktuelle Realität inklusive aller Changes.';
+                },
+                get comparisonMetrics() {
+                    const metrics = [
+                        { key: 'assets', label: 'Assets' },
+                        { key: 'devices', label: 'Geräte' },
+                        { key: 'tickets', label: 'Tickets' },
+                        { key: 'roadmaps', label: 'Roadmaps' },
+                        { key: 'dependencies', label: 'Dependencies' },
+                        { key: 'tickets_open', label: 'Tickets offen' }
+                    ];
+                    return metrics.map(metric => {
+                        const baseValue = this.state?.[metric.key] ?? 0;
+                        const compareValue = this.compareEnabled && this.comparisonState ? (this.comparisonState?.[metric.key] ?? 0) : baseValue;
+                        const deltaValue = compareValue - baseValue;
+                        const deltaLabel = this.compareEnabled ? `${deltaValue >= 0 ? '+' : ''}${deltaValue}` : '—';
+                        return {
+                            key: metric.key,
+                            label: metric.label,
+                            value: compareValue,
+                            delta: `Δ ${deltaLabel}`,
+                            deltaClass: this.compareEnabled ? (deltaValue >= 0 ? 'text-emerald-600' : 'text-rose-600') : 'text-slate-400'
+                        };
+                    });
+                }
+            };
+        }
+    </script>
+    <script src="https://unpkg.com/feather-icons"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            feather.replace();
+        });
+    </script>
+    <script src="/static/ui.js"></script>
+    <script src="/static/theme.js"></script>
+</body>
+</html>

--- a/templates/users.html
+++ b/templates/users.html
@@ -104,7 +104,7 @@
                                 {% endif %}
                             </div>
                         </div>
-                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions %}
+                        {% if 'stats.view' in permissions or 'dependencies.view' in permissions or 'dependencies.manage' in permissions or 'timemachine.view' in permissions %}
                         <div>
                             <p class="px-2 text-xs uppercase tracking-widest text-slate-400">Auswertung</p>
                             <div class="mt-2 space-y-1">
@@ -121,6 +121,14 @@
                                     <span class="flex items-center gap-2">
                                         <i data-feather="share-2" class="h-4 w-4 text-slate-400"></i>
                                         Dependency-Graph
+                                    </span>
+                                </a>
+                                {% endif %}
+                                {% if 'timemachine.view' in permissions %}
+                                <a href="/time-machine" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="clock" class="h-4 w-4 text-slate-400"></i>
+                                        Zeitmaschine
                                     </span>
                                 </a>
                                 {% endif %}


### PR DESCRIPTION
### Motivation
- Introduce time as a first-class concept so the system can render historical and simulated future states instead of only the current snapshot. 
- Provide a timeline UI, change objects and branching to enable what-if simulations (ignore ticket, simulate roadmaps, compare states). 
- Surface existing data (activity log, roadmaps, tickets, dependency graph) into a visual, queryable time-travel workflow.

### Description
- Add a new permission `timemachine.view` and include it in the default `Mitarbeiter` role so authorized users can access the module via navigation. 
- Add a route `@app.route('/time-machine')` and render a new template `templates/time_machine.html` that implements the Timeline / Branch / Comparison UI using Alpine.js. 
- Implement two API endpoints `GET /api/time-machine/changes` and `GET /api/time-machine/state` that aggregate `activity_log`, `roadmaps`, `roadmap_steps` and `tickets` and return change events and a snapshot state at a given timestamp. 
- Add helper functions `parse_time_machine_timestamp` and `format_time_machine_change` to normalize timestamps and humanize change titles. 
- Wire the Zeitmaschine link into the app navigation in several templates (`index`, `tickets`, `roadmap`, `dependencies`, `stats`, `locations`, `users`) and add a landing target so users with the permission are routed to the module after login. 
- Keep all changes server-side and UI-only in the new template; changes use existing DB tables (`activity_log`, `roadmaps`, `roadmap_steps`, `tickets`, `dependency_links`) to produce the timeline and snapshots.

### Testing
- Launched the Flask app (`python app.py`) and confirmed the server started successfully; route and APIs reachable. (succeeded)
- Ran an automated Playwright script to log in with the test user, navigate to `/time-machine` and capture a screenshot (`artifacts/time-machine.png`), which completed and returned the page assets. (succeeded)
- Exercised the new API endpoints during the UI run and observed `GET /api/time-machine/changes` and `GET /api/time-machine/state` returned HTTP 200 in server logs. (succeeded)
- Adjusted a test user role to permit access and re-ran the UI test; the flow completed and the module loaded. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697531fc15cc832ea24cde99141bf92e)