### PR TITLE
Fix asset assignment modal click handling

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1016,7 +1016,7 @@
         </div>
     </div>
 
-    <div x-show="assignmentModalOpen" @click.away="closeAssetAssignmentModal()" class="modal fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50 p-4" x-transition>
+    <div x-show="assignmentModalOpen" @click.self="closeAssetAssignmentModal()" class="modal fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50 p-4" x-transition>
         <div class="modal-panel bg-white w-full max-w-lg rounded-t-3xl sm:rounded-3xl shadow-2xl">
             <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
                 <div>


### PR DESCRIPTION
### Motivation
- Prevent the assignment modal from closing when interacting with its form controls by ensuring only clicks on the overlay/backdrop close it.

### Description
- Replace `@click.away="closeAssetAssignmentModal()"` with `@click.self="closeAssetAssignmentModal()"` in `templates/index.html` so only clicks directly on the modal backdrop (overlay) trigger closing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6976598cbf0c832ebe5fcbf673704783)