### PR TITLE
Make device rows clickable and simplify actions

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -22,7 +22,7 @@ document.addEventListener('alpine:init', () => {
         createdTo: '',
         specQuery: '',
         sortDropdownOpen: false,
-        filtersOpen: true,
+        filtersOpen: false,
         featureFlags: {
             pro_enabled: false,
             pro_features: [],
@@ -253,6 +253,9 @@ document.addEventListener('alpine:init', () => {
 
         async loadDevices(categoryId = null) {
             this.activeCategory = categoryId;
+            if (categoryId) {
+                this.filtersOpen = false;
+            }
             const url = categoryId 
                 ? `/api/devices?category_id=${categoryId}`
                 : '/api/devices';
@@ -261,6 +264,11 @@ document.addEventListener('alpine:init', () => {
             if (response.ok) {
                 this.devices = await response.json();
                 this.searchDevices();
+                this.$nextTick(() => {
+                    if (window.feather) {
+                        feather.replace();
+                    }
+                });
             }
             if (this.selectedDevice) {
                 const updated = this.devices.find(device => device.id === this.selectedDevice.id);

--- a/templates/index.html
+++ b/templates/index.html
@@ -269,7 +269,13 @@
                         <div class="flex flex-wrap items-center justify-between gap-4">
                             <div>
                                 <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Inventory</p>
-                                <h2 class="text-2xl font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h2>
+                                <div class="flex flex-wrap items-center gap-3">
+                                    <h2 class="text-2xl font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h2>
+                                    <button x-show="activeCategory" @click="loadDevices()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-50">
+                                        <i data-feather="x-circle" class="h-3 w-3"></i>
+                                        Alle Geräte anzeigen
+                                    </button>
+                                </div>
                                 <p class="mt-1 text-sm text-slate-500">Geräte, Assets und Kategorien zentral verwalten.</p>
                             </div>
                             <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
@@ -455,7 +461,7 @@
                             </div>
                         </div>
                     </section>
-                    <section class="grid gap-6 lg:grid-cols-2">
+                    <section class="grid gap-6 lg:grid-cols-2" x-show="!activeCategory">
                         <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
                             <div class="flex items-center justify-between">
                                 <div>
@@ -482,7 +488,7 @@
                         </div>
                     </section>
 
-                    <section class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+                    <section class="grid gap-6" :class="activeCategory ? 'lg:grid-cols-1' : 'lg:grid-cols-[minmax(0,1fr)_320px]'">
                         <div class="space-y-4">
                             <div class="flex flex-wrap items-center justify-between gap-3">
                                 <div class="inline-flex rounded-full border border-slate-200 bg-white p-1 text-xs font-semibold">
@@ -517,7 +523,7 @@
                                         </thead>
                                         <tbody class="divide-y divide-slate-100">
                                             <template x-for="device in filteredDevices" :key="device.id">
-                                                <tr class="hover:bg-slate-50">
+                                                <tr class="hover:bg-slate-50 cursor-pointer" @click="openDeviceDetail(device)">
                                                     <td class="py-4 px-4 sm:px-6">
                                                         <p class="max-w-[14rem] truncate font-semibold text-slate-900 sm:max-w-none" x-text="device.name"></p>
                                                         <p class="text-xs text-slate-500" x-text="device.created_at?.slice(0, 10) || ''"></p>
@@ -529,25 +535,24 @@
                                                     </td>
                                                     <td class="py-4 px-4 sm:px-6 text-slate-700 truncate max-w-0" x-text="device.location_name || '-' "></td>
                                                     <td class="hidden md:table-cell py-4 px-4 sm:px-6 text-slate-700 truncate max-w-0" x-text="device.serial_number || '-' "></td>
-                                                    <td class="hidden lg:table-cell py-4 px-4 sm:px-6">
-                                                        <div class="flex flex-wrap gap-2">
+                                                    <td class="hidden lg:table-cell py-4 px-4 sm:px-6 max-w-[16rem]">
+                                                        <div class="flex flex-wrap gap-2 max-w-full">
                                                             <template x-for="(value, key) in Object.entries(JSON.parse(device.specs || '{}')).slice(0, 2)" :key="key">
-                                                                <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
-                                                                    <span x-text="key"></span>: <span class="ml-1 text-slate-800" x-text="value"></span>
+                                                                <span class="inline-flex max-w-full items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+                                                                    <span class="truncate" x-text="key"></span>: <span class="ml-1 truncate text-slate-800" x-text="value"></span>
                                                                 </span>
                                                             </template>
                                                             <span x-show="Object.keys(JSON.parse(device.specs || '{}')).length === 0" class="text-xs text-slate-400">Keine Specs</span>
                                                         </div>
                                                     </td>
-                                                    <td class="py-4 px-4 sm:px-6 text-right">
+                                                    <td class="py-4 px-4 sm:px-6 text-right" @click.stop>
                                                         <div class="flex items-center justify-end gap-2" x-data="{ open: false }">
-                                                            <button @click="openDeviceDetail(device)" class="rounded-full border border-blue-100 px-3 py-1 text-xs font-semibold text-blue-600 hover:bg-blue-50">Öffnen</button>
-                                                            <button @click="open = !open" class="icon-button inline-flex items-center justify-center rounded-full border border-slate-200 px-2 py-1 text-slate-600 hover:bg-slate-100" aria-label="Weitere Aktionen">
+                                                            <button @click.stop="open = !open" class="icon-button inline-flex items-center justify-center rounded-full border border-slate-200 px-2 py-1 text-slate-600 hover:bg-slate-100" aria-label="Weitere Aktionen">
                                                                 <i data-feather="more-vertical" class="h-4 w-4"></i>
                                                             </button>
                                                             <div x-show="open" @click.away="open = false" class="absolute right-4 z-20 mt-24 w-40 rounded-2xl border border-slate-200 bg-white shadow-xl" x-transition>
-                                                                <button @click="openEditDeviceModal(device); open=false" class="block w-full px-4 py-2 text-left text-sm hover:bg-slate-50">Bearbeiten</button>
-                                                                <button @click="deleteDevice(device.id); open=false" class="block w-full px-4 py-2 text-left text-sm text-rose-600 hover:bg-rose-50">Löschen</button>
+                                                                <button @click.stop="openEditDeviceModal(device); open=false" class="block w-full px-4 py-2 text-left text-sm hover:bg-slate-50">Bearbeiten</button>
+                                                                <button @click.stop="deleteDevice(device.id); open=false" class="block w-full px-4 py-2 text-left text-sm text-rose-600 hover:bg-rose-50">Löschen</button>
                                                             </div>
                                                         </div>
                                                     </td>
@@ -614,7 +619,7 @@
                             </div>
                         </div>
 
-                        <aside class="space-y-4">
+                        <aside class="space-y-4" x-show="!activeCategory">
                             <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
                                 <div class="flex items-center justify-between">
                                     <div>


### PR DESCRIPTION
### Motivation
- Reduce horizontal clutter in the device list by removing the dedicated `Öffnen` button and opening details when a row is clicked. 
- Keep the overflow action menu compact and isolated so it does not trigger row navigation and remains accessible. 
- Preserve icon rendering and prevent long spec chips from overlapping the actions by ensuring icons are refreshed and specs are constrained.

### Description
- Make device table rows clickable by adding `@click="openDeviceDetail(device)"` on the `<tr>` and add `cursor-pointer` for affordance. 
- Remove the separate `Öffnen` button and isolate the actions column with `@click.stop` on the actions cell and `@click.stop` on overflow menu buttons so the menu toggles without opening the row. 
- Add an `Alle Geräte anzeigen` button to clear `activeCategory` and added conditional layout/showing so side panels and grid columns adapt when a category is active. 
- Constrain the Specs column with `max-w-[16rem]` and `truncate` on spec key/values, default `filtersOpen` to `false`, and re-run `feather.replace()` inside `loadDevices()` via `$nextTick` to restore icons after reloading devices.

### Testing
- Started the application with `python app.py` and the server started successfully. 
- Ran a Playwright script that loaded the dashboard and saved a screenshot (`artifacts/dashboard-row-click.png`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69789ec01498832e8553804b28ef155b)