### PR TITLE
Make local LLM Windows-safe (threaded stdout reader) and harden AI chat fallback

### DIFF
--- a/pondsec_ai/blueprints.py
+++ b/pondsec_ai/blueprints.py
@@ -53,8 +53,9 @@ def ai_chat():
     except Exception as exc:
         logger.exception("pondsec_ai.chat.error %s", exc)
         response = {
-            "insights": "LLM crashed; using fallback. Bitte erneut versuchen.",
+            "insights": f"AI error: {str(exc)[:120]}. Using fallback.",
             "proposed_actions": [],
+            "questions": [],
             "references": [],
         }
     return jsonify(response)

--- a/pondsec_ai/llm_worker.py
+++ b/pondsec_ai/llm_worker.py
@@ -26,13 +26,16 @@ def _max_tokens() -> int:
 def _resolve_model_path() -> Tuple[Optional[str], Optional[str]]:
     model_path = os.environ.get("PONDSEC_AI_LLM_MODEL_PATH")
     model_name = os.environ.get("PONDSEC_AI_LLM_MODEL_NAME")
+    if not model_name:
+        model_name = "mistral-7b-instruct-v0.2.Q4_K_S.gguf"
     if model_path:
         path = Path(model_path).expanduser()
         if path.exists():
             return path.name, str(path.parent)
         return None, None
-    if not model_name:
-        return None, None
+    model_name_path = Path(model_name).expanduser()
+    if model_name_path.parent != Path(".") and model_name_path.exists():
+        return model_name_path.name, str(model_name_path.parent)
     candidate_paths = [
         Path("./models").expanduser() / model_name,
         Path.home() / ".cache" / "gpt4all" / model_name,
@@ -49,6 +52,7 @@ def _load_model():
     model_name, model_dir = _resolve_model_path()
     if not model_name or not model_dir:
         raise RuntimeError("Local LLM model not configured")
+    logger.info("LLM model path resolved to %s", str(Path(model_dir).resolve() / model_name))
     if provider == "gpt4all":
         from gpt4all import GPT4All
 

--- a/pondsec_ai/local_llm.py
+++ b/pondsec_ai/local_llm.py
@@ -1,16 +1,17 @@
 """Local LLM adapter for PondSec AI."""
 from __future__ import annotations
 
+import collections
 import json
 import logging
 import os
 from pathlib import Path
-import select
+import queue
 import subprocess
 import sys
 import threading
 import uuid
-from typing import Optional, Tuple
+from typing import Deque, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,10 @@ class WorkerClient:
     def __init__(self) -> None:
         self._process: Optional[subprocess.Popen[str]] = None
         self._lock = threading.Lock()
+        self._stdout_queue: Optional[queue.Queue[str]] = None
+        self._stderr_buffer: Optional[Deque[str]] = None
+        self._stdout_thread: Optional[threading.Thread] = None
+        self._stderr_thread: Optional[threading.Thread] = None
 
     @classmethod
     def instance(cls) -> "WorkerClient":
@@ -38,11 +43,17 @@ class WorkerClient:
             cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=None,
+            stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
             env=env,
         )
+        self._stdout_queue = queue.Queue()
+        self._stderr_buffer = collections.deque(maxlen=20)
+        self._stdout_thread = threading.Thread(target=self._read_stdout, daemon=True)
+        self._stderr_thread = threading.Thread(target=self._read_stderr, daemon=True)
+        self._stdout_thread.start()
+        self._stderr_thread.start()
 
     def _stop_worker(self) -> None:
         if self._process is None:
@@ -54,20 +65,40 @@ class WorkerClient:
             except subprocess.TimeoutExpired:
                 self._process.kill()
         self._process = None
+        self._stdout_thread = None
+        self._stderr_thread = None
+        self._stdout_queue = None
+        self._stderr_buffer = None
 
     def _ensure_worker(self) -> None:
         if self._process is None or self._process.poll() is not None:
             self._stop_worker()
             self._start_worker()
 
