### PR TITLE
Persist local LLM worker process

### DIFF
--- a/pondsec_ai/llm_worker.py
+++ b/pondsec_ai/llm_worker.py
@@ -2,10 +2,14 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
+import time
 from pathlib import Path
 from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 
 def _provider_name() -> str:
@@ -14,9 +18,9 @@ def _provider_name() -> str:
 
 def _max_tokens() -> int:
     try:
-        return int(os.environ.get("PONDSEC_AI_LLM_MAX_TOKENS", "512"))
+        return int(os.environ.get("PONDSEC_AI_LLM_MAX_TOKENS", "128"))
     except ValueError:
-        return 512
+        return 128
 
 
 def _resolve_model_path() -> Tuple[Optional[str], Optional[str]]:
@@ -40,21 +44,40 @@ def _resolve_model_path() -> Tuple[Optional[str], Optional[str]]:
     return None, None
 
 
-def _generate(prompt: str) -> str:
+def _load_model():
     provider = _provider_name()
     model_name, model_dir = _resolve_model_path()
     if not model_name or not model_dir:
         raise RuntimeError("Local LLM model not configured")
-    max_tokens = _max_tokens()
     if provider == "gpt4all":
         from gpt4all import GPT4All
 
         model = GPT4All(model_name, model_path=model_dir)
-        return model.generate(prompt, max_tokens=max_tokens) or ""
-    if provider in {"llamacpp", "llama-cpp"}:
+    elif provider in {"llamacpp", "llama-cpp"}:
         from llama_cpp import Llama
 
         model = Llama(model_path=str(Path(model_dir) / model_name))
+    else:
+        raise RuntimeError(f"Unknown LLM provider: {provider}")
+    return model, provider
+
+
+def _coerce_max_tokens(value: object) -> int:
+    if value is None:
+        return _max_tokens()
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return _max_tokens()
+    if parsed <= 0:
+        return _max_tokens()
+    return parsed
+
+
+def _generate(model, provider: str, prompt: str, max_tokens: int) -> str:
+    if provider == "gpt4all":
+        return model.generate(prompt, max_tokens=max_tokens) or ""
+    if provider in {"llamacpp", "llama-cpp"}:
         output = model(
             prompt,
             max_tokens=max_tokens,
@@ -65,18 +88,53 @@ def _generate(prompt: str) -> str:
     raise RuntimeError(f"Unknown LLM provider: {provider}")
 
 
+def _emit(payload: dict) -> None:
+    sys.stdout.write(json.dumps(payload))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
 def main() -> int:
-    prompt = sys.stdin.read()
-    if not prompt:
-        sys.stdout.write(json.dumps({"text": ""}))
-        return 0
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+    model = None
+    provider = ""
+    load_error: Optional[str] = None
+    start_load = time.monotonic()
     try:
-        text = _generate(prompt)
-        sys.stdout.write(json.dumps({"text": text}))
-        return 0
-    except Exception as exc:
-        sys.stderr.write(str(exc))
-        return 1
+        model, provider = _load_model()
+        elapsed = time.monotonic() - start_load
+        logger.info("LLM model loaded in %.2f seconds", elapsed)
+    except Exception as exc:  # pragma: no cover - logged for runtime visibility
+        load_error = str(exc)
+        logger.exception("LLM model failed to load")
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        request_id = "unknown"
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            _emit({"id": request_id, "error": "invalid_json"})
+            continue
+        request_id = request.get("id") or "unknown"
+        prompt = request.get("prompt") or ""
+        max_tokens = _coerce_max_tokens(request.get("max_tokens"))
+        start = time.monotonic()
+        try:
+            if load_error:
+                raise RuntimeError(load_error)
+            text = _generate(model, provider, prompt, max_tokens)
+            elapsed = time.monotonic() - start
+            logger.info("LLM generate took %.2f seconds", elapsed)
+            _emit({"id": request_id, "text": text})
+        except Exception as exc:  # pragma: no cover - runtime safety
+            elapsed = time.monotonic() - start
+            logger.exception("LLM generate failed")
+            logger.info("LLM generate took %.2f seconds", elapsed)
+            _emit({"id": request_id, "error": str(exc)})
+    return 0
 
 
 if __name__ == "__main__":

--- a/pondsec_ai/local_llm.py
+++ b/pondsec_ai/local_llm.py
@@ -5,11 +5,100 @@ import json
 import logging
 import os
 from pathlib import Path
+import select
 import subprocess
 import sys
+import threading
+import uuid
 from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
+
+
+class WorkerClient:
+    _instance: Optional["WorkerClient"] = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._process: Optional[subprocess.Popen[str]] = None
+        self._lock = threading.Lock()
+
+    @classmethod
+    def instance(cls) -> "WorkerClient":
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = cls()
+            return cls._instance
+
+    def _start_worker(self) -> None:
+        env = os.environ.copy()
+        cmd = [sys.executable, "-m", "pondsec_ai.llm_worker"]
+        logger.info("pondsec_ai.local_llm.worker_start provider=%s", LocalLLM._provider_name())
+        self._process = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=None,
+            text=True,
+            bufsize=1,
+            env=env,
+        )
+
+    def _stop_worker(self) -> None:
+        if self._process is None:
+            return
+        if self._process.poll() is None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+        self._process = None
+
+    def _ensure_worker(self) -> None:
+        if self._process is None or self._process.poll() is not None:
+            self._stop_worker()
+            self._start_worker()
+
+    def _readline_with_timeout(self, timeout: float) -> Optional[str]:
+        if self._process is None or self._process.stdout is None:
+            return None
+        stdout = self._process.stdout
+        ready, _, _ = select.select([stdout], [], [], timeout)
+        if not ready:
+            return None
+        return stdout.readline()
+
+    def request(self, prompt: str, max_tokens: int) -> dict:
+        request_id = uuid.uuid4().hex
+        payload = {"id": request_id, "prompt": prompt, "max_tokens": max_tokens}
+        with self._lock:
+            self._ensure_worker()
+            if self._process is None or self._process.stdin is None or self._process.stdout is None:
+                return {"id": request_id, "error": "worker_not_running"}
+            try:
+                self._process.stdin.write(json.dumps(payload) + "\n")
+                self._process.stdin.flush()
+            except BrokenPipeError:
+                logger.warning("pondsec_ai.local_llm.worker_broken_pipe")
+                self._stop_worker()
+                return {"id": request_id, "error": "worker_broken_pipe"}
+            timeout_seconds = LocalLLM._timeout_seconds()
+            line = self._readline_with_timeout(timeout_seconds)
+            if line is None:
+                logger.warning("pondsec_ai.local_llm.worker_timeout")
+                self._stop_worker()
+                return {"id": request_id, "error": "timeout"}
+            if not line:
+                logger.warning("pondsec_ai.local_llm.worker_died")
+                self._stop_worker()
+                return {"id": request_id, "error": "worker_died"}
+            try:
+                response = json.loads(line.strip())
+            except json.JSONDecodeError:
+                logger.warning("pondsec_ai.local_llm.worker_invalid_json")
+                return {"id": request_id, "error": "invalid_json"}
+            return response
 
 
 class LocalLLM:
