### PR TITLE
Refresh feather icons on device reload and constrain Specs column

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -22,7 +22,7 @@ document.addEventListener('alpine:init', () => {
         createdTo: '',
         specQuery: '',
         sortDropdownOpen: false,
-        filtersOpen: true,
+        filtersOpen: false,
         featureFlags: {
             pro_enabled: false,
             pro_features: [],
@@ -253,6 +253,9 @@ document.addEventListener('alpine:init', () => {
 
         async loadDevices(categoryId = null) {
             this.activeCategory = categoryId;
+            if (categoryId) {
+                this.filtersOpen = false;
+            }
             const url = categoryId 
                 ? `/api/devices?category_id=${categoryId}`
                 : '/api/devices';
@@ -261,6 +264,11 @@ document.addEventListener('alpine:init', () => {
             if (response.ok) {
                 this.devices = await response.json();
                 this.searchDevices();
+                this.$nextTick(() => {
+                    if (window.feather) {
+                        feather.replace();
+                    }
+                });
             }
             if (this.selectedDevice) {
                 const updated = this.devices.find(device => device.id === this.selectedDevice.id);

--- a/templates/index.html
+++ b/templates/index.html
@@ -269,7 +269,13 @@
                         <div class="flex flex-wrap items-center justify-between gap-4">
                             <div>
                                 <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Inventory</p>
-                                <h2 class="text-2xl font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h2>
+                                <div class="flex flex-wrap items-center gap-3">
+                                    <h2 class="text-2xl font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h2>
+                                    <button x-show="activeCategory" @click="loadDevices()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-50">
+                                        <i data-feather="x-circle" class="h-3 w-3"></i>
+                                        Alle Geräte anzeigen
+                                    </button>
+                                </div>
                                 <p class="mt-1 text-sm text-slate-500">Geräte, Assets und Kategorien zentral verwalten.</p>
                             </div>
                             <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
@@ -455,7 +461,7 @@
                             </div>
                         </div>
                     </section>
-                    <section class="grid gap-6 lg:grid-cols-2">
+                    <section class="grid gap-6 lg:grid-cols-2" x-show="!activeCategory">
                         <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
                             <div class="flex items-center justify-between">
                                 <div>
@@ -482,7 +488,7 @@
                         </div>
                     </section>
 
-                    <section class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+                    <section class="grid gap-6" :class="activeCategory ? 'lg:grid-cols-1' : 'lg:grid-cols-[minmax(0,1fr)_320px]'">
                         <div class="space-y-4">
                             <div class="flex flex-wrap items-center justify-between gap-3">
                                 <div class="inline-flex rounded-full border border-slate-200 bg-white p-1 text-xs font-semibold">
@@ -529,11 +535,11 @@
                                                     </td>
                                                     <td class="py-4 px-4 sm:px-6 text-slate-700 truncate max-w-0" x-text="device.location_name || '-' "></td>
                                                     <td class="hidden md:table-cell py-4 px-4 sm:px-6 text-slate-700 truncate max-w-0" x-text="device.serial_number || '-' "></td>
-                                                    <td class="hidden lg:table-cell py-4 px-4 sm:px-6">
-                                                        <div class="flex flex-wrap gap-2">
+                                                    <td class="hidden lg:table-cell py-4 px-4 sm:px-6 max-w-[16rem]">
+                                                        <div class="flex flex-wrap gap-2 max-w-full">
                                                             <template x-for="(value, key) in Object.entries(JSON.parse(device.specs || '{}')).slice(0, 2)" :key="key">
-                                                                <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
-                                                                    <span x-text="key"></span>: <span class="ml-1 text-slate-800" x-text="value"></span>
+                                                                <span class="inline-flex max-w-full items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+                                                                    <span class="truncate" x-text="key"></span>: <span class="ml-1 truncate text-slate-800" x-text="value"></span>
                                                                 </span>
                                                             </template>
                                                             <span x-show="Object.keys(JSON.parse(device.specs || '{}')).length === 0" class="text-xs text-slate-400">Keine Specs</span>
@@ -614,7 +620,7 @@
                             </div>
                         </div>
 
-                        <aside class="space-y-4">
+                        <aside class="space-y-4" x-show="!activeCategory">
                             <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
                                 <div class="flex items-center justify-between">
                                     <div>


### PR DESCRIPTION
### Motivation
- Fix a UI bug where the action menu icon (`more-vertical`) disappears after selecting a category and then clicking "Alle Geräte anzeigen". 
- Prevent long spec chips in the `Specs` column from overflowing into the `Aktionen` column and overlapping action buttons. 

### Description
- Re-run `feather.replace()` after the device list is reloaded by calling it inside a `$nextTick` in `loadDevices()` to restore missing icons. 
- Add a visible `Alle Geräte anzeigen` button (calls `loadDevices()`) to clear `activeCategory` and return to the full device view. 
- Default `filtersOpen` to `false` and explicitly set `filtersOpen = false` when a category is selected to keep filters collapsed when navigating categories. 
- Constrain the Specs column by adding `max-w-[16rem]` to the `td`, `max-w-full` to the wrapping `div`, and apply `truncate` to spec key and value spans so long spec chips wrap/truncate instead of overlapping actions. 
- Make several layout adjustments: conditional `x-show` to hide side panels when a category is active and responsive grid class binding so the main/list layout adapts when filtering by category. 

### Testing
- Started the application with `python app.py` and verified the server runs without errors. 
- Ran a Playwright script to capture a dashboard screenshot (`artifacts/dashboard-feather-icons.png`) after the changes, which completed successfully. 
- No automated unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69789ec01498832e8553804b28ef155b)