+    def _read_stdout(self) -> None:
+        if self._process is None or self._process.stdout is None or self._stdout_queue is None:
+            return
+        for line in self._process.stdout:
+            self._stdout_queue.put(line)
+
+    def _read_stderr(self) -> None:
+        if self._process is None or self._process.stderr is None or self._stderr_buffer is None:
+            return
+        for line in self._process.stderr:
+            self._stderr_buffer.append(line.rstrip())
+
+    def _stderr_tail(self) -> str:
+        if not self._stderr_buffer:
+            return ""
+        return " | ".join(list(self._stderr_buffer)[-5:])
+
     def _readline_with_timeout(self, timeout: float) -> Optional[str]:
-        if self._process is None or self._process.stdout is None:
+        if self._stdout_queue is None:
             return None
-        stdout = self._process.stdout
-        ready, _, _ = select.select([stdout], [], [], timeout)
-        if not ready:
+        try:
+            return self._stdout_queue.get(timeout=timeout)
+        except queue.Empty:
             return None
-        return stdout.readline()
 
     def request(self, prompt: str, max_tokens: int) -> dict:
         request_id = uuid.uuid4().hex
@@ -80,24 +111,30 @@ class WorkerClient:
                 self._process.stdin.write(json.dumps(payload) + "\n")
                 self._process.stdin.flush()
             except BrokenPipeError:
-                logger.warning("pondsec_ai.local_llm.worker_broken_pipe")
+                logger.warning("pondsec_ai.local_llm.worker_broken_pipe stderr_tail=%s", self._stderr_tail())
                 self._stop_worker()
                 return {"id": request_id, "error": "worker_broken_pipe"}
             timeout_seconds = LocalLLM._timeout_seconds()
             line = self._readline_with_timeout(timeout_seconds)
             if line is None:
-                logger.warning("pondsec_ai.local_llm.worker_timeout")
+                logger.warning("pondsec_ai.local_llm.worker_timeout stderr_tail=%s", self._stderr_tail())
                 self._stop_worker()
                 return {"id": request_id, "error": "timeout"}
             if not line:
-                logger.warning("pondsec_ai.local_llm.worker_died")
+                logger.warning("pondsec_ai.local_llm.worker_died stderr_tail=%s", self._stderr_tail())
                 self._stop_worker()
                 return {"id": request_id, "error": "worker_died"}
             try:
                 response = json.loads(line.strip())
             except json.JSONDecodeError:
-                logger.warning("pondsec_ai.local_llm.worker_invalid_json")
+                logger.warning("pondsec_ai.local_llm.worker_invalid_json stderr_tail=%s", self._stderr_tail())
                 return {"id": request_id, "error": "invalid_json"}
+            if response.get("error"):
+                logger.warning(
+                    "pondsec_ai.local_llm.worker_error=%s stderr_tail=%s",
+                    response.get("error"),
+                    self._stderr_tail(),
+                )
             return response
 
 
@@ -120,21 +157,24 @@ class LocalLLM:
     @staticmethod
     def _timeout_seconds() -> float:
         try:
-            return float(os.environ.get("PONDSEC_AI_LLM_TIMEOUT_SECONDS", "180"))
+            return float(os.environ.get("PONDSEC_AI_LLM_TIMEOUT_SECONDS", "120"))
         except ValueError:
-            return 180.0
+            return 120.0
 
     @staticmethod
     def _resolve_model_path() -> Tuple[Optional[str], Optional[str]]:
         model_path = os.environ.get("PONDSEC_AI_LLM_MODEL_PATH")
         model_name = os.environ.get("PONDSEC_AI_LLM_MODEL_NAME")
+        if not model_name:
+            model_name = "mistral-7b-instruct-v0.2.Q4_K_S.gguf"
         if model_path:
             path = Path(model_path).expanduser()
             if path.exists():
                 return path.name, str(path.parent)
             return None, None
