### PR TITLE
PondSec AI: ticket ID parsing, selection UX, and write-tools

### DIFF
--- a/pondsec_ai/blueprints.py
+++ b/pondsec_ai/blueprints.py
@@ -6,6 +6,7 @@ import json
 from . import context
 from .db import get_agent_settings, update_agent_settings
 from .policy import approve_action, reject_action
+from .registry import TOOL_REGISTRY
 from .runtime import AgentRuntime
 
 ai_bp = Blueprint("pondsec_ai", __name__)
@@ -86,6 +87,18 @@ def ai_settings():
     settings = get_agent_settings(db)
     roles = db.execute('SELECT id, name, is_superuser FROM roles ORDER BY name').fetchall()
     tools = db.execute('SELECT * FROM agent_tool_permissions ORDER BY tool_name').fetchall()
+    tool_rows = [dict(row) for row in tools]
+    existing_keys = {(row["role_id"], row["tool_name"]) for row in tool_rows}
+    for tool_name, tool_def in TOOL_REGISTRY.items():
+        key = (None, tool_name)
+        if key not in existing_keys:
+            tool_rows.append({
+                "role_id": None,
+                "tool_name": tool_name,
+                "allowed": 0,
+                "risk_level": tool_def.risk,
+                "require_approval": 0,
+            })
     return render_template(
         "ai_settings.html",
         username=session.get("username"),
@@ -93,7 +106,7 @@ def ai_settings():
         is_superuser=access["is_superuser"],
         settings=settings,
         roles=[dict(row) for row in roles],
-        tool_permissions=[dict(row) for row in tools],
+        tool_permissions=sorted(tool_rows, key=lambda row: row["tool_name"]),
     )
 
 

--- a/pondsec_ai/context.py
+++ b/pondsec_ai/context.py
@@ -1,4 +1,5 @@
 """Shared app context references for PondSec AI."""
+import re
 
 get_db = None
 get_user_access = None
@@ -9,6 +10,22 @@ login_required = None
 require_permission = None
 require_permissions = None
 app = None
