### PR TITLE
Switch PondSec AI to Ollama backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,23 +82,44 @@ Die Anwendung läuft anschließend standardmäßig auf `http://localhost:5000`.
 | `APP_VERSION` | Anzeige in der UI/Diagnostics | `unbekannt` |
 | `FLASK_ENV` | Environment Label | `production` |
 
-### PondSec AI – Local LLM (kostenlos, ohne Cloud)
-PondSec AI kann lokal auf einer CPU mit einem Open-Source-LLM laufen. Es werden **keine** API-Keys benötigt.
+### PondSec AI – Ollama (kostenlos, lokal/remote)
+PondSec AI nutzt Ollama als Standard-LLM. Es werden **keine** API-Keys benötigt.
 
-**Optionen (kostenlos):**
-- `gpt4all` (empfohlen, CPU-first)
-- `llama-cpp-python` (CPU-first, GGUF)
+**Vorbereitung:**
+```bash
+ollama pull mistral
+```
 
-**Setup (Beispiel mit gguf-Datei):**
-1. Lege ein Modell in `./models/` ab, z. B. `./models/mistral-7b-instruct-v0.2.Q4_K_M.gguf`.
-2. Setze die Umgebungsvariablen:
-   ```bash
-   export PONDSEC_AI_LLM_PROVIDER=gpt4all   # oder llamacpp
-   export PONDSEC_AI_LLM_MODEL_NAME=mistral-7b-instruct-v0.2.Q4_K_M.gguf
-   export PONDSEC_AI_LLM_MAX_TOKENS=512
-   ```
+**Option A (Ollama auf dem Host):**
+```bash
+export PONDSEC_AI_LLM_PROVIDER=ollama
+export PONDSEC_AI_OLLAMA_URL=http://host.docker.internal:11434
+export PONDSEC_AI_OLLAMA_MODEL=mistral
+```
 
-**Hinweis:** Das System lädt keine großen Modelle automatisch herunter. Wenn kein Modell gefunden wird, nutzt PondSec AI die deterministische Fallback-Logik.
+**Option B (Ollama als Container via Docker Compose):**
+```yaml
+services:
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama:/root/.ollama
+```
+```bash
+export PONDSEC_AI_LLM_PROVIDER=ollama
+export PONDSEC_AI_OLLAMA_URL=http://ollama:11434
+export PONDSEC_AI_OLLAMA_MODEL=mistral
+```
+
+**Zusätzliche Optionen:**
+```bash
+export PONDSEC_AI_LLM_TIMEOUT_SECONDS=30
+export PONDSEC_AI_LLM_MAX_TOKENS=256
+```
+
+**Hinweis:** Wenn Ollama nicht erreichbar ist, nutzt PondSec AI eine deterministische Fallback-Logik.
 
 ### Neue Berechtigungen (Auszug)
 | Permission | Zweck |

--- a/pondsec_ai/blueprints.py
+++ b/pondsec_ai/blueprints.py
@@ -9,6 +9,7 @@ from . import context
 from .db import get_agent_settings, update_agent_settings
 from .policy import approve_action, reject_action
 from .local_llm import LocalLLM
+from .ollama_client import ollama_settings, ping_ollama
 from .registry import TOOL_REGISTRY
 from .runtime import AgentRuntime
 
@@ -53,10 +54,10 @@ def ai_chat():
     except Exception as exc:
         logger.exception("pondsec_ai.chat.error %s", exc)
         response = {
-            "insights": f"AI error: {str(exc)[:120]}. Using fallback.",
+            "insights": "Ollama unreachable oder interner Fehler. Fallback aktiviert.",
             "proposed_actions": [],
             "questions": [],
-            "references": [],
+            "references": ui_context.get("entity_refs", []),
         }
     return jsonify(response)
 
@@ -120,6 +121,8 @@ def ai_settings():
         is_superuser=access["is_superuser"],
         settings=settings,
         llm_status=LocalLLM.status(),
+        llm_settings=ollama_settings(),
+        ollama_reachable=ping_ollama(),
         roles=[dict(row) for row in roles],
         tool_permissions=sorted(tool_rows, key=lambda row: row["tool_name"]),
     )

--- a/pondsec_ai/local_llm.py
+++ b/pondsec_ai/local_llm.py
@@ -13,6 +13,8 @@ import threading
 import uuid
 from typing import Deque, Optional, Tuple
 
+from .ollama_client import ping_ollama
+
 logger = logging.getLogger(__name__)
 
 
@@ -145,21 +147,21 @@ class LocalLLM:
 
     @staticmethod
     def _provider_name() -> str:
-        return os.environ.get("PONDSEC_AI_LLM_PROVIDER", "gpt4all").strip().lower()
+        return os.environ.get("PONDSEC_AI_LLM_PROVIDER", "ollama").strip().lower()
 
     @staticmethod
     def _max_tokens() -> int:
         try:
