### PR TITLE
Improve dashboard focus mode for categories

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -22,7 +22,7 @@ document.addEventListener('alpine:init', () => {
         createdTo: '',
         specQuery: '',
         sortDropdownOpen: false,
-        filtersOpen: true,
+        filtersOpen: false,
         featureFlags: {
             pro_enabled: false,
             pro_features: [],
@@ -253,6 +253,9 @@ document.addEventListener('alpine:init', () => {
 
         async loadDevices(categoryId = null) {
             this.activeCategory = categoryId;
+            if (categoryId) {
+                this.filtersOpen = false;
+            }
             const url = categoryId 
                 ? `/api/devices?category_id=${categoryId}`
                 : '/api/devices';

--- a/templates/index.html
+++ b/templates/index.html
@@ -269,7 +269,13 @@
                         <div class="flex flex-wrap items-center justify-between gap-4">
                             <div>
                                 <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Inventory</p>
-                                <h2 class="text-2xl font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h2>
+                                <div class="flex flex-wrap items-center gap-3">
+                                    <h2 class="text-2xl font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h2>
+                                    <button x-show="activeCategory" @click="loadDevices()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-50">
+                                        <i data-feather="x-circle" class="h-3 w-3"></i>
+                                        Alle Geräte anzeigen
+                                    </button>
+                                </div>
                                 <p class="mt-1 text-sm text-slate-500">Geräte, Assets und Kategorien zentral verwalten.</p>
                             </div>
                             <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
@@ -455,7 +461,7 @@
                             </div>
                         </div>
                     </section>
-                    <section class="grid gap-6 lg:grid-cols-2">
+                    <section class="grid gap-6 lg:grid-cols-2" x-show="!activeCategory">
                         <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
                             <div class="flex items-center justify-between">
                                 <div>
@@ -482,7 +488,7 @@
                         </div>
                     </section>
 
-                    <section class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+                    <section class="grid gap-6" :class="activeCategory ? 'lg:grid-cols-1' : 'lg:grid-cols-[minmax(0,1fr)_320px]'">
                         <div class="space-y-4">
                             <div class="flex flex-wrap items-center justify-between gap-3">
                                 <div class="inline-flex rounded-full border border-slate-200 bg-white p-1 text-xs font-semibold">
@@ -614,7 +620,7 @@
                             </div>
                         </div>
 
-                        <aside class="space-y-4">
+                        <aside class="space-y-4" x-show="!activeCategory">
                             <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
                                 <div class="flex items-center justify-between">
                                     <div>


### PR DESCRIPTION
### Motivation
- Reduce vertical scrolling and improve focus when a category is selected so device entries are immediately visible. 
- Ensure the dashboard filter panel starts collapsed and automatically hides when a category is activated to maximise usable space. 
- Temporarily hide non-essential widgets (`PondSec AI`, `Insights`, `Activities`) while in category-focus mode to create a cleaner, more user-friendly UI.

### Description
- Set default filter state to collapsed by changing `filtersOpen` to `false` in `static/script.js`.
- Close the filters when a category is selected by updating `loadDevices(categoryId)` to set `this.filtersOpen = false` when `categoryId` is provided in `static/script.js`.
- Add a quick reset control in the header (`Alle Geräte anzeigen` button) which calls `loadDevices()` to clear `activeCategory` in `templates/index.html`.
- Hide the `PondSec AI` widgets and the right-side `Insights`/`Activities` aside when `activeCategory` is set by adding `x-show="!activeCategory"` and update the layout grid to a single column while focused using conditional `:class` in `templates/index.html`.

### Testing
- Installed Python deps via `pip install -r requirements.txt` which completed successfully. (succeeded)
- Started the Flask app with `python app.py` and confirmed the server responded to requests in the logs. (succeeded)
- Ran an automated Playwright script that navigated to the dashboard, interacted with the category control, and produced a screenshot artifact `artifacts/dashboard-category-focus.png` to verify the focused layout; the script executed successfully. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69789ec01498832e8553804b28ef155b)