+
+
+def parse_entity_refs(message):
+    if not message:
+        return {}
+    patterns = {
+        "ticket_id": r"\b(?:ticket|Ticket)\s*#?\s*(\d+)\b",
+        "asset_id": r"\b(?:asset|gerät|geraet|device)\s*#?\s*(\d+)\b",
+        "kb_id": r"\b(?:kb|knowledge\s*base|wissensbasis)\s*#?\s*(\d+)\b",
+    }
+    refs = {}
+    for key, pattern in patterns.items():
+        match = re.search(pattern, message)
+        if match:
+            refs[key] = int(match.group(1))
+    return refs
 
 
 def init(

--- a/pondsec_ai/db.py
+++ b/pondsec_ai/db.py
@@ -139,6 +139,10 @@ def seed_default_tool_permissions(db):
     roles = db.execute('SELECT id, is_superuser FROM roles').fetchall()
     superuser_roles = [row["id"] for row in roles if row["is_superuser"]]
     read_tools = [name for name, tool in TOOL_REGISTRY.items() if not tool.is_write]
+    default_write_tools = {
+        "ticket.add_comment",
+        "alert.create",
+    }
     now = datetime.utcnow().isoformat()
     for tool_name in read_tools:
         tool = TOOL_REGISTRY[tool_name]
@@ -151,6 +155,20 @@ def seed_default_tool_permissions(db):
                 VALUES (?, ?, 1, ?, 0)
                 ''',
                 (role_id, tool_name, tool.risk)
+            )
+    for tool_name in default_write_tools:
+        tool = TOOL_REGISTRY.get(tool_name)
+        if not tool:
+            continue
+        target_roles = superuser_roles or [None]
+        for role_id in target_roles:
+            db.execute(
+                '''
+                INSERT OR IGNORE INTO agent_tool_permissions
+                    (role_id, tool_name, allowed, risk_level, require_approval)
+                VALUES (?, ?, 1, ?, 0)
+                ''',
+                (role_id, tool_name, tool.risk),
             )
     db.execute('UPDATE agent_settings SET updated_at = ? WHERE id = 1', (now,))
     db.commit()

--- a/pondsec_ai/planner.py
+++ b/pondsec_ai/planner.py
@@ -25,31 +25,63 @@ class DeterministicFallbackPlanner(Planner):
         wants_summary = any(keyword in message for keyword in ("fasse", "zusammenfassung", "zusammenfassen"))
         wants_internal_note = any(keyword in message for keyword in ("interne notiz", "interner kommentar", "internal note", "notiz erstellen"))
         wants_next_steps = any(keyword in message for keyword in ("nächste schritte", "next steps"))
+        wants_resolution = bool(re.search(r"(wie\s+löse|wie\s+loese|lösen|loesen|resolve|fix|beheben)", message))
 
         if ticket_ctx.get("type") == "ticket" and ticket_id:
-            if wants_summary:
-                # Provide a short, safe summary without executing tools.
-                title = ticket_data.get("title") or "Ticket"
-                priority = ticket_data.get("priority") or "unbekannt"
-                status = ticket_data.get("status") or "unbekannt"
-                description = (ticket_data.get("description") or "").strip()
-                description = description[:240] + ("…" if len(description) > 240 else "")
+            title = ticket_data.get("title") or "Ticket"
+            priority = ticket_data.get("priority") or "unbekannt"
+            status = ticket_data.get("status") or "unbekannt"
+            description = (ticket_data.get("description") or "").strip()
+            description = description[:240] + ("…" if len(description) > 240 else "")
+            next_steps = (
+                "1) Problem und Scope bestätigen\n"
+                "2) Priorität/SLA prüfen und zuständige Person festlegen\n"
+                "3) Reproduktion/Logs sammeln\n"
+                "4) Lösungsschritte durchführen und dokumentieren\n"
+                "5) Rückmeldung geben und Ticket abschließen"
+            )
+
+            if wants_summary or wants_resolution:
                 plan["summary"] = (
                     f"Zusammenfassung: {title} (Status: {status}, Priorität: {priority}). "
-                    f"{description or 'Keine Beschreibung vorhanden.'}"
+                    f"{description or 'Keine Beschreibung vorhanden.'}\n\n"
+                    f"Vermutete nächste Schritte:\n{next_steps}"
                 )
 
-            if wants_internal_note or wants_next_steps:
+            if wants_summary or wants_resolution or wants_internal_note or wants_next_steps:
+                plan["steps"].append({
+                    "title": "Ticket laden",
+                    "tool": "ticket.get",
+                    "input": {
+                        "ticket_id": ticket_id,
+                    },
+                })
+
+            if wants_internal_note or wants_next_steps or wants_resolution:
                 plan["summary"] = plan["summary"] or "Nächste Schritte für das Ticket."
                 plan["steps"].append({
                     "title": "Interne Notiz hinzufügen",
-                    "tool": "ticket.comment",
+                    "tool": "ticket.add_comment",
                     "input": {
                         "ticket_id": ticket_id,
-                        "body": "Nächste Schritte: Ticket priorisieren, Verantwortliche:n festlegen, SLA prüfen und Rückmeldung an den/die Anfragende:n geben.",
-                        "internal_note": True,
+                        "body": f"Nächste Schritte:\n{next_steps}",
+                        "internal": True,
                     },
                 })
+        elif ticket_ctx.get("type") in {"tickets", "ticket_list"}:
+            cleaned = re.sub(r"(ticket|#|\d+)", " ", message, flags=re.IGNORECASE).strip()
+            plan["summary"] = (
+                "Ich sehe eine Ticket-Liste. Bitte nenne eine Ticket-ID oder wähle ein Ticket aus. "
+                "Ich kann sonst nach passenden Tickets suchen."
+            )
+            plan["steps"].append({
+                "title": "Ticket-Suche vorschlagen",
+                "tool": "ticket.search",
+                "input": {
+                    "query": cleaned or message.strip(),
+                    "limit": 5,
+                },
+            })
 
         if re.search(r"(urgent|kritisch|sofort|sla)", message):
             plan["summary"] = plan["summary"] or "Dringlichkeits-Alert erstellen"

--- a/pondsec_ai/runtime.py
+++ b/pondsec_ai/runtime.py
@@ -50,19 +50,61 @@ class AgentRuntime:
         access = user_ctx.get("access") or {}
         ui_ctx = (ui_context or {}).get("ui_context") or {}
         entity_ctx = (ui_context or {}).get("context") or {}
+        parsed_refs = context.parse_entity_refs(message)
+        explicit_ticket_id = parsed_refs.get("ticket_id")
+        effective_context = dict(entity_ctx) if entity_ctx else {}
+        list_types = {"tickets", "ticket_list", "unknown"}
+        if explicit_ticket_id and (not effective_context or effective_context.get("type") in list_types):
+            effective_context = {"type": "ticket", "id": explicit_ticket_id}
         context_payload = {
             "ui_context": ui_ctx,
-            "context": entity_ctx,
+            "context": effective_context,
             "entity_refs": ui_ctx.get("entity_refs", []) if ui_ctx else [],
-            "ticket_id": entity_ctx.get("id") if entity_ctx.get("type") == "ticket" else None,
+            "ticket_id": effective_context.get("id") if effective_context.get("type") == "ticket" else None,
         }
+        if explicit_ticket_id and not any(
+            ref.get("type") == "ticket" and ref.get("id") == explicit_ticket_id
+            for ref in context_payload["entity_refs"]
+        ):
+            context_payload["entity_refs"].append({"type": "ticket", "id": explicit_ticket_id})
         if context_payload.get("ticket_id"):
             ticket = self.db.execute(
                 "SELECT id, title, description, status, priority, requester_name, assignee, due_date FROM tickets WHERE id = ?",
                 (context_payload["ticket_id"],),
             ).fetchone()
+            if not ticket and explicit_ticket_id:
+                return {
+                    "insights": (
+                        f"Ich konnte kein Ticket mit der ID #{explicit_ticket_id} finden. "
+                        "Bitte prüfe die ID oder starte eine Suche."
+                    ),
+                    "proposed_actions": [
+                        {
+                            "title": "Ticket-Suche",
+                            "rationale": "Ticket-ID nicht gefunden.",
+                            "risk": "low",
+                            "steps": [{
+                                "tool": "ticket.search",
+                                "input": {
+                                    "query": message.strip() or f"ticket {explicit_ticket_id}",
+                                    "limit": 5,
+                                },
+                            }],
+                            "requires_approval": False,
+                            "status": "proposed",
+                        }
+                    ],
+                    "references": context_payload.get("entity_refs", []),
+                }
             if ticket:
-                context_payload["ticket"] = dict(ticket)
+                ticket_dict = dict(ticket)
+                if not context.ensure_ticket_access(ticket_dict, access):
+                    return {
+                        "insights": "Ich habe keine Berechtigung, dieses Ticket zu sehen.",
+                        "proposed_actions": [],
+                        "references": context_payload.get("entity_refs", []),
+                    }
+                context_payload["ticket"] = ticket_dict
         plan = self.planner.plan(message, context_payload)
         plan_steps = plan.get("steps", [])
         summary = plan.get("summary", "")

--- a/pondsec_ai/tools/tickets.py
+++ b/pondsec_ai/tools/tickets.py
@@ -5,6 +5,37 @@ from .. import context
 from ..registry import agent_tool
 
 
+def _create_ticket_comment(ctx, tool_input, *, internal_flag):
+    db = context.get_db()
+    access = ctx.get("access") or context.get_user_access(db)
+    ticket_id = int(tool_input.get("ticket_id"))
+    body = (tool_input.get("body") or "").strip()
+    if not body:
+        return {"error": "body_required"}
+    ticket = db.execute('SELECT * FROM tickets WHERE id = ?', (ticket_id,)).fetchone()
+    if not ticket:
+        return {"error": "not_found"}
+    if not context.ensure_ticket_access(dict(ticket), access):
+        return {"error": "forbidden"}
+    can_comment = access["is_superuser"] or "tickets.comment" in access["permissions"]
+    can_comment_own = "tickets.comment_own" in access["permissions"]
+    if not can_comment and not (can_comment_own and ticket["created_by"] == ctx.get("user", {}).get("username")):
+        return {"error": "forbidden"}
+    allow_internal = access["is_superuser"] or "tickets.comment_internal" in access["permissions"]
+    is_internal = 1 if allow_internal and internal_flag else 0
+    db.execute(
+        '''
+        INSERT INTO ticket_comments (ticket_id, author, body, is_internal)
+        VALUES (?, ?, ?, ?)
+        ''',
+        (ticket_id, ctx.get("user", {}).get("username"), body, is_internal),
+    )
+    db.execute('UPDATE tickets SET updated_at = CURRENT_TIMESTAMP WHERE id = ?', (ticket_id,))
+    context.log_activity(db, "comment", "ticket", ticket_id)
+    db.commit()
+    return {"status": "created", "ticket_id": ticket_id}
+
+
 @agent_tool(
     "ticket.search",
     schema={"query": "str", "limit": "int"},
@@ -59,34 +90,18 @@ def ticket_get(ctx, tool_input):
     is_write=True,
 )
 def ticket_comment(ctx, tool_input):
-    db = context.get_db()
-    access = ctx.get("access") or context.get_user_access(db)
-    ticket_id = int(tool_input.get("ticket_id"))
-    body = (tool_input.get("body") or "").strip()
-    if not body:
-        return {"error": "body_required"}
-    ticket = db.execute('SELECT * FROM tickets WHERE id = ?', (ticket_id,)).fetchone()
-    if not ticket:
-        return {"error": "not_found"}
-    if not context.ensure_ticket_access(dict(ticket), access):
-        return {"error": "forbidden"}
-    can_comment = access["is_superuser"] or "tickets.comment" in access["permissions"]
-    can_comment_own = "tickets.comment_own" in access["permissions"]
-    if not can_comment and not (can_comment_own and ticket["created_by"] == ctx.get("user", {}).get("username")):
-        return {"error": "forbidden"}
-    allow_internal = access["is_superuser"] or "tickets.comment_internal" in access["permissions"]
-    is_internal = 1 if allow_internal and tool_input.get("internal_note") else 0
-    db.execute(
-        '''
-        INSERT INTO ticket_comments (ticket_id, author, body, is_internal)
-        VALUES (?, ?, ?, ?)
-        ''',
-        (ticket_id, ctx.get("user", {}).get("username"), body, is_internal),
-    )
-    db.execute('UPDATE tickets SET updated_at = CURRENT_TIMESTAMP WHERE id = ?', (ticket_id,))
-    context.log_activity(db, "comment", "ticket", ticket_id)
-    db.commit()
-    return {"status": "created", "ticket_id": ticket_id}
+    return _create_ticket_comment(ctx, tool_input, internal_flag=bool(tool_input.get("internal_note")))
+
+
+@agent_tool(
+    "ticket.add_comment",
+    schema={"ticket_id": "int", "body": "str", "internal": "bool"},
+    required=["ticket_id", "body"],
+    requires_perm="tickets.comment",
+    is_write=True,
+)
+def ticket_add_comment(ctx, tool_input):
+    return _create_ticket_comment(ctx, tool_input, internal_flag=bool(tool_input.get("internal")))
 
 
 @agent_tool(

--- a/templates/pondsec_ai_drawer.html
+++ b/templates/pondsec_ai_drawer.html
@@ -1,7 +1,7 @@
 <script>
     window.pondsecUiContext = {{ pondsec_ai_ui_context | tojson }};
     if (!window.PONDSEC_AI_CONTEXT) {
-        window.PONDSEC_AI_CONTEXT = { type: window.pondsecUiContext?.page || 'global' };
+        window.PONDSEC_AI_CONTEXT = { type: 'unknown' };
     }
 </script>
 <div id="pondsec-ai-overlay" class="fixed inset-0 bg-slate-900/40 hidden z-40"></div>
@@ -18,6 +18,14 @@
     <div class="p-6 space-y-4 h-[calc(100%-4rem)] overflow-y-auto">
         <div class="flex flex-wrap gap-2 text-xs text-slate-500" id="pondsec-ai-context">
             <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1">Kontext: <span id="pondsec-ai-context-text"></span></span>
+        </div>
+        <div id="pondsec-ai-selection" class="rounded-2xl border border-slate-200 bg-slate-50 p-4 space-y-2 hidden">
+            <p class="text-xs font-semibold text-slate-600">Ticket auswählen</p>
+            <div class="flex items-center gap-2">
+                <input id="pondsec-ai-select-ticket" type="number" min="1" class="w-24 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm" placeholder="#ID">
+                <button type="button" id="pondsec-ai-select-ticket-btn" class="rounded-xl bg-indigo-600 px-3 py-2 text-xs font-semibold text-white hover:bg-indigo-500">Auswählen</button>
+            </div>
+            <p class="text-xs text-slate-500">Tipp: Alternativ kannst du im Text „ticket #123“ angeben.</p>
         </div>
         <div>
             <label class="text-xs font-semibold text-slate-500">Nachricht</label>
@@ -47,6 +55,9 @@
     const insightsEl = document.getElementById('pondsec-ai-insights');
     const actionsEl = document.getElementById('pondsec-ai-actions');
     const contextText = document.getElementById('pondsec-ai-context-text');
+    const selectionPanel = document.getElementById('pondsec-ai-selection');
+    const selectTicketInput = document.getElementById('pondsec-ai-select-ticket');
+    const selectTicketBtn = document.getElementById('pondsec-ai-select-ticket-btn');
     const openButtons = document.querySelectorAll('[data-pondsec-ai-open]');
     const closeButtons = document.querySelectorAll('[data-pondsec-ai-close]');
 
@@ -54,8 +65,16 @@
     const isApprover = (window.inventoryIsSuperuser || false) || permissions.includes('ai.approve');
 
     function setContext() {
-        const ctx = window.pondsecUiContext || {};
-        contextText.textContent = ctx.page || ctx.path || 'global';
+        const ctx = window.PONDSEC_AI_CONTEXT || { type: 'unknown' };
+        if (ctx.type === 'ticket' && ctx.id) {
+            contextText.textContent = `ticket #${ctx.id}`;
+        } else {
+            contextText.textContent = ctx.type || 'unknown';
+        }
+        if (selectionPanel) {
+            const showSelection = ctx.type === 'tickets' && !ctx.id;
+            selectionPanel.classList.toggle('hidden', !showSelection);
+        }
     }
 
     function openDrawer() {
@@ -88,8 +107,7 @@
                 credentials: 'same-origin',
                 body: JSON.stringify({
                     message,
-                    ui_context: window.pondsecUiContext || {},
-                    context: window.PONDSEC_AI_CONTEXT || {}
+                    context: window.PONDSEC_AI_CONTEXT || { type: 'unknown' }
                 })
             });
             const data = await response.json();
@@ -175,6 +193,16 @@
 
     if (sendBtn) {
         sendBtn.addEventListener('click', sendMessage);
+    }
+    if (selectTicketBtn) {
+        selectTicketBtn.addEventListener('click', () => {
+            const value = Number(selectTicketInput?.value || 0);
+            if (!value) {
+                return;
+            }
+            window.PONDSEC_AI_CONTEXT = { type: 'ticket', id: value };
+            setContext();
+        });
     }
 })();
 </script>


### PR DESCRIPTION
### Motivation
- Make PondSec AI functional from ticket list and detail views by reliably binding user messages to concrete entities and not returning the vague "open a ticket" fallback.
- Allow the planner to propose and (when allowed) execute low-risk writes like internal comments and alerts while keeping existing permission gating.
- Provide a small selection UX for list pages and surface all agent tools in settings so admins can enable required tools.

### Description
- Added a robust entity parser `parse_entity_refs(message)` in `pondsec_ai/context.py` to extract `ticket_id`, `asset_id`, and `kb_id` from German/English phrases like "ticket #1".
- Updated `AgentRuntime.handle_user_prompt` to honor explicit IDs found in messages, synthesize an effective `context` (list->ticket), validate ticket existence and access, and return a clear not-found response that proposes `ticket.search` when appropriate (`pondsec_ai/runtime.py`).
- Enhanced the deterministic planner to detect resolution intents (German/English), always load the ticket with `ticket.get` when resolving, and propose an internal comment action using a new `ticket.add_comment` tool; list-context prompts now propose a `ticket.search` step (`pondsec_ai/planner.py`).
- Implemented `ticket.add_comment` and factored comment creation into `_create_ticket_comment` in `pondsec_ai/tools/tickets.py`, keeping RBAC checks and returning structured results; retained existing `ticket.comment` as a wrapper for compatibility.
- Exposed all tools dynamically in the AI settings UI and seeded default permissions for low-risk write tools (`ticket.add_comment`, `alert.create`) for superuser/global roles, and updated the settings blueprint to include missing tools (`pondsec_ai/blueprints.py`, `pondsec_ai/db.py`).
- Improved drawer UI to reliably use `window.PONDSEC_AI_CONTEXT`, show a contextual label like "Kontext: ticket #<id>", and display a small ticket-selection panel on list pages that sets the context before sending (`templates/pondsec_ai_drawer.html`).

### Testing
- Ran repository inspections and code grep/sed checks to verify changes were wired into templates and tool registry (succeeded).
- Attempted to start the app with `python app.py` to run an end-to-end smoke test, but the server failed to start due to a missing dependency: `ModuleNotFoundError: No module named 'apscheduler'` (failed); because of this the runtime end-to-end execution tests (AI chat flows) could not be executed in this environment.
- No automated unit tests were present for the agent flow; changes are limited and permission-checked so follow-up validation steps are: enable the tools in `/ai/settings`, then perform the manual test scenarios from the definition of done (list/detail prompts, non-existent ID behavior, advisor vs autopilot execution).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69766c6ddcc08322930d8fdd265b87f6)