-            return int(os.environ.get("PONDSEC_AI_LLM_MAX_TOKENS", "128"))
+            return int(os.environ.get("PONDSEC_AI_LLM_MAX_TOKENS", "256"))
         except ValueError:
-            return 128
+            return 256
 
     @staticmethod
     def _timeout_seconds() -> float:
         try:
-            return float(os.environ.get("PONDSEC_AI_LLM_TIMEOUT_SECONDS", "120"))
+            return float(os.environ.get("PONDSEC_AI_LLM_TIMEOUT_SECONDS", "30"))
         except ValueError:
-            return 120.0
+            return 30.0
 
     @staticmethod
     def _resolve_model_path() -> Tuple[Optional[str], Optional[str]]:
@@ -208,7 +210,7 @@ class LocalLLM:
     def status(cls) -> str:
         provider = cls._provider_name()
         if provider == "ollama":
-            return "Remote LLM: ready (ollama)"
+            return "Ollama: reachable" if ping_ollama() else "Ollama: unreachable"
         if provider == "auto":
             return "Auto LLM: local/ollama fallback"
         model_name, model_dir = cls._resolve_model_path()

--- a/pondsec_ai/ollama_client.py
+++ b/pondsec_ai/ollama_client.py
@@ -1,0 +1,96 @@
+"""Ollama client utilities for PondSec AI."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaError(Exception):
+    def __init__(self, message: str, kind: str = "unknown") -> None:
+        super().__init__(message)
+        self.kind = kind
+
+
+def ollama_provider() -> str:
+    return os.environ.get("PONDSEC_AI_LLM_PROVIDER", "ollama").strip().lower()
+
+
+def ollama_url() -> str:
+    return os.environ.get("PONDSEC_AI_OLLAMA_URL", "http://localhost:11434").strip()
+
+
+def ollama_model() -> str:
+    return os.environ.get("PONDSEC_AI_OLLAMA_MODEL", "mistral").strip()
+
+
+def ollama_timeout_seconds() -> int:
+    try:
+        return int(os.environ.get("PONDSEC_AI_LLM_TIMEOUT_SECONDS", "30"))
+    except ValueError:
+        return 30
+
+
+def ollama_max_tokens() -> int:
+    try:
+        return int(os.environ.get("PONDSEC_AI_LLM_MAX_TOKENS", "256"))
+    except ValueError:
+        return 256
+
+
+def call_ollama(prompt: str, max_tokens: int, timeout: int) -> str:
+    if not prompt:
+        return ""
+    payload = {
+        "model": ollama_model(),
+        "prompt": prompt,
+        "stream": False,
+        "options": {
+            "num_predict": max_tokens,
+            "temperature": 0.2,
+        },
+    }
+    url = f"{ollama_url().rstrip('/')}/api/generate"
+    try:
+        response = requests.post(url, json=payload, timeout=timeout)
+    except requests.Timeout as exc:
+        logger.warning("pondsec_ai.ollama.timeout")
+        raise OllamaError("ollama_timeout", kind="timeout") from exc
+    except requests.RequestException as exc:
+        logger.warning("pondsec_ai.ollama.connection_error")
+        raise OllamaError("ollama_connection_error", kind="connection") from exc
+    if response.status_code != 200:
+        logger.warning("pondsec_ai.ollama.bad_status status=%s", response.status_code)
+        raise OllamaError("ollama_bad_status", kind="response")
+    try:
+        data = response.json()
+    except ValueError as exc:
+        logger.warning("pondsec_ai.ollama.invalid_json")
+        raise OllamaError("ollama_invalid_json", kind="response") from exc
+    text = data.get("response")
+    if not isinstance(text, str):
+        raise OllamaError("ollama_missing_response", kind="response")
+    return text.strip()
+
+
+def ping_ollama(timeout: float = 2.0) -> bool:
+    url = f"{ollama_url().rstrip('/')}/api/tags"
+    try:
+        response = requests.get(url, timeout=timeout)
+    except requests.RequestException:
+        return False
+    return response.status_code == 200
+
+
+def ollama_settings() -> dict:
+    return {
+        "provider": ollama_provider(),
+        "url": ollama_url(),
+        "model": ollama_model(),
+        "timeout": ollama_timeout_seconds(),
+        "max_tokens": ollama_max_tokens(),
+    }

--- a/pondsec_ai/planner.py
+++ b/pondsec_ai/planner.py
@@ -7,6 +7,7 @@ import re
 from typing import Any, Dict, List, Optional
 
 from .local_llm import LocalLLM
+from .ollama_client import OllamaError, call_ollama
 from .registry import TOOL_REGISTRY
 
 logger = logging.getLogger(__name__)
@@ -206,11 +207,24 @@ class LocalLLMPlanner(Planner):
         return data
 
     def plan(self, user_message: str, context: Dict[str, Any]) -> Dict[str, Any]:
-        if not LocalLLM.is_available():
-            logger.info("pondsec_ai.planner.fallback reason=llm_unavailable")
+        provider = LocalLLM._provider_name()
+        if provider != "ollama":
+            logger.info("pondsec_ai.planner.fallback reason=provider_disabled provider=%s", provider)
             return DeterministicFallbackPlanner().plan(user_message, context)
         prompt = self._build_prompt(user_message, context)
-        raw = LocalLLM.generate(prompt, max_tokens=self.max_tokens)
+        try:
+            raw = call_ollama(
+                prompt,
+                max_tokens=self.max_tokens,
+                timeout=int(LocalLLM._timeout_seconds()),
+            )
+        except OllamaError as exc:
+            logger.warning("pondsec_ai.planner.fallback reason=ollama_error kind=%s", exc.kind)
+            plan = DeterministicFallbackPlanner().plan(user_message, context)
+            if exc.kind in {"connection", "timeout"}:
+                note = "Hinweis: Ollama unreachable, Fallback aktiviert."
+                plan["insights"] = f"{note}\n\n{plan.get('insights', '')}".strip()
+            return plan
         if not raw:
             logger.warning("pondsec_ai.planner.fallback reason=llm_empty")
             return DeterministicFallbackPlanner().plan(user_message, context)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 flask
 flask-cors
 werkzeug
+requests
 pyotp
 qrcode
 pillow

--- a/templates/ai_settings.html
+++ b/templates/ai_settings.html
@@ -171,9 +171,14 @@
                             </div>
                         </div>
                         <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4 space-y-2">
-                            <p class="text-xs font-semibold text-slate-500">Local LLM</p>
-                            <p class="text-sm font-semibold text-slate-800">{{ llm_status }}</p>
-                            <p class="text-xs text-slate-500">Model wird lokal geladen, keine Cloud-Keys.</p>
+                            <p class="text-xs font-semibold text-slate-500">LLM Provider</p>
+                            <p class="text-sm font-semibold text-slate-800">{{ llm_settings.provider }}</p>
+                            <p class="text-xs text-slate-500">Ollama URL: {{ llm_settings.url }}</p>
+                            <p class="text-xs text-slate-500">Ollama Model: {{ llm_settings.model }}</p>
+                            <p class="text-xs text-slate-500">Timeout: {{ llm_settings.timeout }}s</p>
+                            <p class="text-xs text-slate-500">Max Tokens: {{ llm_settings.max_tokens }}</p>
+                            <p class="text-xs font-semibold text-slate-700">Ollama: {{ 'reachable' if ollama_reachable else 'unreachable' }}</p>
+                            <p class="text-xs text-slate-500">{{ llm_status }}</p>
                         </div>
                     </div>
                 </section>


### PR DESCRIPTION
### Motivation
- Replace fragile local subprocess-based LLM backends with Ollama to avoid Windows/native crashes and provide a stable HTTP-based local/remote LLM integration.  
- Ensure the agent keeps strict JSON-only planner output, deterministic fallback behavior, and never hangs or crashes when Ollama is unreachable.  
- Surface Ollama configuration/status in the settings UI and document Docker Compose host/container options.

### Description
- Add `pondsec_ai/ollama_client.py` implementing `call_ollama(prompt,max_tokens,timeout)`, ping (`/api/tags`), environment-driven settings and a controlled `OllamaError` on timeouts/connection errors.  
- Update planner (`pondsec_ai/planner.py`) to use `call_ollama()` when provider is `ollama`, strictly require JSON schema `{insights, actions, questions}`, validate output, and fall back to `DeterministicFallbackPlanner` on errors while prepending a short "Ollama unreachable" note for connection/timeouts.  
- Make `ollama` the default provider and adjust defaults in `pondsec_ai/local_llm.py` (provider=`ollama`, `PONDSEC_AI_LLM_MAX_TOKENS=256`, `PONDSEC_AI_LLM_TIMEOUT_SECONDS=30`) and display reachable/unreachable using the ping helper.  
- Update `/ai/chat` error handling to always return a valid fallback JSON and include references, and extend `/ai/settings` rendering to pass `llm_settings` and `ollama_reachable` to the template.  
- Change UI template `templates/ai_settings.html` to show provider, URL, model, timeout, max tokens and reachability, and update `README.md` with Ollama host/container examples and env vars.  
- Add `requests` to `requirements.txt` (used by the Ollama client).

### Testing
- Installed dependencies with `pip install -r requirements.txt` which completed successfully.  
- Launched the web app with `python app.py` and confirmed the Flask server starts and serves on `127.0.0.1:5000`.  
- Ran a Playwright script to open `/ai/settings` and captured a screenshot artifact (the endpoint redirected to login in this environment so the login view was captured).  
- No automated LLM calls or unit tests were executed against a running Ollama instance during this run (Ollama-specific behavior and planner-produced JSON output should be validated with a live Ollama server as described in the README manual verification steps).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697685386b40832298ea33e386d5bfcb)