### PR TITLE
Add server settings admin module

### DIFF
--- a/app.py
+++ b/app.py
@@ -219,6 +219,12 @@ PERMISSIONS = [
         "group": "Administration"
     },
     {
+        "key": "server_settings.manage",
+        "label": "Servereinstellungen verwalten",
+        "description": "Serverkonfigurationen wie Port und Debug-Modus anpassen.",
+        "group": "Administration"
+    },
+    {
         "key": "stats.view",
         "label": "Statistiken anzeigen",
         "description": "Dashboards und Statistiken einsehen.",
@@ -1476,6 +1482,18 @@ def init_db():
         c.execute('INSERT OR IGNORE INTO ad_settings (id) VALUES (1)')
 
         c.execute('''
+            CREATE TABLE IF NOT EXISTS server_settings (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                host TEXT DEFAULT '0.0.0.0',
+                port INTEGER DEFAULT 5000,
+                debug_mode INTEGER DEFAULT 1,
+                pro_enabled INTEGER DEFAULT 1,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+        c.execute('INSERT OR IGNORE INTO server_settings (id) VALUES (1)')
+
+        c.execute('''
             CREATE TABLE IF NOT EXISTS device_tags (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 device_id INTEGER NOT NULL,
@@ -2505,6 +2523,29 @@ def serialize_ad_settings(settings):
         "has_bind_password": bool(settings["bind_password"])
     }
 
+def get_server_settings(db):
+    settings = db.execute('SELECT * FROM server_settings WHERE id = 1').fetchone()
+    if not settings:
+        db.execute('INSERT INTO server_settings (id) VALUES (1)')
+        db.commit()
+        settings = db.execute('SELECT * FROM server_settings WHERE id = 1').fetchone()
+    return settings
+
+def serialize_server_settings(settings):
+    if not settings:
+        return {
+            "host": "0.0.0.0",
+            "port": 5000,
+            "debug": True,
+            "pro_enabled": True
+        }
+    return {
+        "host": settings["host"] or "0.0.0.0",
+        "port": settings["port"] or 5000,
+        "debug": bool(settings["debug_mode"]),
+        "pro_enabled": bool(settings["pro_enabled"])
+    }
+
 def domain_to_base_dn(domain):
     parts = [part for part in (domain or "").split('.') if part]
     if not parts:
@@ -2684,6 +2725,13 @@ def index():
 def users_page():
     access = get_user_access(get_db())
     return render_template('users.html', username=session.get('username'), permissions=sorted(access["permissions"]), is_superuser=access["is_superuser"])
+
+@app.route('/settings')
+@login_required
+@require_permission('server_settings.manage')
+def server_settings_page():
+    access = get_user_access(get_db())
+    return render_template('server_settings.html', username=session.get('username'), permissions=sorted(access["permissions"]), is_superuser=access["is_superuser"])
 
 @app.route('/locations')
 @login_required
@@ -4638,8 +4686,9 @@ def notification_test():
 @app.route('/api/features', methods=['GET'])
 @login_required
 def feature_flags():
+    settings = get_server_settings(get_db())
     return jsonify({
-        "pro_enabled": PRO_ENABLED,
+        "pro_enabled": bool(settings["pro_enabled"]) if settings else PRO_ENABLED,
         "pro_features": PRO_FEATURES,
         "free_features": FREE_FEATURES
     })
@@ -5158,6 +5207,39 @@ def update_user_roles(user_id):
         ORDER BY r.name
     ''', (user_id,)).fetchall()
     return jsonify({"status": "updated", "roles": [dict(role) for role in roles]}), 200
+
+@app.route('/api/server-settings', methods=['GET', 'POST'])
+@login_required
+@require_permission('server_settings.manage')
+def server_settings():
+    db = get_db()
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        host = (data.get('host') or '0.0.0.0').strip()
+        try:
+            port = int(data.get('port') or 5000)
+        except (TypeError, ValueError):
+            return jsonify({"error": "Port muss eine Zahl sein"}), 400
+        if port < 1 or port > 65535:
+            return jsonify({"error": "Port muss zwischen 1 und 65535 liegen"}), 400
+        debug_mode = 1 if data.get('debug') else 0
+        pro_enabled = 1 if data.get('pro_enabled') else 0
+        if not host:
+            return jsonify({"error": "Host darf nicht leer sein"}), 400
+        db.execute('''
+            UPDATE server_settings
+            SET host = ?, port = ?, debug_mode = ?, pro_enabled = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE id = 1
+        ''', (host, port, debug_mode, pro_enabled))
+        log_activity(db, "update", "server_settings", details={
+            "host": host,
+            "port": port,
+            "debug_mode": bool(debug_mode),
+            "pro_enabled": bool(pro_enabled)
+        })
+        db.commit()
+    settings = get_server_settings(db)
+    return jsonify(serialize_server_settings(settings))
 
 @app.route('/api/ad/settings', methods=['GET'])
 @login_required
@@ -6006,4 +6088,9 @@ def otp_status():
 
 if __name__ == '__main__':
     init_db()
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    with app.app_context():
+        settings = get_server_settings(get_db())
+        runtime_host = settings["host"] if settings else '0.0.0.0'
+        runtime_port = settings["port"] if settings else 5000
+        runtime_debug = bool(settings["debug_mode"]) if settings else True
+    app.run(host=runtime_host, port=runtime_port, debug=runtime_debug)

--- a/templates/dependencies.html
+++ b/templates/dependencies.html
@@ -69,6 +69,14 @@
                                     </span>
                                 </a>
                                 {% endif %}
+                                {% if 'server_settings.manage' in permissions %}
+                                <a href="/settings" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="settings" class="h-4 w-4 text-slate-400"></i>
+                                        Servereinstellungen
+                                    </span>
+                                </a>
+                                {% endif %}
                                 {% if 'locations.view' in permissions or 'locations.manage' in permissions %}
                                 <a href="/locations" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
                                     <span class="flex items-center gap-2">

--- a/templates/index.html
+++ b/templates/index.html
@@ -230,6 +230,14 @@
                                     </span>
                                 </a>
                                 {% endif %}
+                                {% if 'server_settings.manage' in permissions %}
+                                <a href="/settings" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="settings" class="h-4 w-4 text-slate-400"></i>
+                                        Servereinstellungen
+                                    </span>
+                                </a>
+                                {% endif %}
                                 {% if 'locations.view' in permissions or 'locations.manage' in permissions %}
                                 <a href="/locations" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
                                     <span class="flex items-center gap-2">

--- a/templates/knowledge.html
+++ b/templates/knowledge.html
@@ -72,6 +72,14 @@
                                     </span>
                                 </a>
                                 {% endif %}
+                                {% if 'server_settings.manage' in permissions %}
+                                <a href="/settings" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="settings" class="h-4 w-4 text-slate-400"></i>
+                                        Servereinstellungen
+                                    </span>
+                                </a>
+                                {% endif %}
                                 {% if 'locations.view' in permissions or 'locations.manage' in permissions %}
                                 <a href="/locations" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
                                     <span class="flex items-center gap-2">

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -74,6 +74,14 @@
                                     </span>
                                 </a>
                                 {% endif %}
+                                {% if 'server_settings.manage' in permissions %}
+                                <a href="/settings" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="settings" class="h-4 w-4 text-slate-400"></i>
+                                        Servereinstellungen
+                                    </span>
+                                </a>
+                                {% endif %}
                                 {% if 'locations.view' in permissions or 'locations.manage' in permissions %}
                                 <a href="/locations" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
                                     <span class="flex items-center gap-2">

--- a/templates/server_settings.html
+++ b/templates/server_settings.html
@@ -1,34 +1,38 @@
 <!DOCTYPE html>
-<html lang="de" x-data="locationsAdmin()">
+<html lang="de" x-data="serverSettingsApp()">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Inventory Pro - Standorte</title>
+    <title>Inventory Pro - Servereinstellungen</title>
     <script src="/static/theme.js"></script>
     <script>
         tailwind.config = { darkMode: 'class' };
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+    <script>
+        window.inventoryPermissions = {{ permissions | tojson }};
+        window.inventoryIsSuperuser = {{ is_superuser | tojson }};
+    </script>
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body class="app-body">
     <div class="app-shell">
         <aside class="app-sidebar sidebar bg-white/90 backdrop-blur-xl border-r border-slate-200 shadow-sm">
             <div class="sidebar-header p-6 border-b border-slate-200">
-                <a href="https://inv.pondsec.com">
-                <div class="logo flex items-center space-x-3">
-                    <span class="inline-flex items-center justify-center w-10 h-10 rounded-2xl bg-gradient-to-br from-blue-500 via-indigo-500 to-purple-500 text-white shadow-lg">
-                        <i data-feather="cpu" class="w-5 h-5"></i>
-                    </span>
-                    <div>
-                        <p class="text-lg font-semibold text-slate-900 sidebar-text">Inventory Pro</p>
-                        <p class="text-xs text-slate-500 sidebar-text">Smart Asset Hub</p>
+                <a href="/">
+                    <div class="logo flex items-center space-x-3">
+                        <span class="inline-flex items-center justify-center w-10 h-10 rounded-2xl bg-gradient-to-br from-blue-500 via-indigo-500 to-purple-500 text-white shadow-lg">
+                            <i data-feather="cpu" class="w-5 h-5"></i>
+                        </span>
+                        <div>
+                            <p class="text-lg font-semibold text-slate-900 sidebar-text">Inventory Pro</p>
+                            <p class="text-xs text-slate-500 sidebar-text">Smart Asset Hub</p>
+                        </div>
                     </div>
-                </div>
                 </a>
             </div>
-            <nav x-data="{ appsOpen: false }" class="p-4 space-y-4 sidebar-scroll sidebar-primary-links">
+            <nav x-data="{ appsOpen: true }" class="p-4 space-y-4 sidebar-scroll sidebar-primary-links">
                 <div class="rounded-2xl border border-slate-200 bg-white/80 shadow-sm">
                     <button @click="appsOpen = !appsOpen" class="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-slate-50 transition-colors">
                         <span class="flex items-center gap-3">
@@ -71,17 +75,17 @@
                                 </a>
                                 {% endif %}
                                 {% if 'server_settings.manage' in permissions %}
-                                <a href="/settings" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                <a href="/settings" class="flex items-center justify-between rounded-xl bg-white px-3 py-2 text-sm font-semibold text-indigo-700 shadow-sm">
                                     <span class="flex items-center gap-2">
-                                        <i data-feather="settings" class="h-4 w-4 text-slate-400"></i>
+                                        <i data-feather="settings" class="h-4 w-4 text-indigo-500"></i>
                                         Servereinstellungen
                                     </span>
                                 </a>
                                 {% endif %}
                                 {% if 'locations.view' in permissions or 'locations.manage' in permissions %}
-                                <a href="/locations" class="flex items-center justify-between rounded-xl bg-white px-3 py-2 text-sm font-semibold text-indigo-700 shadow-sm">
+                                <a href="/locations" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
                                     <span class="flex items-center gap-2">
-                                        <i data-feather="map-pin" class="h-4 w-4 text-indigo-500"></i>
+                                        <i data-feather="map-pin" class="h-4 w-4 text-slate-400"></i>
                                         Standorte
                                     </span>
                                 </a>
@@ -160,8 +164,8 @@
                         <i data-feather="menu" class="w-4 h-4"></i>
                     </button>
                     <div>
-                        <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Assets</p>
-                        <h1 class="text-2xl font-semibold text-slate-900">Standorte verwalten</h1>
+                        <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Admin</p>
+                        <h1 class="text-2xl font-semibold text-slate-900">Servereinstellungen</h1>
                     </div>
                 </div>
                 <div class="flex items-center gap-2 sm:gap-3">
@@ -175,113 +179,79 @@
                         <span class="sr-only sm:not-sr-only">Abmelden</span>
                     </button>
                 </div>
-                <script>
-                    async function logout() {
-                        try {
-                            const response = await fetch('/logout', {
-                                method: 'POST',
-                                credentials: 'same-origin',
-                                headers: { 'Content-Type': 'application/json' }
-                            });
-
-                            if (response.ok) {
-                                window.location.href = 'https://inv.pondsec.com/login';
-                            } else {
-                                const data = await response.json();
-                                alert('Logout failed: ' + (data.error || 'Unknown error'));
-                            }
-                        } catch (error) {
-                            alert('Network error: ' + error.message);
-                        }
-                    }
-                </script>
             </header>
 
-            <main class="app-content flex-1 overflow-auto p-8 pt-24 space-y-8 scrollbar-hide">
-            <section class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-                <div class="flex flex-wrap items-start justify-between gap-4">
-                    <div>
-                        <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Standorte</p>
-                        <h2 class="text-2xl font-semibold text-slate-900">Standorte verwalten</h2>
-                        <p class="mt-1 text-sm text-slate-500">Lager, Etagen und Abteilungen zentral pflegen.</p>
-                    </div>
-                    <div class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
-                        <p class="text-xs uppercase text-slate-400">Gesamt</p>
-                        <p class="mt-2 text-2xl font-semibold text-slate-900" x-text="locations.length"></p>
-                        <p class="text-xs text-slate-500">aktive Standorte</p>
-                    </div>
-                </div>
-            </section>
-
-            <section class="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
-                <div class="flex flex-wrap items-center justify-between gap-4">
-                    <div class="relative flex-1 min-w-[220px]">
-                        <label class="text-xs uppercase text-slate-400">Suche</label>
-                        <input type="text" x-model="locationSearch" placeholder="Standort suchen" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm">
-                        <span class="absolute right-4 top-9 text-slate-400">
-                            <i data-feather="search" class="h-4 w-4"></i>
-                        </span>
-                    </div>
-                    <button @click="resetForm()" class="rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-xs font-semibold text-slate-600 hover:bg-slate-100">Formular zurücksetzen</button>
-                </div>
-            </section>
-
-            <section class="grid gap-6 lg:grid-cols-3">
-                <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm lg:col-span-1">
-                    <h3 class="text-lg font-semibold text-slate-900">Neuer Standort</h3>
-                    <p class="text-sm text-slate-500">Füge einen neuen Standort hinzu.</p>
-                    <form class="mt-4 space-y-3" @submit.prevent="saveLocation()">
-                        <input type="text" x-model="form.name" placeholder="Name"
-                               class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500" required>
-                        <textarea x-model="form.description" placeholder="Beschreibung"
-                                  class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-blue-500 focus:ring-blue-500"></textarea>
-                        <button type="submit" class="w-full rounded-2xl bg-blue-600 px-4 py-3 text-sm font-semibold text-white hover:bg-blue-500">
-                            <span x-text="editing ? 'Aktualisieren' : 'Speichern'"></span>
-                        </button>
-                        <button type="button" @click="resetForm()" class="w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm font-semibold text-slate-600 hover:bg-slate-100">
-                            Zurücksetzen
-                        </button>
-                        <p class="text-xs text-rose-500" x-text="errorMessage" x-show="errorMessage"></p>
-                    </form>
-                </div>
-
-                <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm lg:col-span-2">
-                    <div class="flex items-center justify-between mb-4">
-                        <div>
-                            <h3 class="text-lg font-semibold text-slate-900">Standorte</h3>
-                            <p class="text-sm text-slate-500">Verwalte bestehende Orte.</p>
+            <main class="app-content px-8 pt-[120px] pb-10" x-cloak>
+                <div class="max-w-4xl">
+                    <div class="mb-6 rounded-3xl border border-indigo-100 bg-indigo-50/70 p-4 text-sm text-indigo-700">
+                        <div class="flex items-start gap-3">
+                            <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white text-indigo-600 shadow-sm">
+                                <i data-feather="info" class="h-4 w-4"></i>
+                            </span>
+                            <div>
+                                <p class="font-semibold">Hinweis</p>
+                                <p class="text-sm text-indigo-700/90">Änderungen an Host, Port oder Debug-Modus werden erst nach einem Neustart des Servers aktiv.</p>
+                            </div>
                         </div>
-                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
-                            <i data-feather="map" class="w-3 h-3"></i>
-                            Zuletzt aktualisiert
-                        </span>
                     </div>
-                    <div class="space-y-3">
-                        <template x-for="location in filteredLocations()" :key="location.id">
-                            <div class="rounded-2xl border border-slate-200 p-4 hover:bg-slate-50">
-                                <div class="flex items-center justify-between">
-                                    <div>
-                                        <p class="font-semibold text-slate-900" x-text="location.name"></p>
-                                        <p class="text-sm text-slate-500" x-text="location.description || 'Keine Beschreibung'"></p>
-                                    </div>
-                                    <div class="flex items-center gap-2" x-data="{ open: false }">
-                                        <button @click="editLocation(location)" class="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-100">
-                                            Bearbeiten
-                                        </button>
-                                        <button @click="open = !open" class="inline-flex items-center justify-center rounded-full border border-slate-200 px-2 py-1 text-slate-600 hover:bg-slate-100" aria-label="Weitere Aktionen">
-                                            <i data-feather="more-vertical" class="h-4 w-4"></i>
-                                        </button>
-                                        <div x-show="open" @click.away="open = false" class="absolute right-4 z-20 mt-20 w-40 rounded-2xl border border-slate-200 bg-white shadow-xl" x-transition>
-                                            <button @click="deleteLocation(location); open=false" class="block w-full px-4 py-2 text-left text-sm text-rose-600 hover:bg-rose-50">Löschen</button>
-                                        </div>
-                                    </div>
+
+                    <form @submit.prevent="saveSettings" class="space-y-6">
+                        <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm">
+                            <div class="flex items-center gap-3">
+                                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-100 text-slate-600">
+                                    <i data-feather="server" class="h-5 w-5"></i>
+                                </span>
+                                <div>
+                                    <h2 class="text-xl font-semibold text-slate-900">Serverkonfiguration</h2>
+                                    <p class="text-sm text-slate-500">Passe die grundlegenden Runtime-Einstellungen der Anwendung an.</p>
                                 </div>
                             </div>
-                        </template>
-                        <p x-show="locations.length === 0" class="text-sm text-slate-400">Noch keine Standorte vorhanden.</p>
-                    </div>
+
+                            <div class="mt-6 grid gap-6 md:grid-cols-2">
+                                <div class="space-y-2">
+                                    <label class="text-sm font-semibold text-slate-700">Host</label>
+                                    <input type="text" x-model="settings.host" class="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="0.0.0.0">
+                                    <p class="text-xs text-slate-400">IP-Adresse oder Hostname für den Flask-Server.</p>
+                                </div>
+                                <div class="space-y-2">
+                                    <label class="text-sm font-semibold text-slate-700">Port</label>
+                                    <input type="number" min="1" max="65535" x-model.number="settings.port" class="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="5000">
+                                    <p class="text-xs text-slate-400">Port, unter dem der Server erreichbar sein soll.</p>
+                                </div>
+                            </div>
+
+                            <div class="mt-6 grid gap-4 md:grid-cols-2">
+                                <label class="flex items-start gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                                    <input type="checkbox" x-model="settings.debug" class="mt-1 h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500">
+                                    <div>
+                                        <p class="text-sm font-semibold text-slate-700">Debug-Modus aktivieren</p>
+                                        <p class="text-xs text-slate-500">Aktiviert ausführliche Logs und Fehlerseiten (nur für Entwicklung).</p>
+                                    </div>
+                                </label>
+                                <label class="flex items-start gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                                    <input type="checkbox" x-model="settings.pro_enabled" class="mt-1 h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500">
+                                    <div>
+                                        <p class="text-sm font-semibold text-slate-700">Pro-Features aktiv</p>
+                                        <p class="text-xs text-slate-500">Steuert, ob erweiterte Module in der UI verfügbar sind.</p>
+                                    </div>
+                                </label>
+                            </div>
+                        </div>
+
+                        <div class="flex flex-wrap items-center gap-3">
+                            <button type="submit" :disabled="saving" class="inline-flex items-center gap-2 rounded-2xl bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-70">
+                                <span x-show="!saving">Einstellungen speichern</span>
+                                <span x-show="saving">Speichert...</span>
+                            </button>
+                            <button type="button" @click="fetchSettings" class="inline-flex items-center gap-2 rounded-2xl border border-slate-200 px-4 py-3 text-sm font-semibold text-slate-600 shadow-sm hover:bg-slate-50">
+                                <i data-feather="refresh-cw" class="h-4 w-4"></i>
+                                Neu laden
+                            </button>
+                            <span x-show="errorMessage" class="text-sm text-rose-600" x-text="errorMessage"></span>
+                            <span x-show="successMessage" class="text-sm text-emerald-600" x-text="successMessage"></span>
+                        </div>
+                    </form>
                 </div>
-            </section>
             </main>
         </div>
     </div>
@@ -289,76 +259,86 @@
     <script src="https://unpkg.com/feather-icons"></script>
     <script>
         document.addEventListener('alpine:init', () => {
-            Alpine.data('locationsAdmin', () => ({
-                locations: [],
-                locationSearch: '',
-                form: { id: null, name: '', description: '' },
-                editing: false,
+            Alpine.data('serverSettingsApp', () => ({
+                settings: {
+                    host: '0.0.0.0',
+                    port: 5000,
+                    debug: true,
+                    pro_enabled: true
+                },
+                loading: false,
+                saving: false,
                 errorMessage: '',
+                successMessage: '',
 
                 async init() {
-                    await this.loadLocations();
-                    feather.replace();
-                },
-
-                async loadLocations() {
-                    const response = await fetch('/api/locations');
-                    if (response.ok) {
-                        this.locations = await response.json();
-                    }
+                    await this.fetchSettings();
                     this.$nextTick(() => feather.replace());
                 },
 
-                filteredLocations() {
-                    const query = (this.locationSearch || '').toLowerCase().trim();
-                    if (!query) return this.locations;
-                    return this.locations.filter((location) => {
-                        return `${location.name} ${location.description || ''}`.toLowerCase().includes(query);
-                    });
-                },
-
-                editLocation(location) {
-                    this.form = { id: location.id, name: location.name, description: location.description || '' };
-                    this.editing = true;
-                },
-
-                resetForm() {
-                    this.form = { id: null, name: '', description: '' };
-                    this.editing = false;
+                async fetchSettings() {
+                    this.loading = true;
                     this.errorMessage = '';
-                },
-
-                async saveLocation() {
-                    this.errorMessage = '';
-                    const payload = { name: this.form.name, description: this.form.description };
-                    const url = this.editing ? `/api/locations/${this.form.id}` : '/api/locations';
-                    const method = this.editing ? 'PUT' : 'POST';
-                    const response = await fetch(url, {
-                        method,
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify(payload)
-                    });
-                    if (response.ok) {
-                        await this.loadLocations();
-                        this.resetForm();
-                    } else {
-                        const error = await response.json();
-                        this.errorMessage = error.error || 'Fehler beim Speichern';
+                    this.successMessage = '';
+                    try {
+                        const response = await fetch('/api/server-settings');
+                        if (!response.ok) {
+                            const error = await response.json();
+                            throw new Error(error.error || 'Konnte Einstellungen nicht laden.');
+                        }
+                        this.settings = await response.json();
+                    } catch (error) {
+                        this.errorMessage = error.message;
+                    } finally {
+                        this.loading = false;
+                        this.$nextTick(() => feather.replace());
                     }
                 },
 
-                async deleteLocation(location) {
-                    if (!confirm(`Standort ${location.name} wirklich löschen?`)) return;
-                    const response = await fetch(`/api/locations/${location.id}`, { method: 'DELETE' });
-                    if (response.ok) {
-                        await this.loadLocations();
-                    } else {
-                        const error = await response.json();
-                        alert(error.error || 'Fehler beim Löschen');
+                async saveSettings() {
+                    this.saving = true;
+                    this.errorMessage = '';
+                    this.successMessage = '';
+                    try {
+                        const response = await fetch('/api/server-settings', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(this.settings)
+                        });
+                        const data = await response.json();
+                        if (!response.ok) {
+                            throw new Error(data.error || 'Speichern fehlgeschlagen.');
+                        }
+                        this.settings = data;
+                        this.successMessage = 'Einstellungen gespeichert.';
+                    } catch (error) {
+                        this.errorMessage = error.message;
+                    } finally {
+                        this.saving = false;
+                        this.$nextTick(() => feather.replace());
                     }
                 }
             }));
         });
+
+        async function logout() {
+            try {
+                const response = await fetch('/logout', {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: { 'Content-Type': 'application/json' }
+                });
+
+                if (response.ok) {
+                    window.location.href = '/login';
+                } else {
+                    const data = await response.json();
+                    alert('Logout failed: ' + (data.error || 'Unknown error'));
+                }
+            } catch (error) {
+                alert('Network error: ' + error.message);
+            }
+        }
     </script>
     <script src="/static/ui.js"></script>
     <script src="/static/theme.js"></script>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -85,6 +85,14 @@
                                     </span>
                                 </a>
                                 {% endif %}
+                                {% if 'server_settings.manage' in permissions %}
+                                <a href="/settings" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="settings" class="h-4 w-4 text-slate-400"></i>
+                                        Servereinstellungen
+                                    </span>
+                                </a>
+                                {% endif %}
                                 {% if 'locations.view' in permissions or 'locations.manage' in permissions %}
                                 <a href="/locations" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
                                     <span class="flex items-center gap-2">

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -74,6 +74,14 @@
                                     </span>
                                 </a>
                                 {% endif %}
+                                {% if 'server_settings.manage' in permissions %}
+                                <a href="/settings" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="settings" class="h-4 w-4 text-slate-400"></i>
+                                        Servereinstellungen
+                                    </span>
+                                </a>
+                                {% endif %}
                                 {% if 'locations.view' in permissions or 'locations.manage' in permissions %}
                                 <a href="/locations" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
                                     <span class="flex items-center gap-2">

--- a/templates/time_machine.html
+++ b/templates/time_machine.html
@@ -68,6 +68,14 @@
                                     </span>
                                 </a>
                                 {% endif %}
+                                {% if 'server_settings.manage' in permissions %}
+                                <a href="/settings" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="settings" class="h-4 w-4 text-slate-400"></i>
+                                        Servereinstellungen
+                                    </span>
+                                </a>
+                                {% endif %}
                                 {% if 'locations.view' in permissions or 'locations.manage' in permissions %}
                                 <a href="/locations" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
                                     <span class="flex items-center gap-2">

--- a/templates/users.html
+++ b/templates/users.html
@@ -73,6 +73,14 @@
                                         Benutzer
                                     </span>
                                 </a>
+                                {% if 'server_settings.manage' in permissions %}
+                                <a href="/settings" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
+                                    <span class="flex items-center gap-2">
+                                        <i data-feather="settings" class="h-4 w-4 text-slate-400"></i>
+                                        Servereinstellungen
+                                    </span>
+                                </a>
+                                {% endif %}
                                 {% if 'locations.view' in permissions or 'locations.manage' in permissions %}
                                 <a href="/locations" class="flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900">
                                     <span class="flex items-center gap-2">


### PR DESCRIPTION
### Motivation
- Allow runtime server configuration (host, port, debug, pro-features) to be managed via the web UI instead of being hard-coded in `app.py`.
- Provide controlled access to those settings via a permission so administrators can update them safely.

### Description
- Add a new permission `server_settings.manage` to `PERMISSIONS` so access can be restricted to authorized roles.
- Persist server configuration in a new `server_settings` SQLite table and provide helper functions `get_server_settings` and `serialize_server_settings` to read/serialize values.
- Implement a JSON API endpoint `GET|POST /api/server-settings` protected by `@require_permission('server_settings.manage')` that validates and saves `host`, `port`, `debug`, and `pro_enabled`, and records updates via `log_activity`.
- Add an admin page at `GET /settings` with template `templates/server_settings.html` and an Alpine.js-driven form to fetch/save settings, and insert navigation links across several templates to surface the page.
- Use the saved `server_settings.pro_enabled` value in the `GET /api/features` response and load saved `host`, `port`, `debug` values at application startup to control `app.run()`.

### Testing
- Launched the development server and verified it reads runtime settings from the DB and starts with the configured `host`, `port`, and `debug` values (manual dev server run succeeded). 
- Automated browser check: ran a Playwright script that logged in and navigated to `/settings`, which returned HTTP 200 and produced a screenshot artifact (`artifacts/server-settings.png`), confirming the page loads and the API returns settings; this run completed successfully. 
- No unit tests were added for this PR. All automated/manual checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6975b8cd203c8331972c01080afcb58e)