### PR TITLE
Prevent asset detail modal from closing while assignment modal is open

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -784,7 +784,7 @@
         </div>
     </div>
 
-    <div x-show="assetDetailOpen" @click.away="closeAssetDetail()" class="modal fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-6" x-transition>
+    <div x-show="assetDetailOpen" @click.away="if (!assignmentModalOpen) { closeAssetDetail() }" class="modal fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-6" x-transition>
         <div class="modal-panel bg-white rounded-3xl shadow-2xl w-full max-w-4xl max-h-[90vh] overflow-y-auto scrollbar-hide">
             <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
                 <div>
@@ -1016,7 +1016,7 @@
         </div>
     </div>
 
-    <div x-show="assignmentModalOpen" @click.away="closeAssetAssignmentModal()" class="modal fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50 p-4" x-transition>
+    <div x-show="assignmentModalOpen" @click.self="closeAssetAssignmentModal()" class="modal fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50 p-4" x-transition>
         <div class="modal-panel bg-white w-full max-w-lg rounded-t-3xl sm:rounded-3xl shadow-2xl">
             <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
                 <div>


### PR DESCRIPTION
### Motivation
- The asset detail modal was being closed when interacting with the assignment modal because `@click.away` on the asset detail responded to clicks that occurred inside the nested assignment modal.

### Description
- Update `templates/index.html` to guard the asset detail backdrop handler by changing `@click.away="closeAssetDetail()"` to `@click.away="if (!assignmentModalOpen) { closeAssetDetail() }"` so the detail modal won't close while the assignment modal is open.
- Change the assignment modal backdrop handler from `@click.away="closeAssetAssignmentModal()"` to `@click.self="closeAssetAssignmentModal()"` so only clicks on the overlay (not inside the form) close the assignment modal.
- These changes ensure clicks inside the assignment form or other controls do not unintentionally close either modal.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6976598cbf0c832ebe5fcbf673704783)