### PR TITLE
Fix knowledge base grid layout on smaller screens

### DIFF
--- a/templates/knowledge.html
+++ b/templates/knowledge.html
@@ -218,8 +218,8 @@
                     </div>
                 </section>
 
-                <section class="grid gap-6 xl:grid-cols-[0.8fr_1fr_1.2fr]">
-                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4">
+                <section class="grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-[0.8fr_1fr_1.2fr]">
+                    <div class="min-w-0 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4">
                         <div class="flex items-center justify-between">
                             <div>
                                 <p class="text-xs uppercase text-slate-400">Kategorien</p>
@@ -249,7 +249,7 @@
                         </div>
                     </div>
 
-                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4">
+                    <div class="min-w-0 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4">
                         <div class="flex items-center justify-between gap-3">
                             <div>
                                 <p class="text-xs uppercase text-slate-400">Einträge</p>
@@ -274,7 +274,7 @@
                         </div>
                     </div>
 
-                    <div class="space-y-6">
+                    <div class="min-w-0 space-y-6 lg:col-span-2 xl:col-span-1">
                         <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm" x-show="selectedEntry">
                             <template x-if="selectedEntry">
                                 <div class="space-y-4">


### PR DESCRIPTION
### Motivation
- Prevent the knowledge detail panel from overflowing off the right edge on small/medium screens and ensure category and entry lists remain visible when an entry is selected. 
- Make the knowledge page layout responsive so the detail view does not hide or push other panels out of view.

### Description
- Updated `templates/knowledge.html` to use a responsive grid: `grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-[0.8fr_1fr_1.2fr]` to collapse to one column on small screens and expand on larger ones. 
- Added `min-w-0` to the panel columns and made the details panel span the full width on medium (`lg:col-span-2`) to prevent flexbox overflow and ensure correct wrapping. 
- Changes applied in `templates/knowledge.html` (adjusted grid classes and added `min-w-0`).

### Testing
- Ran the application start with `python app.py`, but the run failed due to a missing dependency: `ModuleNotFoundError: No module named 'apscheduler'`, so no further automated UI tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6978a7eacd38832e9a94cffc753cc950)