@@ -24,9 +113,16 @@ class LocalLLM:
     @staticmethod
     def _max_tokens() -> int:
         try:
-            return int(os.environ.get("PONDSEC_AI_LLM_MAX_TOKENS", "512"))
+            return int(os.environ.get("PONDSEC_AI_LLM_MAX_TOKENS", "128"))
         except ValueError:
-            return 512
+            return 128
+
+    @staticmethod
+    def _timeout_seconds() -> float:
+        try:
+            return float(os.environ.get("PONDSEC_AI_LLM_TIMEOUT_SECONDS", "180"))
+        except ValueError:
+            return 180.0
 
     @staticmethod
     def _resolve_model_path() -> Tuple[Optional[str], Optional[str]]:
@@ -106,35 +202,17 @@ class LocalLLM:
         return cls._model
 
     @classmethod
-    def generate(cls, prompt: str, max_tokens: int = 512) -> str:
+    def generate(cls, prompt: str, max_tokens: Optional[int] = None) -> str:
         max_tokens = max_tokens or cls._max_tokens()
         if not prompt:
             return ""
-        env = os.environ.copy()
-        env["PONDSEC_AI_LLM_MAX_TOKENS"] = str(max_tokens)
-        cmd = [sys.executable, "-m", "pondsec_ai.llm_worker"]
-        logger.info("pondsec_ai.local_llm.worker_start provider=%s", cls._provider_name())
-        try:
-            result = subprocess.run(
-                cmd,
-                input=prompt,
-                text=True,
-                capture_output=True,
-                timeout=20,
-                env=env,
-            )
-        except subprocess.TimeoutExpired:
-            logger.warning("pondsec_ai.local_llm.worker_timeout")
-            return ""
-        if result.stderr:
-            logger.warning("pondsec_ai.local_llm.worker_stderr=%s", result.stderr.strip())
-        if result.returncode != 0:
-            logger.warning("pondsec_ai.local_llm.worker_failed code=%s", result.returncode)
-            return ""
-        try:
-            payload = json.loads(result.stdout.strip() or "{}")
-        except json.JSONDecodeError:
-            logger.warning("pondsec_ai.local_llm.worker_invalid_json")
-            return ""
-        text = payload.get("text") or ""
+        client = WorkerClient.instance()
+        response = client.request(prompt, max_tokens)
+        error = response.get("error")
+        if error:
+            logger.warning("pondsec_ai.local_llm.worker_error=%s", error)
+            return json.dumps({"error": error})
+        text = response.get("text")
+        if text is None:
+            return json.dumps({"error": "empty_response"})
         return text


### PR DESCRIPTION
### Motivation
- Requests were spawning a subprocess per call causing cold-starts and timeouts (planner falling back with `llm_empty`).
- The system needs a long-lived model process so only the first request pays the load cost and subsequent `/ai/chat` calls complete within timeout.
- The worker must always return structured JSON (including errors) so the planner can fallback gracefully.

### Description
- Add a persistent JSON-lines worker `pondsec_ai/llm_worker.py` that loads the GGUF model once, logs load time with the message `LLM model loaded in X seconds`, and responds per-line with `{"id":..., "text":...}` or `{"id":..., "error":...}` while logging `LLM generate took Y seconds` per request.
- Implement a `WorkerClient` singleton in `pondsec_ai/local_llm.py` that starts the worker on first use, sends JSON requests, reads JSON responses with a read timeout, and restarts the worker if it dies or hits errors.
- Introduce environment-configurable defaults: `PONDSEC_AI_LLM_MAX_TOKENS` now defaults to `128` and `PONDSEC_AI_LLM_TIMEOUT_SECONDS` defaults to `180` seconds, with coercion and validation for token/time values.
- Change `LocalLLM.generate` to use the `WorkerClient` and to return error payloads (JSON-encoded error objects) when the worker returns an error or empty response, and add logging hooks for worker start/errors/timeouts.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69767d797f188322b4aca79747e89ae9)