### PR TITLE
Make ticket notification emails asynchronous to avoid blocking requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -5196,6 +5196,25 @@ def send_notification_email(settings, recipients, subject, body, html_body=None)
     except Exception:
         return False
 
+def send_notification_email_async(settings, recipients, subject, body, html_body=None):
+    if not settings or not settings["enabled"]:
+        return False
+    settings_payload = dict(settings)
+
+    def dispatch():
+        success = send_notification_email(
+            settings_payload,
+            recipients,
+            subject,
+            body,
+            html_body=html_body,
+        )
+        if not success:
+            app.logger.warning("Benachrichtigungs-E-Mail konnte nicht asynchron gesendet werden.")
+
+    threading.Thread(target=dispatch, daemon=True).start()
+    return True
+
 def truncate_text(value, limit=240):
     if not value:
         return ""
@@ -5433,7 +5452,7 @@ def trigger_ticket_notifications(db, event_type, ticket, changes=None, actor=Non
         actor=actor,
         comment=comment,
     )
-    send_notification_email(settings, [creator_email], subject, text_body, html_body=html_body)
+    send_notification_email_async(settings, [creator_email], subject, text_body, html_body=html_body)
 
 def fetch_ticket(db, ticket_id):
     ticket = db.execute('''


### PR DESCRIPTION
### Motivation
- Users reported slow UI when creating tickets or posting comments because notification sending can block request handling, so notifications should be dispatched in the background to improve perceived performance.

### Description
- Add an async helper `send_notification_email_async` that spawns a daemon `threading.Thread` to call the existing `send_notification_email` and logs a warning on failure.
- Switch `trigger_ticket_notifications` to call `send_notification_email_async` instead of `send_notification_email` so ticket creation/comment requests no longer block on SMTP delivery.
- Preserve existing validation and behavior by copying `settings` into a payload and keeping the same email rendering logic via `render_ticket_email`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6978a41529ac832ebd48ae453b7d92ff)