### PR TITLE
Redesign dashboard navbar for clearer categories and grouped actions

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -591,6 +591,352 @@ button {
   backdrop-filter: blur(8px);
 }
 
+.app-navbar {
+  background: var(--color-surface-elevated);
+  border-bottom: 1px solid var(--color-border);
+  backdrop-filter: blur(12px);
+}
+
+.app-navbar--expanded {
+  --navbar-height: 140px;
+  height: auto;
+  padding: env(safe-area-inset-top) var(--space-6) var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: stretch;
+  justify-content: flex-start;
+}
+
+.app-navbar__top,
+.app-navbar__bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  width: 100%;
+}
+
+.app-navbar__top {
+  flex-wrap: wrap;
+}
+
+.app-navbar__left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.app-navbar__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.app-navbar__eyebrow {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--color-text-muted);
+}
+
+.app-navbar__title {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.app-navbar__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.nav-button,
+.nav-icon-button {
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-weight: 600;
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 14px;
+  height: 40px;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.nav-button:hover,
+.nav-icon-button:hover {
+  background: var(--color-surface-muted);
+}
+
+.nav-button:active,
+.nav-icon-button:active {
+  transform: translateY(1px);
+}
+
+.nav-button:focus-visible,
+.nav-icon-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.nav-button[disabled],
+.nav-icon-button[disabled] {
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.nav-icon-button {
+  width: 40px;
+  padding: 0;
+  justify-content: center;
+}
+
+.nav-icon-button--wide {
+  width: auto;
+  padding: 0 14px;
+}
+
+.nav-button--ghost {
+  background: transparent;
+  border-color: transparent;
+}
+
+.nav-cta {
+  background: linear-gradient(135deg, #2563eb, #4f46e5);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: var(--shadow-xs);
+}
+
+.nav-cta:hover {
+  background: linear-gradient(135deg, #1d4ed8, #4338ca);
+}
+
+.nav-button--ai {
+  border-color: rgba(99, 102, 241, 0.35);
+  background: rgba(99, 102, 241, 0.1);
+  color: #4338ca;
+}
+
+.nav-button--ai:hover {
+  background: rgba(99, 102, 241, 0.18);
+}
+
+.nav-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
+}
+
+.nav-search {
+  position: relative;
+  flex: 1 1 260px;
+  min-width: 220px;
+  max-width: 360px;
+}
+
+.nav-search__input {
+  width: 100%;
+  height: 40px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  padding: 0 40px 0 16px;
+  font-size: 0.85rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.nav-search__input:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.nav-search__icon {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-text-muted);
+}
+
+.app-navbar__menu {
+  position: absolute;
+  right: 0;
+  margin-top: 8px;
+  min-width: 220px;
+  border-radius: 18px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-md);
+  padding: 6px 0;
+  z-index: 30;
+}
+
+.app-navbar__menu--wide {
+  min-width: 260px;
+}
+
+.app-navbar__menu-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 10px 16px;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  background: transparent;
+  border: none;
+  text-align: left;
+  text-decoration: none;
+}
+
+.app-navbar__menu-item:hover,
+.app-navbar__menu-item:focus-visible {
+  background: var(--color-surface-muted);
+  outline: none;
+}
+
+.app-navbar__menu-item--icon {
+  align-items: center;
+}
+
+.app-navbar__menu-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 12px;
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
+}
+
+.app-navbar__menu-icon--success {
+  background: rgba(16, 185, 129, 0.15);
+  color: #059669;
+}
+
+.app-navbar__primary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 1;
+  min-width: 0;
+}
+
+.app-navbar__section-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.app-navbar__category-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.app-navbar__category-wrap::before,
+.app-navbar__category-wrap::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 32px;
+  pointer-events: none;
+}
+
+.app-navbar__category-wrap::before {
+  left: 0;
+  background: linear-gradient(90deg, var(--color-surface-elevated) 0%, transparent 100%);
+}
+
+.app-navbar__category-wrap::after {
+  right: 0;
+  background: linear-gradient(270deg, var(--color-surface-elevated) 0%, transparent 100%);
+}
+
+.app-navbar__category-scroll {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  overflow-x: auto;
+  padding: 4px 36px;
+  scroll-behavior: smooth;
+}
+
+.app-navbar__category-item {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 6px 14px;
+  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+}
+
+.app-navbar__category-item:hover,
+.app-navbar__category-item:focus-visible {
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+  outline: none;
+}
+
+.app-navbar__category-item.is-active {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
+  border-color: rgba(37, 99, 235, 0.3);
+}
+
+.nav-scroll-button {
+  background: var(--color-surface);
+  border-color: var(--color-border);
+}
+
+.app-navbar__more-button {
+  white-space: nowrap;
+}
+
+.app-navbar__mobile-toggle {
+  display: none;
+  width: 100%;
+  justify-content: space-between;
+}
+
+.app-navbar__category-panel {
+  display: none;
+  width: 100%;
+  border-radius: 20px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+  padding: 6px 0;
+}
+
+.app-content--nav {
+  padding: calc(var(--navbar-height) + var(--space-6) + env(safe-area-inset-top)) var(--space-6) calc(var(--space-8) + env(safe-area-inset-bottom));
+}
+
 .header-group {
   display: flex;
   align-items: center;
@@ -1197,12 +1543,50 @@ button {
     padding: calc(var(--header-height) + var(--space-4)) var(--space-4) var(--space-6);
   }
 
+  .app-content--nav {
+    padding: calc(var(--navbar-height) + var(--space-4) + env(safe-area-inset-top)) var(--space-4) var(--space-6);
+  }
+
   .two-column {
     grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 768px) {
+  .app-navbar--expanded {
+    --navbar-height: 200px;
+    padding: env(safe-area-inset-top) var(--space-4) var(--space-4);
+  }
+
+  .app-navbar__actions {
+    justify-content: flex-start;
+  }
+
+  .nav-search {
+    order: 3;
+    width: 100%;
+    max-width: none;
+  }
+
+  .app-navbar__bottom {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .app-navbar__category-scroll,
+  .nav-scroll-button,
+  .app-navbar__more-button {
+    display: none;
+  }
+
+  .app-navbar__mobile-toggle {
+    display: inline-flex;
+  }
+
+  .app-navbar__category-panel {
+    display: grid;
+  }
+
   .page-title {
     font-size: 1.5rem;
   }
@@ -1240,6 +1624,15 @@ button {
 
   .app-content,
   .app-content--padded {
+    padding-left: var(--space-4);
+    padding-right: var(--space-4);
+  }
+
+  .app-navbar--expanded {
+    padding: env(safe-area-inset-top) var(--space-4) var(--space-4);
+  }
+
+  .app-content--nav {
     padding-left: var(--space-4);
     padding-right: var(--space-4);
   }

--- a/templates/index.html
+++ b/templates/index.html
@@ -250,72 +250,124 @@
         </aside>
 
         <div class="main-content app-main app-main--fixed">
-            <header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 z-30 h-[82px]">
-                <div class="flex items-center gap-4">
-                    <button type="button" data-sidebar-toggle aria-label="Navigation umschalten" class="icon-button inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white p-2 text-slate-600 shadow-sm hover:bg-slate-50">
-                        <i data-feather="menu" class="w-4 h-4"></i>
-                    </button>
-                    <div>
-                    <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Dashboard</p>
-                    <h1 class="text-2xl font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h1>
+            <header class="app-header app-navbar app-navbar--expanded">
+                <div class="app-navbar__top">
+                    <div class="app-navbar__left">
+                        <button type="button" data-sidebar-toggle aria-label="Navigation umschalten" class="nav-icon-button">
+                            <i data-feather="menu" class="w-4 h-4"></i>
+                        </button>
+                        <div class="app-navbar__titles">
+                            <p class="app-navbar__eyebrow">Dashboard</p>
+                            <h1 class="app-navbar__title" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h1>
+                        </div>
+                    </div>
+                    <div class="app-navbar__actions">
+                        <div class="nav-search">
+                            <label class="sr-only" for="navbar-search">Suche</label>
+                            <input id="navbar-search" type="text" placeholder="Geräte, Owner, Kategorie, Standort..." class="nav-search__input" x-model="searchQuery" @input.debounce.300ms="searchDevices()">
+                            <span class="nav-search__icon" aria-hidden="true">
+                                <i data-feather="search" class="h-4 w-4"></i>
+                            </span>
+                        </div>
+                        <button @click="openAddDeviceModal()" data-testid="open-device-modal" class="nav-button nav-cta">
+                            <i data-feather="plus" class="w-4 h-4"></i>
+                            <span>Neues Gerät</span>
+                        </button>
+                        {% include 'pondsec_ai_button.html' %}
+                        <div class="relative" x-data="{ open: false }" @keydown.escape.window="open = false">
+                            <button @click="open = !open" data-testid="dashboard-action-menu-toggle" class="nav-icon-button" aria-label="Weitere Aktionen" :aria-expanded="open.toString()">
+                                <i data-feather="more-horizontal" class="w-4 h-4"></i>
+                            </button>
+                            <div x-show="open" data-testid="dashboard-action-menu" @click.away="open = false" class="app-navbar__menu" x-transition role="menu">
+                                <button @click="openAddCategoryModal(); open=false" class="app-navbar__menu-item" role="menuitem">Kategorie anlegen</button>
+                                <button @click="openAddAssetModal(); open=false" class="app-navbar__menu-item" role="menuitem">Neues Asset</button>
+                                <a href="/api/export/devices" class="app-navbar__menu-item" role="menuitem">CSV Export</a>
+                            </div>
+                        </div>
+                        <div class="relative" x-data="{ open: false }" @keydown.escape.window="open = false">
+                            <button @click="open = !open" class="nav-button nav-button--ghost" :aria-expanded="open.toString()">
+                                <span class="nav-avatar">
+                                    <i data-feather="user" class="w-4 h-4"></i>
+                                </span>
+                                <span class="hidden md:inline">Profil</span>
+                            </button>
+                            <div x-show="open" @click.away="open = false" class="app-navbar__menu app-navbar__menu--wide" x-transition role="menu">
+                                <button @click="setupOTP(); open=false" class="app-navbar__menu-item app-navbar__menu-item--icon" role="menuitem">
+                                    <span class="app-navbar__menu-icon app-navbar__menu-icon--success">
+                                        <i data-feather="shield" class="w-4 h-4"></i>
+                                    </span>
+                                    <span class="flex-1">2FA verwalten</span>
+                                    <span x-show="otpEnabled" class="text-emerald-500">
+                                        <i data-feather="check-circle" class="w-4 h-4"></i>
+                                    </span>
+                                    <span x-show="!otpEnabled" class="text-rose-500">
+                                        <i data-feather="x-circle" class="w-4 h-4"></i>
+                                    </span>
+                                </button>
+                                <a href="/reset" class="app-navbar__menu-item app-navbar__menu-item--icon" role="menuitem">
+                                    <span class="app-navbar__menu-icon">
+                                        <i data-feather="lock" class="w-4 h-4"></i>
+                                    </span>
+                                    Passwort setzen
+                                </a>
+                            </div>
+                        </div>
+                        <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="nav-icon-button nav-icon-button--wide" aria-label="Dark Mode">
+                            <span data-theme-icon aria-hidden="true">🌙</span>
+                            <span data-theme-label class="sr-only lg:not-sr-only">Dark Mode</span>
+                        </button>
+                        <button onclick="logout()" class="nav-icon-button nav-icon-button--wide" aria-label="Abmelden">
+                            <i data-feather="log-out" class="w-4 h-4"></i>
+                            <span class="sr-only lg:not-sr-only">Abmelden</span>
+                        </button>
                     </div>
                 </div>
-                <div class="flex items-center gap-2 sm:gap-3">
-                    <button @click="openAddDeviceModal()" data-testid="open-device-modal" class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-blue-200 hover:from-blue-500 hover:to-indigo-500">
-                        <i data-feather="plus" class="w-4 h-4"></i>
-                        <span>Neues Gerät</span>
-                    </button>
-                    {% include 'pondsec_ai_button.html' %}
-                    <div class="relative" x-data="{ open: false }">
-                        <button @click="open = !open" data-testid="dashboard-action-menu-toggle" class="icon-button inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 bg-white p-2 text-slate-600 shadow-sm hover:bg-slate-50" aria-label="Weitere Aktionen">
-                            <i data-feather="more-horizontal" class="w-4 h-4"></i>
+                <div class="app-navbar__bottom" x-data="{ moreOpen: false, mobileCategoriesOpen: false }" @keydown.escape.window="moreOpen = false; mobileCategoriesOpen = false">
+                    <div class="app-navbar__primary">
+                        <span class="app-navbar__section-label">Kategorien</span>
+                        <button type="button" class="nav-icon-button nav-scroll-button" @click="$refs.categoryScroll.scrollBy({ left: -240, behavior: 'smooth' })" aria-label="Nach links scrollen">
+                            <i data-feather="chevron-left" class="w-4 h-4"></i>
                         </button>
-                        <div x-show="open" data-testid="dashboard-action-menu" @click.away="open = false" class="absolute right-0 z-30 mt-2 w-56 rounded-2xl border border-slate-200 bg-white shadow-xl" x-transition>
-                            <button @click="openAddCategoryModal(); open=false" class="block w-full px-4 py-3 text-left text-sm hover:bg-slate-50">Kategorie anlegen</button>
-                            <button @click="openAddAssetModal(); open=false" class="block w-full px-4 py-3 text-left text-sm hover:bg-slate-50">Neues Asset</button>
-                            <a href="/api/export/devices" class="block px-4 py-3 text-sm hover:bg-slate-50">CSV Export</a>
+                        <div class="app-navbar__category-wrap">
+                            <div class="app-navbar__category-scroll scrollbar-hide" x-ref="categoryScroll" role="tablist">
+                                <button class="app-navbar__category-item" :class="{ 'is-active': activeCategory === null }" @click="loadDevices(null)" role="tab" :aria-selected="(activeCategory === null).toString()" aria-label="Alle Geräte">
+                                    Alle Geräte
+                                </button>
+                                <template x-for="category in categories" :key="category.id">
+                                    <button class="app-navbar__category-item" :class="{ 'is-active': activeCategory === category.id }" @click="loadDevices(category.id)" role="tab" :aria-selected="(activeCategory === category.id).toString()" :title="category.name" x-text="category.name"></button>
+                                </template>
+                            </div>
                         </div>
-                    </div>
-                    <div class="relative" x-data="{ open: false }">
-                        <button @click="open = !open" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
-                            <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-slate-100 text-slate-600">
-                                <i data-feather="user" class="w-4 h-4"></i>
-                            </span>
-                            <span class="hidden sm:inline">Profil</span>
+                        <button type="button" class="nav-icon-button nav-scroll-button" @click="$refs.categoryScroll.scrollBy({ left: 240, behavior: 'smooth' })" aria-label="Nach rechts scrollen">
+                            <i data-feather="chevron-right" class="w-4 h-4"></i>
                         </button>
-                        <div x-show="open" @click.away="open = false" class="absolute right-0 z-30 mt-2 w-60 rounded-2xl border border-slate-200 bg-white shadow-xl" x-transition>
-                            <button @click="setupOTP(); open=false" class="flex w-full items-center gap-2 px-4 py-3 text-left text-sm hover:bg-slate-50">
-                                <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-emerald-50 text-emerald-600">
-                                    <i data-feather="shield" class="w-4 h-4"></i>
-                                </span>
-                                <span class="flex-1">2FA verwalten</span>
-                                <span x-show="otpEnabled" class="text-emerald-500">
-                                    <i data-feather="check-circle" class="w-4 h-4"></i>
-                                </span>
-                                <span x-show="!otpEnabled" class="text-rose-500">
-                                    <i data-feather="x-circle" class="w-4 h-4"></i>
-                                </span>
+                        <div class="relative">
+                            <button type="button" class="nav-button nav-button--ghost app-navbar__more-button" @click="moreOpen = !moreOpen" :aria-expanded="moreOpen.toString()" aria-controls="category-more-menu">
+                                Mehr
+                                <i data-feather="chevron-down" class="w-4 h-4"></i>
                             </button>
-                            <a href="/reset" class="flex items-center gap-2 px-4 py-3 text-sm hover:bg-slate-50">
-                                <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-slate-100 text-slate-600">
-                                    <i data-feather="lock" class="w-4 h-4"></i>
-                                </span>
-                                Passwort setzen
-                            </a>
+                            <div id="category-more-menu" x-show="moreOpen" @click.away="moreOpen = false" class="app-navbar__menu app-navbar__menu--wide" x-transition role="menu">
+                                <button @click="loadDevices(null); moreOpen = false" class="app-navbar__menu-item" role="menuitem">Alle Geräte</button>
+                                <template x-for="category in categories" :key="category.id">
+                                    <button @click="loadDevices(category.id); moreOpen = false" class="app-navbar__menu-item" role="menuitem" x-text="category.name"></button>
+                                </template>
+                            </div>
                         </div>
                     </div>
-                    <button type="button" data-theme-toggle onclick="InventoryTheme.toggle()" class="icon-button inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white p-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
-                        <span data-theme-icon aria-hidden="true">🌙</span>
-                        <span data-theme-label class="sr-only sm:not-sr-only">Dark Mode</span>
+                    <button type="button" class="nav-button app-navbar__mobile-toggle" @click="mobileCategoriesOpen = !mobileCategoriesOpen" :aria-expanded="mobileCategoriesOpen.toString()" aria-controls="mobile-categories">
+                        Kategorien anzeigen
+                        <i data-feather="chevron-down" class="w-4 h-4"></i>
                     </button>
-                    <button onclick="logout()" class="icon-button inline-flex h-9 w-9 items-center justify-center gap-2 rounded-full border border-slate-200 bg-white p-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 sm:h-auto sm:w-auto sm:px-4 sm:py-2">
-                        <i data-feather="log-out" class="w-4 h-4"></i>
-                        <span class="sr-only sm:not-sr-only">Abmelden</span>
-                    </button>
+                    <div id="mobile-categories" x-show="mobileCategoriesOpen" x-transition class="app-navbar__category-panel" role="menu">
+                        <button class="app-navbar__menu-item" role="menuitem" @click="loadDevices(null); mobileCategoriesOpen = false">Alle Geräte</button>
+                        <template x-for="category in categories" :key="category.id">
+                            <button class="app-navbar__menu-item" role="menuitem" @click="loadDevices(category.id); mobileCategoriesOpen = false" x-text="category.name"></button>
+                        </template>
+                    </div>
                 </div>
             </header>
 
-            <main class="app-content">
+            <main class="app-content app-content--nav">
                 <div class="page space-y-6">
                     <section class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
                         <div class="flex flex-wrap items-center justify-between gap-4">
@@ -341,12 +393,6 @@
                         </div>
                         <div class="mt-5 space-y-3">
                             <div class="flex flex-wrap items-center gap-3">
-                                <div class="relative flex-1 min-w-[220px]">
-                                    <input type="text" placeholder="Suche nach Gerät, Owner, Kategorie, Standort..." class="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 pr-12 text-sm text-slate-700 shadow-inner focus:border-blue-500 focus:ring-blue-500" x-model="searchQuery" @input.debounce.300ms="searchDevices()">
-                                    <span class="absolute right-4 top-1/2 -translate-y-1/2 text-slate-400">
-                                        <i data-feather="search" class="h-4 w-4"></i>
-                                    </span>
-                                </div>
                                 <button type="button" @click="filtersOpen = !filtersOpen" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-50">
                                     <i data-feather="sliders" class="h-4 w-4"></i>
                                     Filter

--- a/templates/pondsec_ai_button.html
+++ b/templates/pondsec_ai_button.html
@@ -1,3 +1,3 @@
-<button type="button" data-pondsec-ai-open class="inline-flex items-center gap-2 rounded-full border border-indigo-200 bg-indigo-50 px-4 py-2 text-xs font-semibold text-indigo-700 hover:bg-indigo-100">
+<button type="button" data-pondsec-ai-open class="nav-button nav-button--ai">
     <span>Ask PondSec AI</span>
 </button>


### PR DESCRIPTION
### Motivation
- The existing header/nav mixed primary categories with secondary actions and truncated category names on laptop viewports, making categories unreadable and the header hard to scan. The intent is to restructure the header into a two-tier navbar, fix the laptop truncation bug and improve button layout, accessibility and responsive behavior.
- Provide a robust overflow pattern for categories (horizontal scroll + fade edges + explicit arrows + "Mehr" overflow menu) so category labels remain discoverable on laptop breakpoints rather than heavily truncated.

### Description
- Rebuilt the header into a two-tier navbar and added a dedicated categories row with scrollable pills, left/right scroll buttons and a "Mehr" overflow menu; updated markup in `templates/index.html` to introduce the new structure (`app-navbar`, `app-navbar__top`, `app-navbar__bottom`, category scroll, mobile category panel, ARIA/role attributes and Escape-to-close handlers).
- Introduced a small navbar design system in `static/style.css` (new `.app-navbar*`, `.nav-button`, `.nav-icon-button`, `.nav-search`, `.app-navbar__category-*` rules) with consistent button sizes, focus-visible states, fade-edge overlays, responsive tweaks and mobile collapse behavior to ensure readable categories at laptop breakpoints.
- Fixed the laptop-category bug by removing hard truncation and using an overflow/scroll + fade + "Mehr" menu approach to guarantee labels are readable and reachable (category buttons use `white-space: nowrap` and explicit scroll controls/overflow). 
- Improved actions grouping and accessibility: moved search into the navbar, grouped CTAs/AI/profile/theme/logout, added keyboard (`Escape`) handling, ARIA-expanded/role attributes for menus and role=tablist/role=tab for category items, and unified PondSec AI button with the new `nav-button nav-button--ai` style (`templates/pondsec_ai_button.html`).

### Testing
- End-to-end UI check via Playwright: started the Flask app and performed an automated login and navigation to `/` with viewport `1280x720`, then captured a full-page screenshot (`artifacts/navbar-redesign.png`) which shows the new two-tier navbar and readable category pills; the screenshot was produced successfully.
- Manual runtime smoke checks: started the server (`python app.py`) and verified API endpoints used by the navbar returned 200 during page load (e.g., `/api/categories`, `/api/devices`, `/api/assets`) and the dashboard rendered without JS errors; these requests completed successfully during the automated navigation.
- Responsive verification: exercised the laptop/desktop breakpoint by using a 1280px wide viewport (Playwright) and verified category scroll controls + "Mehr" menu exist; mobile collapse behavior implemented via CSS and Alpine toggles (no automated mobile screenshot recorded in this run).
- No unit test changes were required; no automated test failures observed during the UI smoke runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69787f744164832e819f441aa432af3b)