### PR TITLE
Stack sidebar category actions beneath names for better wrapping

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -128,12 +128,12 @@
                                 </div>
                             </div>
                             <template x-for="category in filteredCategories()" :key="category.id">
-                                <div class="group flex items-center justify-between px-3 py-2 rounded-xl hover:bg-white transition-colors">
-                                    <button @click="loadDevices(category.id)" class="flex items-center gap-2 flex-1 min-w-0 text-left">
-                                        <div x-html="feather.icons[category.icon]?.toSvg({ class: 'w-4 h-4 text-slate-500' })"></div>
-                                        <span class="sidebar-text truncate" x-text="category.name"></span>
+                                <div class="group flex flex-col gap-2 px-3 py-2 rounded-xl hover:bg-white transition-colors">
+                                    <button @click="loadDevices(category.id)" class="flex items-start gap-2 text-left">
+                                        <div class="mt-0.5" x-html="feather.icons[category.icon]?.toSvg({ class: 'w-4 h-4 text-slate-500' })"></div>
+                                        <span class="sidebar-text whitespace-normal break-words leading-snug" x-text="category.name"></span>
                                     </button>
-                                    <div class="flex items-center gap-2">
+                                    <div class="flex items-center justify-end gap-2">
                                         <button @click="editCategoryModal(category)" class="icon-button text-slate-500 hover:text-slate-900" aria-label="Kategorie bearbeiten">
                                             <i data-feather="edit" class="w-4 h-4"></i>
                                         </button>


### PR DESCRIPTION
### Motivation
- Long category names were still being truncated and the previous inline alignment tweaks looked awkward on small screens, so actions should not overlap the label and names must be allowed to wrap naturally.

### Description
- Update `templates/index.html` to stack category actions on a second line by changing the list-item wrapper from a single-row flex to `flex flex-col gap-2` and removing the `truncate` behavior.
- Allow category names to wrap by replacing `truncate` with `whitespace-normal break-words leading-snug` and slightly offsetting the icon with `mt-0.5` for visual alignment.
- Keep action buttons visible and aligned on their own row by using `flex items-center justify-end gap-2` for the action container.

### Testing
- Started the dev server with `python app.py`, which launched successfully and served on `http://127.0.0.1:5000` (succeeded).
- Attempted an automated Playwright screenshot run to verify the UI change, but the headless Chromium process crashed with a SIGSEGV and the screenshot step failed (failed).
- Committed the updated template with `git commit` to record the change (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6978963eceb4832e8ea05b3aea26cd40)