-        if not model_name:
-            return None, None
+        model_name_path = Path(model_name).expanduser()
+        if model_name_path.parent != Path(".") and model_name_path.exists():
+            return model_name_path.name, str(model_name_path.parent)
         candidate_paths = [
             Path("./models").expanduser() / model_name,
             Path.home() / ".cache" / "gpt4all" / model_name,
@@ -187,6 +227,7 @@ class LocalLLM:
         model_name, model_dir = cls._resolve_model_path()
         if not model_name or not model_dir:
             raise RuntimeError("Local LLM model not configured")
+        logger.info("pondsec_ai.local_llm.model_path=%s", str(Path(model_dir).resolve() / model_name))
         if provider == "gpt4all":
             from gpt4all import GPT4All
 

--- a/templates/pondsec_ai_drawer.html
+++ b/templates/pondsec_ai_drawer.html
@@ -131,13 +131,13 @@
             statusEl.textContent = 'Antwort erhalten.';
         } catch (error) {
             const message = error?.message || 'Fehler';
-            errorEl.textContent = `${message} (LLM crashed; using fallback)`;
+            errorEl.textContent = `${message} (Antwort fehlgeschlagen, Fallback aktiv).`;
             errorEl.classList.remove('hidden');
             statusEl.textContent = 'Fehler bei der Anfrage.';
+            insightsEl.textContent = 'AI error: Bitte erneut versuchen.';
+            renderActions([]);
         } finally {
-            if (statusEl.textContent === 'Sende...') {
-                statusEl.textContent = '';
-            }
+            statusEl.textContent = '';
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent Windows crashes from using `select.select` on subprocess pipes by switching to a cross-platform reader model. 
- Ensure `/ai/chat` never raises and always returns valid JSON so the UI remains responsive even when the local LLM fails. 
- Make model resolution more robust (default to bundled GGUF) and surface useful diagnostics (resolved path / stderr tail) for troubleshooting.

### Description
- Replaced `select.select` based reads with a background stdout reader thread that pushes lines into a `queue.Queue`, and a stderr reader thread that keeps a small tail buffer for diagnostics, ensuring Windows compatibility and non-blocking reads (`pondsec_ai/local_llm.py`).
- Worker lifecycle: start worker with `stderr=PIPE`, spawn reader threads, `request()` writes JSON-lines to stdin with `flush()` and uses `queue.get(timeout=...)` to wait for a response, returning `{"error":"timeout"}` on timeout and restarting the worker when it dies.
- Default timeout lowered to 120s via `PONDSEC_AI_LLM_TIMEOUT_SECONDS` (used if env missing), and default model name set to `mistral-7b-instruct-v0.2.Q4_K_S.gguf` when `PONDSEC_AI_LLM_MODEL_NAME` is not provided; resolved model path is logged (both client and worker).
- Improved error logging by including a stderr tail for `worker_broken_pipe`, `worker_timeout`, `worker_died`, and invalid JSON responses.
- Hardened runtime and UI: `/ai/chat` now catches exceptions and returns a structured fallback JSON with `insights` and empty action/question lists (in `pondsec_ai/blueprints.py`), and the drawer JS always clears the sending state and shows fallback insights/actions on fetch errors (in `templates/pondsec_ai_drawer.html`).

### Testing
- Confirmed no remaining usage of `select.select` for subprocess stdout by code search (`rg`), which returned no matches (success).
- Attempted to start the app with `python app.py` to run an end-to-end smoke test, but startup failed due to a missing dependency (`ModuleNotFoundError: No module named 'apscheduler'`), so full runtime verification on this environment could not be completed.
- Static/behavioral checks: inspected modified files to verify the reader thread + queue, timeout handling, default model fallback, stderr tail logging, and the `/ai/chat` exception handling were implemented as described (manual code review).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69767f6162088322845354a2b82bda25)