### PR TITLE
Keep category actions inline using grid to reduce row height

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -14,6 +14,7 @@ document.addEventListener('alpine:init', () => {
         assetsOpen: false,
         searchQuery: '',
         categorySearchQuery: '',
+        assetSearchQuery: '',
         ownerQuery: '',
         locationFilter: '',
         categoryFilter: '',
@@ -129,6 +130,7 @@ document.addEventListener('alpine:init', () => {
             this.loadIconCatalog();
             this.$watch('searchQuery', () => this.searchDevices());
             this.$watch('categorySearchQuery', () => this.filterCategories());
+            this.$watch('assetSearchQuery', () => this.filterAssets());
             this.$watch('ownerQuery', () => this.searchDevices());
             this.$watch('locationFilter', () => this.searchDevices());
             this.$watch('categoryFilter', () => this.searchDevices());
@@ -367,6 +369,20 @@ document.addEventListener('alpine:init', () => {
             }
             return this.categories.filter(category =>
                 (category.name || '').toLowerCase().includes(query)
+            );
+        },
+
+        filterAssets() {
+            return this.filteredAssets();
+        },
+
+        filteredAssets() {
+            const query = (this.assetSearchQuery || '').toLowerCase().trim();
+            if (!query) {
+                return this.assets;
+            }
+            return this.assets.filter(asset =>
+                (asset.name || '').toLowerCase().includes(query)
             );
         },
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -128,12 +128,12 @@
                                 </div>
                             </div>
                             <template x-for="category in filteredCategories()" :key="category.id">
-                                <div class="group flex items-center justify-between px-3 py-2 rounded-xl hover:bg-white transition-colors">
-                                    <button @click="loadDevices(category.id)" class="flex items-center gap-2 flex-1 min-w-0 text-left">
-                                        <div x-html="feather.icons[category.icon]?.toSvg({ class: 'w-4 h-4 text-slate-500' })"></div>
-                                        <span class="sidebar-text truncate" x-text="category.name"></span>
+                                <div class="group grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 px-3 py-2 rounded-xl hover:bg-white transition-colors">
+                                    <button @click="loadDevices(category.id)" class="flex items-start gap-2 min-w-0 text-left">
+                                        <div class="mt-0.5" x-html="feather.icons[category.icon]?.toSvg({ class: 'w-4 h-4 text-slate-500' })"></div>
+                                        <span class="sidebar-text whitespace-normal break-words leading-snug" x-text="category.name"></span>
                                     </button>
-                                    <div class="flex items-center gap-2">
+                                    <div class="flex items-center gap-2 pt-0.5">
                                         <button @click="editCategoryModal(category)" class="icon-button text-slate-500 hover:text-slate-900" aria-label="Kategorie bearbeiten">
                                             <i data-feather="edit" class="w-4 h-4"></i>
                                         </button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -358,102 +358,100 @@
                             </div>
                         </div>
                     </section>
-                    <section id="inventory-taxonomy" class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                    <section id="inventory-taxonomy" class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm" x-data="{ taxonomyTab: 'categories' }">
                         <div class="flex flex-wrap items-center justify-between gap-4">
                             <div>
                                 <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Struktur</p>
-                                <h3 class="text-xl font-semibold text-slate-900">Kategorien &amp; Assets</h3>
-                                <p class="mt-1 text-sm text-slate-500">Verwalte Kategorien und Assets zentral im Arbeitsbereich.</p>
+                                <h3 class="text-xl font-semibold text-slate-900">Kategorien &amp; Assets verwalten</h3>
+                                <p class="mt-1 text-sm text-slate-500">Arbeite konzentriert in einem Bereich statt in der Sidebar.</p>
                             </div>
-                            <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
-                                <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
-                                    <i data-feather="layers" class="h-3 w-3"></i>
-                                    <span x-text="categories.length"></span> Kategorien
-                                </span>
-                                <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
-                                    <i data-feather="package" class="h-3 w-3"></i>
-                                    <span x-text="assets.length"></span> Assets
-                                </span>
+                            <div class="flex flex-wrap items-center gap-2">
+                                <div class="inline-flex rounded-full border border-slate-200 bg-slate-50 p-1 text-xs font-semibold">
+                                    <button @click="taxonomyTab = 'categories'" class="rounded-full px-4 py-2" :class="taxonomyTab === 'categories' ? 'bg-slate-900 text-white' : 'text-slate-600'">Kategorien</button>
+                                    <button @click="taxonomyTab = 'assets'" class="rounded-full px-4 py-2" :class="taxonomyTab === 'assets' ? 'bg-slate-900 text-white' : 'text-slate-600'">Assets</button>
+                                </div>
+                                <div class="flex items-center gap-2 text-xs text-slate-500">
+                                    <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1">
+                                        <i data-feather="layers" class="h-3 w-3"></i>
+                                        <span x-text="categories.length"></span>
+                                    </span>
+                                    <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1">
+                                        <i data-feather="package" class="h-3 w-3"></i>
+                                        <span x-text="assets.length"></span>
+                                    </span>
+                                </div>
                             </div>
                         </div>
-                        <div class="mt-6 grid gap-6 lg:grid-cols-2">
-                            <div class="rounded-2xl border border-slate-200 bg-slate-50/60 p-5">
-                                <div class="flex flex-wrap items-start justify-between gap-3">
-                                    <div>
-                                        <h4 class="text-sm font-semibold text-slate-900">Kategorien</h4>
-                                        <p class="text-xs text-slate-500">Für Gerätefilter, Auswertung und Struktur.</p>
-                                    </div>
-                                    <button @click="openAddCategoryModal()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-blue-600 hover:text-blue-800">
-                                        <i data-feather="plus-circle" class="h-4 w-4"></i>
-                                        Kategorie hinzufügen
-                                    </button>
+
+                        <div class="mt-6 rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                            <div class="flex flex-wrap items-center justify-between gap-3">
+                                <div>
+                                    <h4 class="text-sm font-semibold text-slate-900" x-text="taxonomyTab === 'categories' ? 'Kategorien' : 'Assets'"></h4>
+                                    <p class="text-xs text-slate-500" x-text="taxonomyTab === 'categories' ? 'Strukturiere Geräte und Auswertungen.' : 'Assets bündeln Geräte und zeigen Verfügbarkeit.'"></p>
                                 </div>
-                                <div class="mt-4 space-y-3">
-                                    <div class="relative">
-                                        <input type="text" x-model="categorySearchQuery" placeholder="Kategorien suchen..." class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 pr-9 text-xs text-slate-600 focus:border-blue-500 focus:ring-blue-500">
-                                        <span class="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400">
-                                            <i data-feather="search" class="h-3 w-3"></i>
-                                        </span>
-                                    </div>
-                                    <div class="space-y-2 max-h-72 overflow-auto pr-1">
-                                        <template x-for="category in filteredCategories()" :key="category.id">
-                                            <div class="group grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-transparent bg-white px-3 py-2 shadow-sm hover:border-slate-200">
-                                                <button @click="loadDevices(category.id)" class="flex items-start gap-2 min-w-0 text-left">
-                                                    <div class="mt-0.5" x-html="feather.icons[category.icon]?.toSvg({ class: 'w-4 h-4 text-slate-500' })"></div>
-                                                    <span class="text-sm font-medium text-slate-700 whitespace-normal break-words leading-snug" x-text="category.name"></span>
-                                                </button>
-                                                <div class="flex items-center gap-2 pt-0.5">
-                                                    <button @click="editCategoryModal(category)" class="icon-button text-slate-500 hover:text-slate-900" aria-label="Kategorie bearbeiten">
-                                                        <i data-feather="edit" class="w-4 h-4"></i>
-                                                    </button>
-                                                    <button @click="deleteCategory(category.id)" class="icon-button text-rose-500 hover:text-rose-700" aria-label="Kategorie löschen">
-                                                        <i data-feather="trash-2" class="w-4 h-4"></i>
-                                                    </button>
-                                                </div>
-                                            </div>
-                                        </template>
-                                        <p x-show="filteredCategories().length === 0" class="text-xs text-slate-400">Keine Kategorien gefunden.</p>
-                                    </div>
+                                <button x-show="taxonomyTab === 'categories'" @click="openAddCategoryModal()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-blue-600 hover:text-blue-800">
+                                    <i data-feather="plus-circle" class="h-4 w-4"></i>
+                                    Kategorie hinzufügen
+                                </button>
+                                <button x-show="taxonomyTab === 'assets'" @click="openAddAssetModal()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-indigo-600 hover:text-indigo-800">
+                                    <i data-feather="plus-circle" class="h-4 w-4"></i>
+                                    Asset hinzufügen
+                                </button>
+                            </div>
+
+                            <div class="mt-4">
+                                <div class="relative" x-show="taxonomyTab === 'categories'">
+                                    <input type="text" x-model="categorySearchQuery" placeholder="Kategorien suchen..." class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 pr-9 text-xs text-slate-600 focus:border-blue-500 focus:ring-blue-500">
+                                    <span class="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400">
+                                        <i data-feather="search" class="h-3 w-3"></i>
+                                    </span>
+                                </div>
+                                <div class="relative" x-show="taxonomyTab === 'assets'">
+                                    <input type="text" x-model="assetSearchQuery" placeholder="Assets suchen..." class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 pr-9 text-xs text-slate-600 focus:border-blue-500 focus:ring-blue-500">
+                                    <span class="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400">
+                                        <i data-feather="search" class="h-3 w-3"></i>
+                                    </span>
                                 </div>
                             </div>
-                            <div class="rounded-2xl border border-slate-200 bg-slate-50/60 p-5">
-                                <div class="flex flex-wrap items-start justify-between gap-3">
-                                    <div>
-                                        <h4 class="text-sm font-semibold text-slate-900">Assets</h4>
-                                        <p class="text-xs text-slate-500">Assets bündeln Geräte und zeigen Verfügbarkeit.</p>
+
+                            <div class="mt-4 max-h-80 space-y-2 overflow-auto pr-1" x-show="taxonomyTab === 'categories'">
+                                <template x-for="category in filteredCategories()" :key="category.id">
+                                    <div class="group grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-transparent bg-white px-3 py-2 shadow-sm hover:border-slate-200">
+                                        <button @click="loadDevices(category.id)" class="flex items-start gap-2 min-w-0 text-left">
+                                            <div class="mt-0.5" x-html="feather.icons[category.icon]?.toSvg({ class: 'w-4 h-4 text-slate-500' })"></div>
+                                            <span class="text-sm font-medium text-slate-700 whitespace-normal break-words leading-snug" x-text="category.name"></span>
+                                        </button>
+                                        <div class="flex items-center gap-2 pt-0.5">
+                                            <button @click="editCategoryModal(category)" class="icon-button text-slate-500 hover:text-slate-900" aria-label="Kategorie bearbeiten">
+                                                <i data-feather="edit" class="w-4 h-4"></i>
+                                            </button>
+                                            <button @click="deleteCategory(category.id)" class="icon-button text-rose-500 hover:text-rose-700" aria-label="Kategorie löschen">
+                                                <i data-feather="trash-2" class="w-4 h-4"></i>
+                                            </button>
+                                        </div>
                                     </div>
-                                    <button @click="openAddAssetModal()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-indigo-600 hover:text-indigo-800">
-                                        <i data-feather="plus-circle" class="h-4 w-4"></i>
-                                        Asset hinzufügen
-                                    </button>
-                                </div>
-                                <div class="mt-4 space-y-3">
-                                    <div class="relative">
-                                        <input type="text" x-model="assetSearchQuery" placeholder="Assets suchen..." class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 pr-9 text-xs text-slate-600 focus:border-blue-500 focus:ring-blue-500">
-                                        <span class="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400">
-                                            <i data-feather="search" class="h-3 w-3"></i>
-                                        </span>
+                                </template>
+                                <p x-show="filteredCategories().length === 0" class="text-xs text-slate-400">Keine Kategorien gefunden.</p>
+                            </div>
+
+                            <div class="mt-4 max-h-80 space-y-2 overflow-auto pr-1" x-show="taxonomyTab === 'assets'">
+                                <template x-for="asset in filteredAssets()" :key="asset.id">
+                                    <div class="group grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-transparent bg-white px-3 py-2 shadow-sm hover:border-slate-200">
+                                        <button @click="openAssetDetail(asset)" class="flex items-start gap-3 min-w-0 text-left">
+                                            <span class="inline-flex items-center justify-center w-7 h-7 rounded-lg bg-indigo-50 text-indigo-600 text-xs font-semibold" x-text="asset.device_count || 0"></span>
+                                            <span class="text-sm font-medium text-slate-700 whitespace-normal break-words leading-snug" x-text="asset.name"></span>
+                                        </button>
+                                        <div class="flex items-center gap-2">
+                                            <button @click="openEditAssetModal(asset)" class="icon-button text-slate-500 hover:text-slate-900" aria-label="Asset bearbeiten">
+                                                <i data-feather="edit" class="w-4 h-4"></i>
+                                            </button>
+                                            <button @click="deleteAsset(asset.id)" class="icon-button text-rose-500 hover:text-rose-700" aria-label="Asset löschen">
+                                                <i data-feather="trash-2" class="w-4 h-4"></i>
+                                            </button>
+                                        </div>
                                     </div>
-                                    <div class="space-y-2 max-h-72 overflow-auto pr-1">
-                                        <template x-for="asset in filteredAssets()" :key="asset.id">
-                                            <div class="group grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-transparent bg-white px-3 py-2 shadow-sm hover:border-slate-200">
-                                                <button @click="openAssetDetail(asset)" class="flex items-start gap-3 min-w-0 text-left">
-                                                    <span class="inline-flex items-center justify-center w-7 h-7 rounded-lg bg-indigo-50 text-indigo-600 text-xs font-semibold" x-text="asset.device_count || 0"></span>
-                                                    <span class="text-sm font-medium text-slate-700 whitespace-normal break-words leading-snug" x-text="asset.name"></span>
-                                                </button>
-                                                <div class="flex items-center gap-2">
-                                                    <button @click="openEditAssetModal(asset)" class="icon-button text-slate-500 hover:text-slate-900" aria-label="Asset bearbeiten">
-                                                        <i data-feather="edit" class="w-4 h-4"></i>
-                                                    </button>
-                                                    <button @click="deleteAsset(asset.id)" class="icon-button text-rose-500 hover:text-rose-700" aria-label="Asset löschen">
-                                                        <i data-feather="trash-2" class="w-4 h-4"></i>
-                                                    </button>
-                                                </div>
-                                            </div>
-                                        </template>
-                                        <p x-show="filteredAssets().length === 0" class="text-xs text-slate-400">Keine Assets gefunden.</p>
-                                    </div>
-                                </div>
+                                </template>
+                                <p x-show="filteredAssets().length === 0" class="text-xs text-slate-400">Keine Assets gefunden.</p>
                             </div>
                         </div>
                     </section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -109,76 +109,24 @@
                         <span class="text-xs text-slate-400">Filter & Pflege</span>
                     </div>
                     <div class="mt-3 space-y-3">
-                        <button @click="categoriesOpen = !categoriesOpen" class="sidebar-toggle" type="button">
-                            <span class="flex items-center gap-2">
+                        <a href="#inventory-taxonomy" class="sidebar-link">
+                            <span>
                                 <span class="sidebar-link-icon"><i data-feather="layers" class="w-4 h-4"></i></span>
-                                Kategorien
+                                Kategorien &amp; Assets verwalten
                             </span>
-                            <svg :class="{ 'rotate-180': categoriesOpen }" class="w-4 h-4 text-slate-500 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-                            </svg>
-                        </button>
-                        <div x-show="categoriesOpen" x-transition class="rounded-2xl border border-slate-200 bg-slate-50 px-2 py-2 space-y-1 text-sm text-slate-800">
-                            <div class="px-3 pb-2">
-                                <div class="relative">
-                                    <input type="text" x-model="categorySearchQuery" placeholder="Kategorien filtern..." class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 pr-9 text-xs text-slate-600 focus:border-blue-500 focus:ring-blue-500">
-                                    <span class="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400">
-                                        <i data-feather="search" class="w-3 h-3"></i>
-                                    </span>
+                        </a>
+                        <div class="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-3 text-xs text-slate-500">
+                            <p class="font-semibold text-slate-600">Übersicht</p>
+                            <div class="mt-2 grid gap-2">
+                                <div class="flex items-center justify-between">
+                                    <span>Kategorien</span>
+                                    <span class="font-semibold text-slate-700" x-text="categories.length"></span>
+                                </div>
+                                <div class="flex items-center justify-between">
+                                    <span>Assets</span>
+                                    <span class="font-semibold text-slate-700" x-text="assets.length"></span>
                                 </div>
                             </div>
-                            <template x-for="category in filteredCategories()" :key="category.id">
-                                <div class="group grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 px-3 py-2 rounded-xl hover:bg-white transition-colors">
-                                    <button @click="loadDevices(category.id)" class="flex items-start gap-2 min-w-0 text-left">
-                                        <div class="mt-0.5" x-html="feather.icons[category.icon]?.toSvg({ class: 'w-4 h-4 text-slate-500' })"></div>
-                                        <span class="sidebar-text whitespace-normal break-words leading-snug" x-text="category.name"></span>
-                                    </button>
-                                    <div class="flex items-center gap-2 pt-0.5">
-                                        <button @click="editCategoryModal(category)" class="icon-button text-slate-500 hover:text-slate-900" aria-label="Kategorie bearbeiten">
-                                            <i data-feather="edit" class="w-4 h-4"></i>
-                                        </button>
-                                        <button @click="deleteCategory(category.id)" class="icon-button text-rose-500 hover:text-rose-700" aria-label="Kategorie löschen">
-                                            <i data-feather="trash-2" class="w-4 h-4"></i>
-                                        </button>
-                                    </div>
-                                </div>
-                            </template>
-                            <button @click="openAddCategoryModal()" class="flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium text-blue-600 hover:text-blue-800 w-full rounded-xl hover:bg-white transition-colors sidebar-text">
-                                <i data-feather="plus-circle" class="w-4 h-4"></i>
-                                Kategorie hinzufügen
-                            </button>
-                        </div>
-
-                        <button @click="assetsOpen = !assetsOpen" class="sidebar-toggle" type="button">
-                            <span class="flex items-center gap-2">
-                                <span class="sidebar-link-icon"><i data-feather="package" class="w-4 h-4"></i></span>
-                                Assets
-                            </span>
-                            <svg :class="{ 'rotate-180': assetsOpen }" class="w-4 h-4 text-slate-500 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-                            </svg>
-                        </button>
-                        <div x-show="assetsOpen" x-transition class="rounded-2xl border border-slate-200 bg-slate-50 px-2 py-2 space-y-1 text-sm text-slate-800">
-                            <template x-for="asset in assets" :key="asset.id">
-                                <div class="group flex items-center justify-between px-3 py-2 rounded-xl hover:bg-white transition-colors">
-                                    <button @click="openAssetDetail(asset)" class="flex items-center gap-2 flex-1 min-w-0 text-left">
-                                        <span class="inline-flex items-center justify-center w-7 h-7 rounded-lg bg-indigo-50 text-indigo-600 text-xs font-semibold" x-text="asset.device_count || 0"></span>
-                                        <span class="sidebar-text truncate" x-text="asset.name"></span>
-                                    </button>
-                                    <div class="flex items-center gap-2">
-                                        <button @click="openEditAssetModal(asset)" class="icon-button text-slate-500 hover:text-slate-900" aria-label="Asset bearbeiten">
-                                            <i data-feather="edit" class="w-4 h-4"></i>
-                                        </button>
-                                        <button @click="deleteAsset(asset.id)" class="icon-button text-rose-500 hover:text-rose-700" aria-label="Asset löschen">
-                                            <i data-feather="trash-2" class="w-4 h-4"></i>
-                                        </button>
-                                    </div>
-                                </div>
-                            </template>
-                            <button @click="openAddAssetModal()" class="flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium text-indigo-600 hover:text-indigo-800 w-full rounded-xl hover:bg-white transition-colors sidebar-text">
-                                <i data-feather="plus-circle" class="w-4 h-4"></i>
-                                Asset hinzufügen
-                            </button>
                         </div>
                     </div>
                 </div>
@@ -406,6 +354,105 @@
                                 </div>
                                 <div class="flex flex-wrap items-center gap-2">
                                     <button type="button" @click="resetDeviceFilters()" class="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-50">Filter zurücksetzen</button>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                    <section id="inventory-taxonomy" class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                        <div class="flex flex-wrap items-center justify-between gap-4">
+                            <div>
+                                <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Struktur</p>
+                                <h3 class="text-xl font-semibold text-slate-900">Kategorien &amp; Assets</h3>
+                                <p class="mt-1 text-sm text-slate-500">Verwalte Kategorien und Assets zentral im Arbeitsbereich.</p>
+                            </div>
+                            <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                                <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
+                                    <i data-feather="layers" class="h-3 w-3"></i>
+                                    <span x-text="categories.length"></span> Kategorien
+                                </span>
+                                <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
+                                    <i data-feather="package" class="h-3 w-3"></i>
+                                    <span x-text="assets.length"></span> Assets
+                                </span>
+                            </div>
+                        </div>
+                        <div class="mt-6 grid gap-6 lg:grid-cols-2">
+                            <div class="rounded-2xl border border-slate-200 bg-slate-50/60 p-5">
+                                <div class="flex flex-wrap items-start justify-between gap-3">
+                                    <div>
+                                        <h4 class="text-sm font-semibold text-slate-900">Kategorien</h4>
+                                        <p class="text-xs text-slate-500">Für Gerätefilter, Auswertung und Struktur.</p>
+                                    </div>
+                                    <button @click="openAddCategoryModal()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-blue-600 hover:text-blue-800">
+                                        <i data-feather="plus-circle" class="h-4 w-4"></i>
+                                        Kategorie hinzufügen
+                                    </button>
+                                </div>
+                                <div class="mt-4 space-y-3">
+                                    <div class="relative">
+                                        <input type="text" x-model="categorySearchQuery" placeholder="Kategorien suchen..." class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 pr-9 text-xs text-slate-600 focus:border-blue-500 focus:ring-blue-500">
+                                        <span class="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400">
+                                            <i data-feather="search" class="h-3 w-3"></i>
+                                        </span>
+                                    </div>
+                                    <div class="space-y-2 max-h-72 overflow-auto pr-1">
+                                        <template x-for="category in filteredCategories()" :key="category.id">
+                                            <div class="group grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-transparent bg-white px-3 py-2 shadow-sm hover:border-slate-200">
+                                                <button @click="loadDevices(category.id)" class="flex items-start gap-2 min-w-0 text-left">
+                                                    <div class="mt-0.5" x-html="feather.icons[category.icon]?.toSvg({ class: 'w-4 h-4 text-slate-500' })"></div>
+                                                    <span class="text-sm font-medium text-slate-700 whitespace-normal break-words leading-snug" x-text="category.name"></span>
+                                                </button>
+                                                <div class="flex items-center gap-2 pt-0.5">
+                                                    <button @click="editCategoryModal(category)" class="icon-button text-slate-500 hover:text-slate-900" aria-label="Kategorie bearbeiten">
+                                                        <i data-feather="edit" class="w-4 h-4"></i>
+                                                    </button>
+                                                    <button @click="deleteCategory(category.id)" class="icon-button text-rose-500 hover:text-rose-700" aria-label="Kategorie löschen">
+                                                        <i data-feather="trash-2" class="w-4 h-4"></i>
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </template>
+                                        <p x-show="filteredCategories().length === 0" class="text-xs text-slate-400">Keine Kategorien gefunden.</p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="rounded-2xl border border-slate-200 bg-slate-50/60 p-5">
+                                <div class="flex flex-wrap items-start justify-between gap-3">
+                                    <div>
+                                        <h4 class="text-sm font-semibold text-slate-900">Assets</h4>
+                                        <p class="text-xs text-slate-500">Assets bündeln Geräte und zeigen Verfügbarkeit.</p>
+                                    </div>
+                                    <button @click="openAddAssetModal()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-indigo-600 hover:text-indigo-800">
+                                        <i data-feather="plus-circle" class="h-4 w-4"></i>
+                                        Asset hinzufügen
+                                    </button>
+                                </div>
+                                <div class="mt-4 space-y-3">
+                                    <div class="relative">
+                                        <input type="text" x-model="assetSearchQuery" placeholder="Assets suchen..." class="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 pr-9 text-xs text-slate-600 focus:border-blue-500 focus:ring-blue-500">
+                                        <span class="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400">
+                                            <i data-feather="search" class="h-3 w-3"></i>
+                                        </span>
+                                    </div>
+                                    <div class="space-y-2 max-h-72 overflow-auto pr-1">
+                                        <template x-for="asset in filteredAssets()" :key="asset.id">
+                                            <div class="group grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-transparent bg-white px-3 py-2 shadow-sm hover:border-slate-200">
+                                                <button @click="openAssetDetail(asset)" class="flex items-start gap-3 min-w-0 text-left">
+                                                    <span class="inline-flex items-center justify-center w-7 h-7 rounded-lg bg-indigo-50 text-indigo-600 text-xs font-semibold" x-text="asset.device_count || 0"></span>
+                                                    <span class="text-sm font-medium text-slate-700 whitespace-normal break-words leading-snug" x-text="asset.name"></span>
+                                                </button>
+                                                <div class="flex items-center gap-2">
+                                                    <button @click="openEditAssetModal(asset)" class="icon-button text-slate-500 hover:text-slate-900" aria-label="Asset bearbeiten">
+                                                        <i data-feather="edit" class="w-4 h-4"></i>
+                                                    </button>
+                                                    <button @click="deleteAsset(asset.id)" class="icon-button text-rose-500 hover:text-rose-700" aria-label="Asset löschen">
+                                                        <i data-feather="trash-2" class="w-4 h-4"></i>
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </template>
+                                        <p x-show="filteredAssets().length === 0" class="text-xs text-slate-400">Keine Assets gefunden.</p>
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
### Motivation
- The previous stacked layout let names wrap but introduced extra vertical space, making the sidebar taller than necessary.
- The goal is to keep long category names wrapping naturally while keeping edit/delete actions visible on the same row without increasing item height.
- Also improve visual alignment of icons and text for a tighter, cleaner appearance.

### Description
- Switch the category row wrapper to a two-column grid using `grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2` so labels and actions live in separate columns.
- Update the category button to `flex items-start gap-2 min-w-0` and offset the icon with `mt-0.5` to align with wrapped text.
- Replace `truncate` with `whitespace-normal break-words leading-snug` so category names wrap cleanly.
- Keep action icons inline and compact by using `flex items-center gap-2 pt-0.5` for the action container.

### Testing
- Installed Python dependencies with `pip install -r requirements.txt`, which completed successfully.
- Launched the dev server with `python app.py`, which served the app at `http://127.0.0.1:5000` (succeeded).
- Executed a Playwright script to open the UI and capture a screenshot, producing `artifacts/categories-sidebar.png` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6978963eceb4832e8ea05b3aea26cd40)