### PR TITLE
Add asset assignment history (assign/checkout/checkin) and attachments (upload/download/delete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Inventory Pro kombiniert Inventarisierung, Ticketing und Wissensdatenbank. Teams
 - **Dynamische Kategorien** für Geräte mit frei definierbaren Feldern.
 - **Geräteverwaltung** mit Seriennummern, Standorten, Tags und Notizen.
 - **Asset-Registry** inkl. Lebenszyklusdaten (Anschaffung, Inbetriebnahme, Abschreibung, Ausmusterung).
+- **Asset-Zuweisung & Checkout** inkl. Historie, Verantwortlichkeit und Rückgaben.
 - **Wartungsplanung** für Geräte inklusive Status-Tracking.
+- **Anhänge & Dokumente** an Assets, Tickets und Wartungsaufgaben.
 
 ### Helpdesk & Wissen
 - **Ticket-System** mit Kategorien, Prioritäten, Status, SLA/Due-Dates und Eskalationsstufen.
@@ -74,10 +76,22 @@ Die Anwendung läuft anschließend standardmäßig auf `http://localhost:5000`.
 | `DATABASE_URL` | Postgres-Backup via `pg_dump` | – |
 | `INVENTORY_UPLOADS_DIR` | Pfad für Uploads | `uploads/` |
 | `INVENTORY_MAX_IMPORT_BYTES` | Max. Importgröße | `52428800` |
+| `INVENTORY_MAX_UPLOAD_BYTES` | Max. Uploadgröße für Anhänge | `INVENTORY_MAX_IMPORT_BYTES` |
 | `BACKUP_ENCRYPTION_KEY` | Schlüssel für Backup-Verschlüsselung | – |
 | `INVENTORY_ANTIVIRUS_COMMAND` | Optionaler AV-Check beim Import | – |
 | `APP_VERSION` | Anzeige in der UI/Diagnostics | `unbekannt` |
 | `FLASK_ENV` | Environment Label | `production` |
+
+### Neue Berechtigungen (Auszug)
+| Permission | Zweck |
+| --- | --- |
+| `asset.assign` | Asset an Benutzer/Team zuweisen |
+| `asset.checkout` | Asset ausgeben (Checkout) |
+| `asset.checkin` | Asset zurücknehmen (Check-in) |
+| `asset.view_history` | Zuweisungs-/Checkout-Historie einsehen |
+| `attachment.upload` | Anhänge hochladen |
+| `attachment.download` | Anhänge herunterladen |
+| `attachment.delete` | Anhänge löschen |
 
 ### Server-Einstellungen (UI)
 Im Admin-Bereich können u. a. Backup-Strategien, Import/Export-Optionen, Sicherheitsrichtlinien, MFA-Pflicht und IP-Whitelists verwaltet werden.

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, jsonify, request, g, redirect, url_for, session, Response
+from flask import Flask, render_template, jsonify, request, g, redirect, url_for, session, Response, send_file
 from flask_cors import CORS
 from werkzeug.security import generate_password_hash, check_password_hash
 from werkzeug.utils import secure_filename
@@ -45,6 +45,9 @@ APP_INSTANCE_PATH = Path(app.instance_path)
 RUNTIME_CONFIG_PATH = APP_INSTANCE_PATH / "runtime_config.json"
 UPLOADS_DIR = Path(os.environ.get("INVENTORY_UPLOADS_DIR", "uploads"))
 MAX_IMPORT_BYTES = int(os.environ.get("INVENTORY_MAX_IMPORT_BYTES", 50 * 1024 * 1024))
+MAX_UPLOAD_BYTES = int(os.environ.get("INVENTORY_MAX_UPLOAD_BYTES", MAX_IMPORT_BYTES))
+ALLOWED_ATTACHMENT_EXTENSIONS = {".pdf", ".png", ".jpg", ".jpeg", ".txt", ".csv"}
+BLOCKED_ATTACHMENT_EXTENSIONS = {".exe", ".js", ".html", ".htm", ".bat", ".sh", ".ps1"}
 RATE_LIMIT_WINDOW_SECONDS = 60
 RATE_LIMIT_MAX_REQUESTS = 10
 PRO_ENABLED = True
@@ -172,6 +175,30 @@ PERMISSIONS = [
         "group": "Inventar"
     },
     {
+        "key": "asset.assign",
+        "label": "Assets zuweisen",
+        "description": "Assets Personen oder Teams zuweisen.",
+        "group": "Inventar"
+    },
+    {
+        "key": "asset.checkout",
+        "label": "Assets ausgeben",
+        "description": "Assets ausgeben und Rückgabedaten pflegen.",
+        "group": "Inventar"
+    },
+    {
+        "key": "asset.checkin",
+        "label": "Assets einchecken",
+        "description": "Assets zurücknehmen und Status aktualisieren.",
+        "group": "Inventar"
+    },
+    {
+        "key": "asset.view_history",
+        "label": "Asset-Historie anzeigen",
+        "description": "Zuweisungsverlauf und Check-out/Check-in Historie einsehen.",
+        "group": "Inventar"
+    },
+    {
         "key": "locations.view",
         "label": "Standorte anzeigen",
         "description": "Standorte und Details einsehen.",
@@ -194,6 +221,24 @@ PERMISSIONS = [
         "label": "Wartungen verwalten",
         "description": "Wartungsaufgaben erstellen und aktualisieren.",
         "group": "Inventar"
+    },
+    {
+        "key": "attachment.upload",
+        "label": "Anhänge hochladen",
+        "description": "Dateien an Assets, Tickets und Wartungen anhängen.",
+        "group": "Dokumente"
+    },
+    {
+        "key": "attachment.download",
+        "label": "Anhänge herunterladen",
+        "description": "Anhänge aus Assets, Tickets und Wartungen herunterladen.",
+        "group": "Dokumente"
+    },
+    {
+        "key": "attachment.delete",
+        "label": "Anhänge löschen",
+        "description": "Anhänge aus Assets, Tickets und Wartungen löschen.",
+        "group": "Dokumente"
     },
     {
         "key": "tickets.view_all",
@@ -628,10 +673,17 @@ DEFAULT_ROLES = [
             "devices.manage",
             "assets.view",
             "assets.manage",
+            "asset.assign",
+            "asset.checkout",
+            "asset.checkin",
+            "asset.view_history",
             "locations.view",
             "locations.manage",
             "maintenance.view",
             "maintenance.manage",
+            "attachment.upload",
+            "attachment.download",
+            "attachment.delete",
             "tickets.view_all",
             "tickets.create",
             "tickets.update",
@@ -2841,6 +2893,26 @@ def init_db():
         ''')
 
         c.execute('''
+            CREATE TABLE IF NOT EXISTS asset_assignment_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_id INTEGER NOT NULL,
+                assigned_to_user_id INTEGER,
+                assigned_to_team_id INTEGER,
+                status TEXT NOT NULL,
+                checked_out_at TEXT,
+                due_at TEXT,
+                checked_in_at TEXT,
+                note TEXT,
+                created_by_user_id INTEGER,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (asset_id) REFERENCES assets(id),
+                FOREIGN KEY (assigned_to_user_id) REFERENCES users(id),
+                FOREIGN KEY (assigned_to_team_id) REFERENCES teams(id),
+                FOREIGN KEY (created_by_user_id) REFERENCES users(id)
+            )
+        ''')
+
+        c.execute('''
             CREATE TABLE IF NOT EXISTS asset_lifecycle_events (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 asset_id INTEGER NOT NULL,
@@ -2849,6 +2921,22 @@ def init_db():
                 notes TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 FOREIGN KEY (asset_id) REFERENCES assets(id)
+            )
+        ''')
+
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS attachments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_type TEXT NOT NULL,
+                entity_id INTEGER NOT NULL,
+                original_filename TEXT NOT NULL,
+                stored_filename TEXT NOT NULL,
+                mime_type TEXT,
+                size_bytes INTEGER,
+                uploaded_by_user_id INTEGER,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                deleted_at TEXT,
+                FOREIGN KEY (uploaded_by_user_id) REFERENCES users(id)
             )
         ''')
 
@@ -5329,6 +5417,133 @@ def build_asset_summary(db, asset_row, device_rows=None):
     asset['warranty_status'] = warranty_status(asset.get("warranty_end"))
     return asset
 
+def fetch_asset_assignment_history(db, asset_id, limit=20):
+    query = '''
+        SELECT ah.*, u.username as assigned_user, t.name as assigned_team, cu.username as created_by
+        FROM asset_assignment_history ah
+        LEFT JOIN users u ON u.id = ah.assigned_to_user_id
+        LEFT JOIN teams t ON t.id = ah.assigned_to_team_id
+        LEFT JOIN users cu ON cu.id = ah.created_by_user_id
+        WHERE ah.asset_id = ?
+        ORDER BY ah.created_at DESC, ah.id DESC
+    '''
+    params = [asset_id]
+    if limit:
+        query += ' LIMIT ?'
+        params.append(limit)
+    rows = db.execute(query, params).fetchall()
+    return [dict(row) for row in rows]
+
+def fetch_current_asset_assignment(db, asset_id):
+    row = db.execute('''
+        SELECT ah.*, u.username as assigned_user, t.name as assigned_team
+        FROM asset_assignment_history ah
+        LEFT JOIN users u ON u.id = ah.assigned_to_user_id
+        LEFT JOIN teams t ON t.id = ah.assigned_to_team_id
+        WHERE ah.asset_id = ?
+        ORDER BY ah.created_at DESC, ah.id DESC
+        LIMIT 1
+    ''', (asset_id,)).fetchone()
+    return dict(row) if row else None
+
+def normalize_attachment_filename(filename):
+    safe_name = secure_filename(filename or "")
+    return safe_name or "attachment"
+
+def is_attachment_extension_allowed(filename):
+    extension = Path(filename).suffix.lower()
+    if extension in BLOCKED_ATTACHMENT_EXTENSIONS:
+        return False
+    return extension in ALLOWED_ATTACHMENT_EXTENSIONS
+
+def build_attachment_storage_path(entity_type, entity_id):
+    target_dir = UPLOADS_DIR / "attachments" / entity_type / str(entity_id)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    return target_dir
+
+def store_attachment_file(file_storage, entity_type, entity_id):
+    if not file_storage:
+        return None, "Keine Datei hochgeladen."
+    if request.content_length and request.content_length > MAX_UPLOAD_BYTES:
+        return None, "Datei ist zu groß."
+    original_filename = normalize_attachment_filename(file_storage.filename)
+    if not is_attachment_extension_allowed(original_filename):
+        return None, "Dateityp ist nicht erlaubt."
+    extension = Path(original_filename).suffix.lower()
+    stored_filename = f"{secrets.token_hex(16)}{extension}"
+    target_dir = build_attachment_storage_path(entity_type, entity_id)
+    file_path = target_dir / stored_filename
+    file_storage.save(file_path)
+    size_bytes = file_path.stat().st_size
+    if size_bytes > MAX_UPLOAD_BYTES:
+        file_path.unlink(missing_ok=True)
+        return None, "Datei ist zu groß."
+    antivirus_error = validate_import_file(file_path)
+    if antivirus_error:
+        file_path.unlink(missing_ok=True)
+        return None, antivirus_error
+    return {
+        "original_filename": original_filename,
+        "stored_filename": stored_filename,
+        "mime_type": file_storage.mimetype,
+        "size_bytes": size_bytes,
+        "file_path": file_path,
+    }, None
+
+def serialize_attachment(row):
+    entry = dict(row)
+    entry["download_url"] = f"/attachments/{entry['id']}/download"
+    return entry
+
+def resolve_assignment_target(db, user_id, team_id):
+    if user_id and team_id:
+        return None, None, "Bitte nur Benutzer oder Team wählen."
+    if not user_id and not team_id:
+        return None, None, "Zielperson oder Team ist erforderlich."
+    if user_id:
+        user_row = db.execute('SELECT id FROM users WHERE id = ?', (user_id,)).fetchone()
+        if not user_row:
+            return None, None, "Benutzer nicht gefunden."
+    if team_id:
+        team_row = db.execute('SELECT id FROM teams WHERE id = ?', (team_id,)).fetchone()
+        if not team_row:
+            return None, None, "Team nicht gefunden."
+    return user_id, team_id, None
+
+def validate_assignment_transition(current_status, action):
+    if action == "checkin" and current_status != "checked_out":
+        return "Asset ist nicht ausgecheckt."
+    if action in {"assign", "checkout", "unassign"} and current_status == "checked_out":
+        return "Asset ist ausgecheckt. Bitte zuerst einchecken."
+    if action == "checkout" and current_status == "checked_out":
+        return "Asset ist bereits ausgecheckt."
+    return None
+
+def ensure_attachment_entity_access(db, entity_type, entity_id, access):
+    if entity_type == "asset":
+        asset = db.execute('SELECT id FROM assets WHERE id = ?', (entity_id,)).fetchone()
+        if not asset:
+            return None, ("Asset nicht gefunden", 404)
+        if not (access["is_superuser"] or "assets.view" in access["permissions"] or "assets.manage" in access["permissions"]):
+            return None, ("Keine Berechtigung", 403)
+        return dict(asset), None
+    if entity_type == "ticket":
+        ticket_row = db.execute('SELECT * FROM tickets WHERE id = ?', (entity_id,)).fetchone()
+        if not ticket_row:
+            return None, ("Ticket nicht gefunden", 404)
+        ticket = dict(ticket_row)
+        if not ensure_ticket_access(ticket, access):
+            return None, ("Keine Berechtigung", 403)
+        return ticket, None
+    if entity_type == "maintenance":
+        task = db.execute('SELECT id, device_id FROM maintenance_tasks WHERE id = ?', (entity_id,)).fetchone()
+        if not task:
+            return None, ("Wartungsaufgabe nicht gefunden", 404)
+        if not (access["is_superuser"] or "maintenance.view" in access["permissions"] or "maintenance.manage" in access["permissions"]):
+            return None, ("Keine Berechtigung", 403)
+        return dict(task), None
+    return None, ("Ungültiger Typ", 400)
+
 def fetch_ticket_assets(db, ticket_id):
     rows = db.execute('''
         SELECT a.*
@@ -6013,6 +6228,11 @@ def asset_detail(asset_id):
         ''', (asset_id,)).fetchall()
         asset = build_asset_summary(db, asset_row, device_rows=[dict(row) for row in device_rows])
         asset['devices'] = [dict(row) for row in device_rows]
+        asset["assignment"] = fetch_current_asset_assignment(db, asset_id)
+        if user_can("asset.view_history"):
+            asset["assignment_history"] = fetch_asset_assignment_history(db, asset_id)
+        else:
+            asset["assignment_history"] = []
         relation_rows = db.execute('''
             SELECT ar.id, ar.asset_id, ar.related_asset_id, ar.relation_type_id,
                    rt.name as relation_type_name,
@@ -6108,6 +6328,348 @@ def asset_detail(asset_id):
     db.execute('DELETE FROM asset_relations WHERE asset_id = ? OR related_asset_id = ?', (asset_id, asset_id))
     db.execute('DELETE FROM assets WHERE id = ?', (asset_id,))
     log_activity(db, "delete", "asset", asset_id)
+    db.commit()
+    return jsonify({"status": "deleted"}), 200
+
+@app.route('/assets/<int:asset_id>/history', methods=['GET'])
+@login_required
+@require_permission('asset.view_history')
+def asset_assignment_history(asset_id):
+    db = get_db()
+    asset_row = db.execute('SELECT id FROM assets WHERE id = ?', (asset_id,)).fetchone()
+    if not asset_row:
+        return jsonify({"error": "Asset nicht gefunden"}), 404
+    history = fetch_asset_assignment_history(db, asset_id)
+    return jsonify(history)
+
+@app.route('/assets/<int:asset_id>/assign', methods=['POST'])
+@login_required
+@require_permission('asset.assign')
+def assign_asset(asset_id):
+    db = get_db()
+    asset_row = db.execute('SELECT id FROM assets WHERE id = ?', (asset_id,)).fetchone()
+    if not asset_row:
+        return jsonify({"error": "Asset nicht gefunden"}), 404
+    data = request.get_json() or {}
+    assigned_to_user_id = data.get("assigned_to_user_id")
+    assigned_to_team_id = data.get("assigned_to_team_id")
+    note = (data.get("note") or "").strip()
+    current = fetch_current_asset_assignment(db, asset_id)
+    transition_error = validate_assignment_transition(current["status"] if current else None, "assign")
+    if transition_error:
+        return jsonify({"error": transition_error}), 400
+    assigned_to_user_id, assigned_to_team_id, error = resolve_assignment_target(
+        db,
+        assigned_to_user_id,
+        assigned_to_team_id,
+    )
+    if error:
+        return jsonify({"error": error}), 400
+    status = "assigned"
+    if current and (
+        current.get("assigned_to_user_id") != assigned_to_user_id
+        or current.get("assigned_to_team_id") != assigned_to_team_id
+    ):
+        status = "transferred"
+    created_by_user_id = get_current_user_id(db)
+    now = datetime.utcnow().isoformat()
+    db.execute('''
+        INSERT INTO asset_assignment_history (
+            asset_id, assigned_to_user_id, assigned_to_team_id, status, note, created_by_user_id, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    ''', (
+        asset_id,
+        assigned_to_user_id,
+        assigned_to_team_id,
+        status,
+        note,
+        created_by_user_id,
+        now
+    ))
+    log_activity(db, "ASSET_ASSIGNED", "asset", asset_id, {
+        "assigned_to_user_id": assigned_to_user_id,
+        "assigned_to_team_id": assigned_to_team_id,
+        "status": status,
+        "note": note
+    })
+    db.commit()
+    return jsonify({
+        "status": "ok",
+        "assignment": fetch_current_asset_assignment(db, asset_id),
+        "history": fetch_asset_assignment_history(db, asset_id),
+    }), 200
+
+@app.route('/assets/<int:asset_id>/checkout', methods=['POST'])
+@login_required
+@require_permission('asset.checkout')
+def checkout_asset(asset_id):
+    db = get_db()
+    asset_row = db.execute('SELECT id FROM assets WHERE id = ?', (asset_id,)).fetchone()
+    if not asset_row:
+        return jsonify({"error": "Asset nicht gefunden"}), 404
+    data = request.get_json() or {}
+    assigned_to_user_id = data.get("assigned_to_user_id")
+    assigned_to_team_id = data.get("assigned_to_team_id")
+    due_at = (data.get("due_at") or "").strip() or None
+    note = (data.get("note") or "").strip()
+    current = fetch_current_asset_assignment(db, asset_id)
+    transition_error = validate_assignment_transition(current["status"] if current else None, "checkout")
+    if transition_error:
+        return jsonify({"error": transition_error}), 400
+    assigned_to_user_id, assigned_to_team_id, error = resolve_assignment_target(
+        db,
+        assigned_to_user_id,
+        assigned_to_team_id,
+    )
+    if error:
+        return jsonify({"error": error}), 400
+    created_by_user_id = get_current_user_id(db)
+    now = datetime.utcnow().isoformat()
+    db.execute('''
+        INSERT INTO asset_assignment_history (
+            asset_id, assigned_to_user_id, assigned_to_team_id, status,
+            checked_out_at, due_at, note, created_by_user_id, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ''', (
+        asset_id,
+        assigned_to_user_id,
+        assigned_to_team_id,
+        "checked_out",
+        now,
+        due_at,
+        note,
+        created_by_user_id,
+        now
+    ))
+    log_activity(db, "ASSET_CHECKED_OUT", "asset", asset_id, {
+        "assigned_to_user_id": assigned_to_user_id,
+        "assigned_to_team_id": assigned_to_team_id,
+        "due_at": due_at,
+        "note": note
+    })
+    db.commit()
+    return jsonify({
+        "status": "ok",
+        "assignment": fetch_current_asset_assignment(db, asset_id),
+        "history": fetch_asset_assignment_history(db, asset_id),
+    }), 200
+
+@app.route('/assets/<int:asset_id>/checkin', methods=['POST'])
+@login_required
+@require_permission('asset.checkin')
+def checkin_asset(asset_id):
+    db = get_db()
+    asset_row = db.execute('SELECT id FROM assets WHERE id = ?', (asset_id,)).fetchone()
+    if not asset_row:
+        return jsonify({"error": "Asset nicht gefunden"}), 404
+    data = request.get_json() or {}
+    note = (data.get("note") or "").strip()
+    current = fetch_current_asset_assignment(db, asset_id)
+    transition_error = validate_assignment_transition(current["status"] if current else None, "checkin")
+    if transition_error:
+        return jsonify({"error": transition_error}), 400
+    created_by_user_id = get_current_user_id(db)
+    now = datetime.utcnow().isoformat()
+    db.execute('''
+        INSERT INTO asset_assignment_history (
+            asset_id, assigned_to_user_id, assigned_to_team_id, status,
+            checked_in_at, note, created_by_user_id, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    ''', (
+        asset_id,
+        current.get("assigned_to_user_id") if current else None,
+        current.get("assigned_to_team_id") if current else None,
+        "checked_in",
+        now,
+        note,
+        created_by_user_id,
+        now
+    ))
+    log_activity(db, "ASSET_CHECKED_IN", "asset", asset_id, {
+        "note": note
+    })
+    db.commit()
+    return jsonify({
+        "status": "ok",
+        "assignment": fetch_current_asset_assignment(db, asset_id),
+        "history": fetch_asset_assignment_history(db, asset_id),
+    }), 200
+
+@app.route('/assets/<int:asset_id>/unassign', methods=['POST'])
+@login_required
+@require_permission('asset.assign')
+def unassign_asset(asset_id):
+    db = get_db()
+    asset_row = db.execute('SELECT id FROM assets WHERE id = ?', (asset_id,)).fetchone()
+    if not asset_row:
+        return jsonify({"error": "Asset nicht gefunden"}), 404
+    data = request.get_json() or {}
+    note = (data.get("note") or "").strip()
+    current = fetch_current_asset_assignment(db, asset_id)
+    transition_error = validate_assignment_transition(current["status"] if current else None, "unassign")
+    if transition_error:
+        return jsonify({"error": transition_error}), 400
+    created_by_user_id = get_current_user_id(db)
+    now = datetime.utcnow().isoformat()
+    db.execute('''
+        INSERT INTO asset_assignment_history (
+            asset_id, assigned_to_user_id, assigned_to_team_id, status, note, created_by_user_id, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    ''', (
+        asset_id,
+        None,
+        None,
+        "unassigned",
+        note,
+        created_by_user_id,
+        now
+    ))
+    log_activity(db, "ASSET_UNASSIGNED", "asset", asset_id, {"note": note})
+    db.commit()
+    return jsonify({
+        "status": "ok",
+        "assignment": fetch_current_asset_assignment(db, asset_id),
+        "history": fetch_asset_assignment_history(db, asset_id),
+    }), 200
+
+@app.route('/api/asset-assignments/options', methods=['GET'])
+@login_required
+@require_permissions('asset.assign', 'asset.checkout')
+def asset_assignment_options():
+    db = get_db()
+    users = db.execute('SELECT id, username FROM users ORDER BY username').fetchall()
+    teams = db.execute('SELECT id, name FROM teams ORDER BY name').fetchall()
+    return jsonify({
+        "users": [dict(row) for row in users],
+        "teams": [dict(row) for row in teams],
+    })
+
+@app.route('/attachments', methods=['GET'])
+@login_required
+@require_permission('attachment.download')
+def list_attachments():
+    db = get_db()
+    entity_type = (request.args.get("entity_type") or "").strip()
+    entity_id = request.args.get("entity_id", type=int)
+    if not entity_type or not entity_id:
+        return jsonify({"error": "Entität fehlt"}), 400
+    access = get_user_access(db)
+    _, error = ensure_attachment_entity_access(db, entity_type, entity_id, access)
+    if error:
+        message, status = error
+        return jsonify({"error": message}), status
+    rows = db.execute('''
+        SELECT a.*, u.username as uploaded_by
+        FROM attachments a
+        LEFT JOIN users u ON u.id = a.uploaded_by_user_id
+        WHERE a.entity_type = ? AND a.entity_id = ? AND a.deleted_at IS NULL
+        ORDER BY a.created_at DESC
+    ''', (entity_type, entity_id)).fetchall()
+    return jsonify([serialize_attachment(row) for row in rows])
+
+@app.route('/attachments/upload', methods=['POST'])
+@login_required
+@require_permission('attachment.upload')
+def upload_attachment():
+    db = get_db()
+    entity_type = (request.form.get("entity_type") or "").strip()
+    entity_id = request.form.get("entity_id", type=int)
+    if not entity_type or not entity_id:
+        return jsonify({"error": "Entität fehlt"}), 400
+    access = get_user_access(db)
+    _, error = ensure_attachment_entity_access(db, entity_type, entity_id, access)
+    if error:
+        message, status = error
+        return jsonify({"error": message}), status
+    file_storage = request.files.get("file")
+    payload, error_message = store_attachment_file(file_storage, entity_type, entity_id)
+    if error_message:
+        return jsonify({"error": error_message}), 400
+    user_id = get_current_user_id(db)
+    cursor = db.execute('''
+        INSERT INTO attachments (
+            entity_type, entity_id, original_filename, stored_filename, mime_type, size_bytes, uploaded_by_user_id
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    ''', (
+        entity_type,
+        entity_id,
+        payload["original_filename"],
+        payload["stored_filename"],
+        payload["mime_type"],
+        payload["size_bytes"],
+        user_id
+    ))
+    attachment_id = cursor.lastrowid
+    log_activity(db, "ATTACHMENT_UPLOADED", "attachment", attachment_id, {
+        "entity_type": entity_type,
+        "entity_id": entity_id,
+        "filename": payload["original_filename"]
+    })
+    db.commit()
+    row = db.execute('''
+        SELECT a.*, u.username as uploaded_by
+        FROM attachments a
+        LEFT JOIN users u ON u.id = a.uploaded_by_user_id
+        WHERE a.id = ?
+    ''', (attachment_id,)).fetchone()
+    return jsonify(serialize_attachment(row)), 201
+
+@app.route('/attachments/<int:attachment_id>/download', methods=['GET'])
+@login_required
+@require_permission('attachment.download')
+def download_attachment(attachment_id):
+    db = get_db()
+    row = db.execute('''
+        SELECT *
+        FROM attachments
+        WHERE id = ? AND deleted_at IS NULL
+    ''', (attachment_id,)).fetchone()
+    if not row:
+        return jsonify({"error": "Anhang nicht gefunden"}), 404
+    access = get_user_access(db)
+    _, error = ensure_attachment_entity_access(db, row["entity_type"], row["entity_id"], access)
+    if error:
+        message, status = error
+        return jsonify({"error": message}), status
+    file_path = UPLOADS_DIR / "attachments" / row["entity_type"] / str(row["entity_id"]) / row["stored_filename"]
+    if not file_path.exists():
+        return jsonify({"error": "Datei nicht gefunden"}), 404
+    return send_file(
+        file_path,
+        as_attachment=True,
+        download_name=row["original_filename"],
+        mimetype=row["mime_type"] or "application/octet-stream",
+    )
+
+@app.route('/attachments/<int:attachment_id>/delete', methods=['POST'])
+@login_required
+@require_permission('attachment.delete')
+def delete_attachment(attachment_id):
+    db = get_db()
+    row = db.execute('''
+        SELECT *
+        FROM attachments
+        WHERE id = ? AND deleted_at IS NULL
+    ''', (attachment_id,)).fetchone()
+    if not row:
+        return jsonify({"error": "Anhang nicht gefunden"}), 404
+    access = get_user_access(db)
+    _, error = ensure_attachment_entity_access(db, row["entity_type"], row["entity_id"], access)
+    if error:
+        message, status = error
+        return jsonify({"error": message}), status
+    deleted_at = datetime.utcnow().isoformat()
+    db.execute('UPDATE attachments SET deleted_at = ? WHERE id = ?', (deleted_at, attachment_id))
+    log_activity(db, "ATTACHMENT_DELETED", "attachment", attachment_id, {
+        "entity_type": row["entity_type"],
+        "entity_id": row["entity_id"],
+        "filename": row["original_filename"]
+    })
     db.commit()
     return jsonify({"status": "deleted"}), 200
 
@@ -8733,7 +9295,15 @@ def export_data():
         return jsonify({"error": "Export ist deaktiviert."}), 403
     export_format = settings["importExport"]["exportFormat"]
     include_uploads = settings["importExport"]["includeUploads"]
-    tables = ["categories", "locations", "devices", "assets", "maintenance_tasks"]
+    tables = [
+        "categories",
+        "locations",
+        "devices",
+        "assets",
+        "maintenance_tasks",
+        "asset_assignment_history",
+        "attachments",
+    ]
     temp_dir = Path(tempfile.mkdtemp(prefix="inventory_export_"))
     archive_path = None
     try:
@@ -8815,7 +9385,15 @@ def import_data():
     if antivirus_error:
         shutil.rmtree(file_path.parent, ignore_errors=True)
         return jsonify({"error": antivirus_error}), 400
-    tables = ["categories", "locations", "devices", "assets", "maintenance_tasks"]
+    tables = [
+        "categories",
+        "locations",
+        "devices",
+        "assets",
+        "maintenance_tasks",
+        "asset_assignment_history",
+        "attachments",
+    ]
     try:
         if import_mode == "replace":
             run_backup_job(db, settings, force=True)

--- a/static/script.js
+++ b/static/script.js
@@ -27,6 +27,8 @@ document.addEventListener('alpine:init', () => {
             pro_features: [],
             free_features: []
         },
+        userPermissions: window.inventoryPermissions || [],
+        isSuperuser: window.inventoryIsSuperuser || false,
         maintenanceSummary: {
             pro_locked: true,
             open: 0,
@@ -37,9 +39,26 @@ document.addEventListener('alpine:init', () => {
         deviceDetailOpen: false,
         selectedAsset: null,
         assetDetailOpen: false,
+        assetAssignmentHistory: [],
+        assignmentModalOpen: false,
+        assignmentAction: '',
+        assignmentForm: {
+            assigned_to_user_id: '',
+            assigned_to_team_id: '',
+            due_at: '',
+            note: ''
+        },
+        assignmentOptions: {
+            users: [],
+            teams: []
+        },
+        assetAttachments: [],
+        assetAttachmentError: '',
         deviceTags: [],
         deviceNotes: [],
         maintenanceTasks: [],
+        maintenanceAttachments: {},
+        maintenanceAttachmentErrors: {},
         newTag: '',
         newNote: '',
         newMaintenance: {
@@ -118,6 +137,10 @@ document.addEventListener('alpine:init', () => {
             this.$watch('specQuery', () => this.searchDevices());
             feather.replace();
             this.startLiveRefresh();
+        },
+
+        can(permissionKey) {
+            return this.isSuperuser || this.userPermissions.includes(permissionKey);
         },
 
         async loadFeatureFlags() {
@@ -699,6 +722,8 @@ document.addEventListener('alpine:init', () => {
             this.deviceTags = [];
             this.deviceNotes = [];
             this.maintenanceTasks = [];
+            this.maintenanceAttachments = {};
+            this.maintenanceAttachmentErrors = {};
         },
 
         async loadDeviceExtras(deviceId) {
@@ -721,6 +746,7 @@ document.addEventListener('alpine:init', () => {
                 const maintenanceRes = await fetch(`/api/maintenance?device_id=${deviceId}`);
                 if (maintenanceRes.ok) {
                     this.maintenanceTasks = await maintenanceRes.json();
+                    await this.loadMaintenanceAttachments();
                 }
             } catch (error) {
                 console.error('Error loading maintenance tasks:', error);
@@ -843,10 +869,194 @@ document.addEventListener('alpine:init', () => {
             }
         },
 
+        async loadMaintenanceAttachments() {
+            this.maintenanceAttachments = {};
+            this.maintenanceAttachmentErrors = {};
+            if (!this.can('attachment.download')) {
+                return;
+            }
+            const tasks = this.maintenanceTasks || [];
+            await Promise.all(tasks.map(async (task) => {
+                const response = await fetch(`/attachments?entity_type=maintenance&entity_id=${task.id}`);
+                if (response.ok) {
+                    this.maintenanceAttachments[task.id] = await response.json();
+                } else {
+                    this.maintenanceAttachments[task.id] = [];
+                }
+            }));
+        },
+
+        async uploadMaintenanceAttachment(taskId, event) {
+            const file = event.target.files?.[0];
+            if (!file) return;
+            const formData = new FormData();
+            formData.append('entity_type', 'maintenance');
+            formData.append('entity_id', taskId);
+            formData.append('file', file);
+            this.maintenanceAttachmentErrors[taskId] = '';
+            const response = await fetch('/attachments/upload', {
+                method: 'POST',
+                body: formData
+            });
+            if (response.ok) {
+                await this.loadMaintenanceAttachments();
+            } else {
+                const error = await response.json();
+                this.maintenanceAttachmentErrors[taskId] = error.error || 'Upload fehlgeschlagen';
+            }
+            event.target.value = '';
+        },
+
+        async deleteMaintenanceAttachment(taskId, attachmentId) {
+            if (!confirm('Anhang wirklich löschen?')) return;
+            const response = await fetch(`/attachments/${attachmentId}/delete`, { method: 'POST' });
+            if (response.ok) {
+                await this.loadMaintenanceAttachments();
+            }
+        },
+
         formatActivity(item) {
             const name = item.details?.name || item.details?.tag || '';
             const label = `${item.action} ${item.entity_type}`.replace('_', ' ');
             return `${label}${name ? ` • ${name}` : ''}`;
+        },
+
+        formatFileSize(bytes) {
+            if (!bytes && bytes !== 0) return '-';
+            if (bytes < 1024) return `${bytes} B`;
+            const kb = bytes / 1024;
+            if (kb < 1024) return `${kb.toFixed(1)} KB`;
+            const mb = kb / 1024;
+            return `${mb.toFixed(1)} MB`;
+        },
+
+        assignmentStatusLabel(status) {
+            const labels = {
+                assigned: 'Zugewiesen',
+                checked_out: 'Ausgegeben',
+                checked_in: 'Eingecheckt',
+                transferred: 'Übertragen',
+                unassigned: 'Nicht zugewiesen'
+            };
+            return labels[status] || status || '-';
+        },
+
+        assignmentTargetLabel(assignment) {
+            if (!assignment) return '-';
+            if (assignment.assigned_user) return assignment.assigned_user;
+            if (assignment.assigned_team) return assignment.assigned_team;
+            return '-';
+        },
+
+        async loadAssetAssignmentHistory(assetId) {
+            if (!this.can('asset.view_history')) {
+                this.assetAssignmentHistory = [];
+                return;
+            }
+            const response = await fetch(`/assets/${assetId}/history`);
+            if (response.ok) {
+                this.assetAssignmentHistory = await response.json();
+            }
+        },
+
+        async loadAssetAssignmentOptions() {
+            if (this.assignmentOptions.users.length || this.assignmentOptions.teams.length) {
+                return;
+            }
+            const response = await fetch('/api/asset-assignments/options');
+            if (response.ok) {
+                this.assignmentOptions = await response.json();
+            }
+        },
+
+        openAssetAssignmentModal(action) {
+            this.assignmentAction = action;
+            this.assignmentForm = {
+                assigned_to_user_id: '',
+                assigned_to_team_id: '',
+                due_at: '',
+                note: ''
+            };
+            if (action === 'assign' || action === 'checkout') {
+                this.loadAssetAssignmentOptions();
+            }
+            this.assignmentModalOpen = true;
+        },
+
+        closeAssetAssignmentModal() {
+            this.assignmentModalOpen = false;
+            this.assignmentAction = '';
+        },
+
+        async submitAssetAssignment() {
+            if (!this.selectedAsset) return;
+            const payload = {
+                assigned_to_user_id: this.assignmentForm.assigned_to_user_id || null,
+                assigned_to_team_id: this.assignmentForm.assigned_to_team_id || null,
+                due_at: this.assignmentForm.due_at || null,
+                note: this.assignmentForm.note || ''
+            };
+            const endpointMap = {
+                assign: 'assign',
+                checkout: 'checkout',
+                checkin: 'checkin',
+                unassign: 'unassign'
+            };
+            const endpoint = endpointMap[this.assignmentAction];
+            if (!endpoint) return;
+            const response = await fetch(`/assets/${this.selectedAsset.id}/${endpoint}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            if (response.ok) {
+                const result = await response.json();
+                this.selectedAsset.assignment = result.assignment;
+                this.assetAssignmentHistory = result.history || [];
+                await this.loadAssets();
+                await this.loadActivityFeed();
+                this.closeAssetAssignmentModal();
+            } else {
+                const error = await response.json();
+                alert(error.error || 'Zuweisung konnte nicht gespeichert werden');
+            }
+        },
+
+        async loadAssetAttachments(assetId) {
+            const response = await fetch(`/attachments?entity_type=asset&entity_id=${assetId}`);
+            if (response.ok) {
+                this.assetAttachments = await response.json();
+            }
+        },
+
+        async uploadAssetAttachment(event) {
+            if (!this.selectedAsset) return;
+            const file = event.target.files?.[0];
+            if (!file) return;
+            const formData = new FormData();
+            formData.append('entity_type', 'asset');
+            formData.append('entity_id', this.selectedAsset.id);
+            formData.append('file', file);
+            this.assetAttachmentError = '';
+            const response = await fetch('/attachments/upload', {
+                method: 'POST',
+                body: formData
+            });
+            if (response.ok) {
+                await this.loadAssetAttachments(this.selectedAsset.id);
+            } else {
+                const error = await response.json();
+                this.assetAttachmentError = error.error || 'Upload fehlgeschlagen';
+            }
+            event.target.value = '';
+        },
+
+        async deleteAssetAttachment(attachmentId) {
+            if (!confirm('Anhang wirklich löschen?')) return;
+            const response = await fetch(`/attachments/${attachmentId}/delete`, { method: 'POST' });
+            if (response.ok && this.selectedAsset) {
+                await this.loadAssetAttachments(this.selectedAsset.id);
+            }
         },
 
         // Asset Methods
@@ -1025,6 +1235,12 @@ document.addEventListener('alpine:init', () => {
                     throw new Error('Asset konnte nicht geladen werden');
                 }
                 this.selectedAsset = await response.json();
+                this.assetAssignmentHistory = this.selectedAsset.assignment_history || [];
+                this.assetAttachments = [];
+                this.assetAttachmentError = '';
+                if (this.can('attachment.download')) {
+                    await this.loadAssetAttachments(asset.id);
+                }
                 this.assetDetailOpen = true;
             } catch (error) {
                 console.error('Error loading asset detail:', error);
@@ -1035,6 +1251,9 @@ document.addEventListener('alpine:init', () => {
         closeAssetDetail() {
             this.assetDetailOpen = false;
             this.selectedAsset = null;
+            this.assetAssignmentHistory = [];
+            this.assetAttachments = [];
+            this.assetAttachmentError = '';
         },
 
         // Helper Methods

--- a/static/tickets.js
+++ b/static/tickets.js
@@ -5,6 +5,8 @@ document.addEventListener('alpine:init', () => {
         alerts: [],
         assets: [],
         selectedTicket: null,
+        ticketAttachments: [],
+        ticketAttachmentError: '',
         knowledgeSuggestions: [],
         knowledgeLoading: false,
         userPermissions: window.inventoryPermissions || [],
@@ -175,6 +177,11 @@ document.addEventListener('alpine:init', () => {
                 this.internalComment = false;
                 this.newWatcher = '';
                 await this.loadKnowledgeSuggestions();
+                if (this.can('attachment.download')) {
+                    await this.loadTicketAttachments(this.selectedTicket.id);
+                } else {
+                    this.ticketAttachments = [];
+                }
                 this.$nextTick(() => feather.replace());
             }
         },
@@ -182,6 +189,54 @@ document.addEventListener('alpine:init', () => {
         closeTicket() {
             this.selectedTicket = null;
             this.knowledgeSuggestions = [];
+            this.ticketAttachments = [];
+            this.ticketAttachmentError = '';
+        },
+
+        formatFileSize(bytes) {
+            if (!bytes && bytes !== 0) return '-';
+            if (bytes < 1024) return `${bytes} B`;
+            const kb = bytes / 1024;
+            if (kb < 1024) return `${kb.toFixed(1)} KB`;
+            const mb = kb / 1024;
+            return `${mb.toFixed(1)} MB`;
+        },
+
+        async loadTicketAttachments(ticketId) {
+            const response = await fetch(`/attachments?entity_type=ticket&entity_id=${ticketId}`);
+            if (response.ok) {
+                this.ticketAttachments = await response.json();
+            }
+        },
+
+        async uploadTicketAttachment(event) {
+            if (!this.selectedTicket) return;
+            const file = event.target.files?.[0];
+            if (!file) return;
+            const formData = new FormData();
+            formData.append('entity_type', 'ticket');
+            formData.append('entity_id', this.selectedTicket.id);
+            formData.append('file', file);
+            this.ticketAttachmentError = '';
+            const response = await fetch('/attachments/upload', {
+                method: 'POST',
+                body: formData
+            });
+            if (response.ok) {
+                await this.loadTicketAttachments(this.selectedTicket.id);
+            } else {
+                const error = await response.json();
+                this.ticketAttachmentError = error.error || 'Upload fehlgeschlagen';
+            }
+            event.target.value = '';
+        },
+
+        async deleteTicketAttachment(attachmentId) {
+            if (!confirm('Anhang wirklich löschen?')) return;
+            const response = await fetch(`/attachments/${attachmentId}/delete`, { method: 'POST' });
+            if (response.ok && this.selectedTicket) {
+                await this.loadTicketAttachments(this.selectedTicket.id);
+            }
         },
 
         async loadKnowledgeSuggestions() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,10 @@
         tailwind.config = { darkMode: 'class' };
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        window.inventoryPermissions = {{ permissions | tojson }};
+        window.inventoryIsSuperuser = {{ is_superuser | tojson }};
+    </script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"/>
     <link rel="stylesheet" href="/static/style.css">
     <script src="/static/vendor/alpinejs.min.js" defer></script>
@@ -736,14 +740,40 @@
                         </div>
                         <div class="mt-4 space-y-3">
                             <template x-for="task in maintenanceTasks" :key="task.id">
-                                <div class="flex items-start justify-between rounded-2xl border border-indigo-100 bg-white px-3 py-2 text-sm">
-                                    <div>
-                                        <p class="font-semibold text-slate-800" x-text="task.title"></p>
-                                        <p class="text-xs text-slate-400" x-text="task.due_date ? `Fällig: ${task.due_date}` : 'Kein Datum'"></p>
+                                <div class="rounded-2xl border border-indigo-100 bg-white px-3 py-3 text-sm space-y-3">
+                                    <div class="flex items-start justify-between gap-2">
+                                        <div>
+                                            <p class="font-semibold text-slate-800" x-text="task.title"></p>
+                                            <p class="text-xs text-slate-400" x-text="task.due_date ? `Fällig: ${task.due_date}` : 'Kein Datum'"></p>
+                                        </div>
+                                        <button @click="updateMaintenanceStatus(task.id, task.status === 'open' ? 'done' : 'open')" class="text-xs font-semibold text-indigo-600">
+                                            <span x-text="task.status === 'open' ? 'Erledigt' : 'Offen'"></span>
+                                        </button>
                                     </div>
-                                    <button @click="updateMaintenanceStatus(task.id, task.status === 'open' ? 'done' : 'open')" class="text-xs font-semibold text-indigo-600">
-                                        <span x-text="task.status === 'open' ? 'Erledigt' : 'Offen'"></span>
-                                    </button>
+                                    <div class="space-y-2" x-show="can('attachment.download') || can('attachment.upload')">
+                                        <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+                                            <label x-show="can('attachment.upload')" class="inline-flex w-full cursor-pointer items-center justify-center rounded-2xl border border-indigo-100 bg-white px-3 py-2 text-xs font-semibold text-indigo-700 hover:bg-indigo-50 sm:w-auto">
+                                                <span>Anhang hinzufügen</span>
+                                                <input type="file" class="hidden" @change="uploadMaintenanceAttachment(task.id, $event)">
+                                            </label>
+                                            <p class="text-xs text-rose-600" x-show="maintenanceAttachmentErrors[task.id]" x-text="maintenanceAttachmentErrors[task.id]"></p>
+                                        </div>
+                                        <template x-for="attachment in (maintenanceAttachments[task.id] || [])" :key="attachment.id">
+                                            <div class="rounded-2xl border border-indigo-100 bg-indigo-50/60 px-3 py-2">
+                                                <div class="flex items-start justify-between gap-2">
+                                                    <div class="min-w-0">
+                                                        <p class="break-words text-xs font-semibold text-slate-800" x-text="attachment.original_filename"></p>
+                                                        <p class="text-[11px] text-slate-500" x-text="`${formatFileSize(attachment.size_bytes)} • ${attachment.uploaded_by || 'System'}`"></p>
+                                                    </div>
+                                                    <div class="flex shrink-0 items-center gap-2">
+                                                        <a :href="attachment.download_url" class="rounded-full border border-indigo-100 px-2 py-1 text-[11px] font-semibold text-indigo-700 hover:bg-indigo-100">Download</a>
+                                                        <button x-show="can('attachment.delete')" @click="deleteMaintenanceAttachment(task.id, attachment.id)" class="rounded-full border border-rose-200 px-2 py-1 text-[11px] font-semibold text-rose-600 hover:bg-rose-50">Löschen</button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </template>
+                                        <p x-show="(maintenanceAttachments[task.id] || []).length === 0" class="text-xs text-indigo-500">Keine Anhänge.</p>
+                                    </div>
                                 </div>
                             </template>
                             <p x-show="maintenanceTasks.length === 0" class="text-xs text-indigo-500">Keine Wartungen geplant.</p>
@@ -778,6 +808,44 @@
                                 <span>Erstellt</span>
                                 <span class="font-semibold text-slate-900" x-text="selectedAsset?.created_at?.slice(0, 10) || '-' "></span>
                             </div>
+                        </div>
+                    </div>
+
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-slate-900">Zuweisung &amp; Checkout</p>
+                                <p class="text-xs text-slate-500">Status und Verantwortlichkeit</p>
+                            </div>
+                            <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600" x-text="assignmentStatusLabel(selectedAsset?.assignment?.status)"></span>
+                        </div>
+                        <div class="mt-3 grid gap-2 text-sm text-slate-600">
+                            <div class="flex justify-between gap-4">
+                                <span>Zugewiesen an</span>
+                                <span class="font-semibold text-slate-900 text-right" x-text="assignmentTargetLabel(selectedAsset?.assignment)"></span>
+                            </div>
+                            <div class="flex justify-between gap-4">
+                                <span>Fällig am</span>
+                                <span class="font-semibold text-slate-900 text-right" x-text="selectedAsset?.assignment?.due_at || '-'"></span>
+                            </div>
+                            <div class="flex justify-between gap-4">
+                                <span>Checkout</span>
+                                <span class="font-semibold text-slate-900 text-right" x-text="selectedAsset?.assignment?.checked_out_at || '-'"></span>
+                            </div>
+                        </div>
+                        <div class="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+                            <button x-show="can('asset.assign')" @click="openAssetAssignmentModal('assign')" class="w-full rounded-2xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 sm:w-auto">
+                                Zuweisen
+                            </button>
+                            <button x-show="can('asset.checkout') && selectedAsset?.assignment?.status !== 'checked_out'" @click="openAssetAssignmentModal('checkout')" class="w-full rounded-2xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 sm:w-auto">
+                                Checkout
+                            </button>
+                            <button x-show="can('asset.checkin') && selectedAsset?.assignment?.status === 'checked_out'" @click="openAssetAssignmentModal('checkin')" class="w-full rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-700 hover:bg-emerald-100 sm:w-auto">
+                                Check-in
+                            </button>
+                            <button x-show="can('asset.assign') && selectedAsset?.assignment?.status && selectedAsset?.assignment?.status !== 'checked_out'" @click="openAssetAssignmentModal('unassign')" class="w-full rounded-2xl border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-semibold text-rose-700 hover:bg-rose-100 sm:w-auto">
+                                Unassign
+                            </button>
                         </div>
                     </div>
 
@@ -886,8 +954,114 @@
                             <p x-show="(selectedAsset?.open_tickets || []).length === 0" class="text-xs text-amber-500">Keine offenen Tickets.</p>
                         </div>
                     </div>
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4" x-show="can('asset.view_history')">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-slate-900">Historie</p>
+                                <p class="text-xs text-slate-500">Letzte Zuweisungen &amp; Checkouts</p>
+                            </div>
+                            <i data-feather="clock" class="w-4 h-4 text-slate-400"></i>
+                        </div>
+                        <div class="mt-4 space-y-3 text-sm">
+                            <template x-for="entry in assetAssignmentHistory" :key="entry.id">
+                                <div class="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2">
+                                    <div class="flex items-start justify-between gap-2">
+                                        <p class="font-semibold text-slate-800" x-text="assignmentStatusLabel(entry.status)"></p>
+                                        <span class="text-xs text-slate-400" x-text="entry.created_at?.slice(0, 16).replace('T', ' ')"></span>
+                                    </div>
+                                    <p class="text-xs text-slate-500" x-text="entry.assigned_user || entry.assigned_team || 'Keine Zuweisung'"></p>
+                                    <p class="text-xs text-slate-400" x-text="entry.note || ''"></p>
+                                    <p class="text-[11px] text-slate-400" x-text="entry.created_by ? `von ${entry.created_by}` : ''"></p>
+                                </div>
+                            </template>
+                            <p x-show="assetAssignmentHistory.length === 0" class="text-xs text-slate-400">Noch keine Historie.</p>
+                        </div>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4" x-show="can('attachment.download') || can('attachment.upload')">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-slate-900">Anhänge</p>
+                                <p class="text-xs text-slate-500">Dateien zum Asset</p>
+                            </div>
+                            <i data-feather="paperclip" class="w-4 h-4 text-slate-400"></i>
+                        </div>
+                        <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+                            <label x-show="can('attachment.upload')" class="inline-flex w-full cursor-pointer items-center justify-center rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 sm:w-auto">
+                                <span>Datei hochladen</span>
+                                <input type="file" class="hidden" @change="uploadAssetAttachment">
+                            </label>
+                            <p class="text-xs text-rose-600" x-show="assetAttachmentError" x-text="assetAttachmentError"></p>
+                        </div>
+                        <div class="mt-4 space-y-3">
+                            <template x-for="attachment in assetAttachments" :key="attachment.id">
+                                <div class="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2">
+                                    <div class="flex items-start justify-between gap-2">
+                                        <div class="min-w-0">
+                                            <p class="break-words text-sm font-semibold text-slate-800" x-text="attachment.original_filename"></p>
+                                            <p class="text-xs text-slate-500" x-text="`${formatFileSize(attachment.size_bytes)} • ${attachment.uploaded_by || 'System'}`"></p>
+                                        </div>
+                                        <div class="flex shrink-0 items-center gap-2">
+                                            <a :href="attachment.download_url" class="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-100">Download</a>
+                                            <button x-show="can('attachment.delete')" @click="deleteAssetAttachment(attachment.id)" class="rounded-full border border-rose-200 px-3 py-1 text-xs font-semibold text-rose-600 hover:bg-rose-50">Löschen</button>
+                                        </div>
+                                    </div>
+                                    <p class="text-xs text-slate-400" x-text="attachment.created_at?.slice(0, 16).replace('T', ' ')"></p>
+                                </div>
+                            </template>
+                            <p x-show="assetAttachments.length === 0" class="text-xs text-slate-400">Keine Anhänge vorhanden.</p>
+                        </div>
+                    </div>
                 </div>
             </div>
+        </div>
+    </div>
+
+    <div x-show="assignmentModalOpen" @click.away="closeAssetAssignmentModal()" class="modal fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50 p-4" x-transition>
+        <div class="modal-panel bg-white w-full max-w-lg rounded-t-3xl sm:rounded-3xl shadow-2xl">
+            <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Asset Aktion</p>
+                    <h3 class="text-lg font-semibold text-slate-900" x-text="assignmentAction === 'checkout' ? 'Asset ausgeben' : assignmentAction === 'checkin' ? 'Asset einchecken' : assignmentAction === 'unassign' ? 'Zuweisung entfernen' : 'Asset zuweisen'"></h3>
+                </div>
+                <button @click="closeAssetAssignmentModal()" data-modal-close class="icon-button text-slate-400 hover:text-slate-600" aria-label="Assignment-Modal schließen">
+                    <i data-feather="x" class="w-5 h-5"></i>
+                </button>
+            </div>
+            <form @submit.prevent="submitAssetAssignment()" class="space-y-4 p-6">
+                <div x-show="assignmentAction === 'assign' || assignmentAction === 'checkout'" class="space-y-3">
+                    <div>
+                        <label class="text-xs font-semibold text-slate-500">Benutzer</label>
+                        <select x-model="assignmentForm.assigned_to_user_id" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                            <option value="">Kein Benutzer</option>
+                            <template x-for="user in assignmentOptions.users" :key="user.id">
+                                <option :value="user.id" x-text="user.username"></option>
+                            </template>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="text-xs font-semibold text-slate-500">Team</label>
+                        <select x-model="assignmentForm.assigned_to_team_id" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                            <option value="">Kein Team</option>
+                            <template x-for="team in assignmentOptions.teams" :key="team.id">
+                                <option :value="team.id" x-text="team.name"></option>
+                            </template>
+                        </select>
+                        <p class="mt-1 text-[11px] text-slate-400">Bitte nur eine Auswahl treffen.</p>
+                    </div>
+                </div>
+                <div x-show="assignmentAction === 'checkout'">
+                    <label class="text-xs font-semibold text-slate-500">Fällig am</label>
+                    <input type="date" x-model="assignmentForm.due_at" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm">
+                </div>
+                <div>
+                    <label class="text-xs font-semibold text-slate-500">Notiz</label>
+                    <textarea rows="3" x-model="assignmentForm.note" class="mt-1 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm" placeholder="Optionaler Hinweis"></textarea>
+                </div>
+                <div class="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                    <button type="button" @click="closeAssetAssignmentModal()" class="w-full rounded-2xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 sm:w-auto">Abbrechen</button>
+                    <button type="submit" class="w-full rounded-2xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 sm:w-auto">Speichern</button>
+                </div>
+            </form>
         </div>
     </div>
 

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -352,6 +352,41 @@
                                         </div>
                                     </div>
 
+                                    <div class="mt-5 rounded-2xl border border-slate-200 bg-white p-4" x-show="can('attachment.download') || can('attachment.upload')">
+                                        <div class="flex items-center justify-between">
+                                            <div>
+                                                <p class="text-xs uppercase text-slate-400">Anhänge</p>
+                                                <p class="text-sm font-semibold text-slate-700">Dateien zum Ticket</p>
+                                            </div>
+                                            <i data-feather="paperclip" class="w-4 h-4 text-slate-400"></i>
+                                        </div>
+                                        <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+                                            <label x-show="can('attachment.upload')" class="inline-flex w-full cursor-pointer items-center justify-center rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 sm:w-auto">
+                                                <span>Datei hochladen</span>
+                                                <input type="file" class="hidden" @change="uploadTicketAttachment">
+                                            </label>
+                                            <p class="text-xs text-rose-600" x-show="ticketAttachmentError" x-text="ticketAttachmentError"></p>
+                                        </div>
+                                        <div class="mt-4 space-y-3">
+                                            <template x-for="attachment in ticketAttachments" :key="attachment.id">
+                                                <div class="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2">
+                                                    <div class="flex items-start justify-between gap-2">
+                                                        <div class="min-w-0">
+                                                            <p class="break-words text-sm font-semibold text-slate-800" x-text="attachment.original_filename"></p>
+                                                            <p class="text-xs text-slate-500" x-text="`${formatFileSize(attachment.size_bytes)} • ${attachment.uploaded_by || 'System'}`"></p>
+                                                        </div>
+                                                        <div class="flex shrink-0 items-center gap-2">
+                                                            <a :href="attachment.download_url" class="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-100">Download</a>
+                                                            <button x-show="can('attachment.delete')" @click="deleteTicketAttachment(attachment.id)" class="rounded-full border border-rose-200 px-3 py-1 text-xs font-semibold text-rose-600 hover:bg-rose-50">Löschen</button>
+                                                        </div>
+                                                    </div>
+                                                    <p class="text-xs text-slate-400" x-text="attachment.created_at?.slice(0, 16).replace('T', ' ')"></p>
+                                                </div>
+                                            </template>
+                                            <p x-show="ticketAttachments.length === 0" class="text-xs text-slate-400">Keine Anhänge vorhanden.</p>
+                                        </div>
+                                    </div>
+
                                     <div class="mt-5 rounded-2xl border border-slate-200 bg-white p-4" x-show="can('roadmap.view') || can('roadmap.manage')">
                                         <div class="flex items-center justify-between gap-3">
                                             <div>

--- a/tests/test_asset_assignments.py
+++ b/tests/test_asset_assignments.py
@@ -1,0 +1,109 @@
+import tempfile
+from pathlib import Path
+import unittest
+
+import app as inventory_app
+
+
+class AssetAssignmentTestCase(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        temp_path = Path(self.temp_dir.name)
+        inventory_app.DATABASE = str(temp_path / "test_inventory.db")
+        inventory_app.UPLOADS_DIR = temp_path / "uploads"
+        inventory_app.APP_INSTANCE_PATH = temp_path / "instance"
+        inventory_app.RUNTIME_CONFIG_PATH = temp_path / "runtime_config.json"
+        inventory_app.RUNTIME_SETTINGS_CACHE = {
+            "host": "127.0.0.1",
+            "port": 0,
+            "debug": False,
+        }
+
+        with inventory_app.app.app_context():
+            inventory_app.init_db()
+            db = inventory_app.get_db()
+            password_hash = inventory_app.generate_password_hash("secret1234")
+            admin_id = db.execute(
+                "INSERT INTO users (username, password_hash) VALUES (?, ?)",
+                ("test_admin", password_hash),
+            ).lastrowid
+            inventory_app.assign_user_role(db, admin_id, "Admin")
+            assignee_id = db.execute(
+                "INSERT INTO users (username, password_hash) VALUES (?, ?)",
+                ("assignee", password_hash),
+            ).lastrowid
+            viewer_id = db.execute(
+                "INSERT INTO users (username, password_hash) VALUES (?, ?)",
+                ("viewer", password_hash),
+            ).lastrowid
+            inventory_app.assign_user_role(db, viewer_id, "Kunde")
+            team_id = db.execute(
+                "INSERT INTO teams (name) VALUES (?)",
+                ("IT Team",),
+            ).lastrowid
+            asset_id = db.execute(
+                "INSERT INTO assets (name, notes, specs) VALUES (?, ?, ?)",
+                ("Laptop", "Test", "{}"),
+            ).lastrowid
+            db.commit()
+            self.asset_id = asset_id
+            self.assignee_id = assignee_id
+            self.team_id = team_id
+
+        self.client = inventory_app.app.test_client()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def login(self, username="test_admin", password="secret1234"):
+        return self.client.post("/login", data={"username": username, "password": password})
+
+    def test_assignment_checkout_checkin_flow(self):
+        self.login()
+        assign_response = self.client.post(
+            f"/assets/{self.asset_id}/assign",
+            json={"assigned_to_user_id": self.assignee_id, "note": "Start"},
+        )
+        self.assertEqual(assign_response.status_code, 200)
+        payload = assign_response.get_json()
+        self.assertEqual(payload["assignment"]["status"], "assigned")
+
+        checkout_response = self.client.post(
+            f"/assets/{self.asset_id}/checkout",
+            json={
+                "assigned_to_user_id": self.assignee_id,
+                "due_at": "2024-12-31",
+                "note": "Ausgabe",
+            },
+        )
+        self.assertEqual(checkout_response.status_code, 200)
+        payload = checkout_response.get_json()
+        self.assertEqual(payload["assignment"]["status"], "checked_out")
+
+        checkin_response = self.client.post(
+            f"/assets/{self.asset_id}/checkin",
+            json={"note": "Zurück"},
+        )
+        self.assertEqual(checkin_response.status_code, 200)
+        payload = checkin_response.get_json()
+        self.assertEqual(payload["assignment"]["status"], "checked_in")
+
+    def test_checkin_requires_checkout(self):
+        self.login()
+        response = self.client.post(
+            f"/assets/{self.asset_id}/checkin",
+            json={"note": "Ohne Checkout"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_rbac_blocks_assignment(self):
+        self.login(username="viewer", password="secret1234")
+        response = self.client.post(
+            f"/assets/{self.asset_id}/assign",
+            json={"assigned_to_team_id": self.team_id},
+        )
+        self.assertEqual(response.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,0 +1,158 @@
+import io
+import tempfile
+from pathlib import Path
+import unittest
+
+import app as inventory_app
+
+
+class AttachmentTestCase(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        temp_path = Path(self.temp_dir.name)
+        inventory_app.DATABASE = str(temp_path / "test_inventory.db")
+        inventory_app.UPLOADS_DIR = temp_path / "uploads"
+        inventory_app.APP_INSTANCE_PATH = temp_path / "instance"
+        inventory_app.RUNTIME_CONFIG_PATH = temp_path / "runtime_config.json"
+        inventory_app.RUNTIME_SETTINGS_CACHE = {
+            "host": "127.0.0.1",
+            "port": 0,
+            "debug": False,
+        }
+
+        with inventory_app.app.app_context():
+            inventory_app.init_db()
+            db = inventory_app.get_db()
+            password_hash = inventory_app.generate_password_hash("secret1234")
+            admin_id = db.execute(
+                "INSERT INTO users (username, password_hash) VALUES (?, ?)",
+                ("test_admin", password_hash),
+            ).lastrowid
+            inventory_app.assign_user_role(db, admin_id, "Admin")
+            viewer_id = db.execute(
+                "INSERT INTO users (username, password_hash) VALUES (?, ?)",
+                ("viewer", password_hash),
+            ).lastrowid
+            inventory_app.assign_user_role(db, viewer_id, "Kunde")
+            asset_id = db.execute(
+                "INSERT INTO assets (name, notes, specs) VALUES (?, ?, ?)",
+                ("Router", "Test", "{}"),
+            ).lastrowid
+            ticket_category_id = db.execute("SELECT id FROM ticket_categories LIMIT 1").fetchone()["id"]
+            ticket_id = db.execute(
+                """
+                INSERT INTO tickets (title, description, category_id, priority, status, created_by, requester_name, requester_email)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "Ticket",
+                    "Desc",
+                    ticket_category_id,
+                    "normal",
+                    "open",
+                    "viewer",
+                    "Viewer",
+                    "viewer@example.com",
+                ),
+            ).lastrowid
+            db.commit()
+            self.asset_id = asset_id
+            self.ticket_id = ticket_id
+
+        self.client = inventory_app.app.test_client()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def login(self, username="test_admin", password="secret1234"):
+        return self.client.post("/login", data={"username": username, "password": password})
+
+    def test_upload_blocks_disallowed_extension(self):
+        self.login()
+        data = {
+            "entity_type": "asset",
+            "entity_id": str(self.asset_id),
+            "file": (io.BytesIO(b"alert('x');"), "evil.js"),
+        }
+        response = self.client.post("/attachments/upload", data=data, content_type="multipart/form-data")
+        self.assertEqual(response.status_code, 400)
+
+    def test_upload_allows_pdf(self):
+        self.login()
+        data = {
+            "entity_type": "asset",
+            "entity_id": str(self.asset_id),
+            "file": (io.BytesIO(b"%PDF-1.4 test"), "manual.pdf"),
+        }
+        response = self.client.post("/attachments/upload", data=data, content_type="multipart/form-data")
+        self.assertEqual(response.status_code, 201)
+        payload = response.get_json()
+        self.assertEqual(payload["original_filename"], "manual.pdf")
+
+    def test_upload_size_limit(self):
+        self.login()
+        original_limit = inventory_app.MAX_UPLOAD_BYTES
+        inventory_app.MAX_UPLOAD_BYTES = 10
+        try:
+            data = {
+                "entity_type": "asset",
+                "entity_id": str(self.asset_id),
+                "file": (io.BytesIO(b"0123456789ABC"), "big.txt"),
+            }
+            response = self.client.post("/attachments/upload", data=data, content_type="multipart/form-data")
+            self.assertEqual(response.status_code, 400)
+        finally:
+            inventory_app.MAX_UPLOAD_BYTES = original_limit
+
+    def test_upload_sanitizes_filename(self):
+        self.login()
+        data = {
+            "entity_type": "asset",
+            "entity_id": str(self.asset_id),
+            "file": (io.BytesIO(b"test"), "../notes.txt"),
+        }
+        response = self.client.post("/attachments/upload", data=data, content_type="multipart/form-data")
+        self.assertEqual(response.status_code, 201)
+        payload = response.get_json()
+        self.assertEqual(payload["original_filename"], "notes.txt")
+
+    def test_attachment_permissions(self):
+        self.login(username="viewer", password="secret1234")
+        data = {
+            "entity_type": "asset",
+            "entity_id": str(self.asset_id),
+            "file": (io.BytesIO(b"note"), "note.txt"),
+        }
+        response = self.client.post("/attachments/upload", data=data, content_type="multipart/form-data")
+        self.assertEqual(response.status_code, 403)
+
+    def test_ticket_download_requires_permission(self):
+        self.login()
+        data = {
+            "entity_type": "ticket",
+            "entity_id": str(self.ticket_id),
+            "file": (io.BytesIO(b"test"), "note.txt"),
+        }
+        upload_response = self.client.post("/attachments/upload", data=data, content_type="multipart/form-data")
+        attachment_id = upload_response.get_json()["id"]
+
+        self.client = inventory_app.app.test_client()
+        self.login(username="viewer", password="secret1234")
+        download_response = self.client.get(f"/attachments/{attachment_id}/download")
+        self.assertEqual(download_response.status_code, 403)
+
+    def test_admin_can_download_attachment(self):
+        self.login()
+        data = {
+            "entity_type": "asset",
+            "entity_id": str(self.asset_id),
+            "file": (io.BytesIO(b"manual"), "manual.txt"),
+        }
+        upload_response = self.client.post("/attachments/upload", data=data, content_type="multipart/form-data")
+        attachment_id = upload_response.get_json()["id"]
+        download_response = self.client.get(f"/attachments/{attachment_id}/download")
+        self.assertEqual(download_response.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Ergänzen des Asset-Workflows um Zuweisung, Checkout/Check‑in und Historie, damit Verantwortlichkeiten und Rückgaben auditierbar sind.
- Ermöglichen von sicheren Dateianhängen an Assets, Tickets und Wartungsaufgaben zur besseren Dokumentation.
- Integration mit existierendem RBAC/Audit-Log-Pattern, ohne existierende Routen zu brechen.

### Description
- DB: Neue Tabellen `asset_assignment_history` und `attachments` wurden in `ensure_schema()` angelegt und Export/Import um diese Tabellen erweitert; zusätzlich `MAX_UPLOAD_BYTES` und Whitelist/Blocklist für Dateiendungen eingeführt (`app.py`).
- Backend: Neue API/HTML-Endpunkte für Zuweisungen und Lifecycle: `POST /assets/<id>/assign`, `/checkout`, `/checkin`, `/unassign`, `GET /assets/<id>/history`; Attachment-APIs: `POST /attachments/upload`, `GET /attachments`, `GET /attachments/<id>/download`, `POST /attachments/<id>/delete`; alle Endpunkte verwenden bestehende `login_required`/`require_permission`-Mechanismen und schreiben Audit-Events (`ASSET_ASSIGNED`, `ASSET_CHECKED_OUT`, `ASSET_CHECKED_IN`, `ATTACHMENT_UPLOADED`, `ATTACHMENT_DELETED`).
- UI: Asset-Detail erweitert (modal) mit Assignment/Checkout-Buttons, Assignment-Historie-Panel, Attachment-Section und responsiven modals/bottom-sheet patterns; Ticket- und Maintenance-Detailseiten bekommen Attachment-Upload/List/Delete UI hooks; Alpine state and helpers wurden ergänzt in `static/script.js` und `static/tickets.js` to drive the new flows.
- Security: Filename sanitization with `secure_filename`, size limits, extension whitelist/blocklist, optional AV-hook reuse (`INVENTORY_ANTIVIRUS_COMMAND`), and permission checks that reuse `ensure_attachment_entity_access` to validate access to asset/ticket/maintenance entities.
- Tests & Docs: Neue pytest files `tests/test_asset_assignments.py` and `tests/test_attachments.py` covering state transitions, RBAC, upload rules and size/filename handling; README updated with new env var and permissions.

### Testing
- Unit/Integration: Ran `PYTHONPATH=. pytest -q tests/test_asset_assignments.py tests/test_attachments.py` and all tests passed (`10 passed`) locally against a temporary SQLite instance and temporary upload dirs.
- Dependency install: Ensured required packages from `requirements.txt` were available when running tests (installed `apscheduler`, `cryptography`, `playwright` as part of test setup where needed).
- Manual UI smoke: Spawned the app and exercised the Asset modal to verify assignment/attachment UI flows (screenshot artifact created during verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69764fde7bac8331bdd730ad13e518a2)