### PR TITLE
Focus knowledge entry detail view

### DIFF
--- a/static/knowledge.js
+++ b/static/knowledge.js
@@ -73,6 +73,10 @@ document.addEventListener('alpine:init', () => {
             this.$nextTick(() => feather.replace());
         },
 
+        clearSelectedEntry() {
+            this.selectedEntry = null;
+        },
+
         setCategoryFilter(categoryId) {
             this.selectedCategoryId = categoryId;
             this.loadEntries();

--- a/templates/knowledge.html
+++ b/templates/knowledge.html
@@ -218,8 +218,8 @@
                     </div>
                 </section>
 
-                <section class="grid gap-6 xl:grid-cols-[0.8fr_1fr_1.2fr]">
-                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4">
+                <section class="grid gap-6" :class="selectedEntry ? 'grid-cols-1' : 'xl:grid-cols-[0.8fr_1fr_1.2fr]'">
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4" x-show="!selectedEntry" x-transition>
                         <div class="flex items-center justify-between">
                             <div>
                                 <p class="text-xs uppercase text-slate-400">Kategorien</p>
@@ -249,7 +249,7 @@
                         </div>
                     </div>
 
-                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4">
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4" x-show="!selectedEntry" x-transition>
                         <div class="flex items-center justify-between gap-3">
                             <div>
                                 <p class="text-xs uppercase text-slate-400">Einträge</p>
@@ -285,6 +285,9 @@
                                             <p class="text-sm text-slate-500" x-text="selectedEntry.summary || 'Keine Kurzbeschreibung.'"></p>
                                         </div>
                                         <div class="flex items-center gap-2" x-data="{ open: false }">
+                                            <button @click="clearSelectedEntry()" class="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-50">
+                                                Zurück
+                                            </button>
                                             <button x-show="can('knowledge.manage')" @click="openEntryModal(selectedEntry)" class="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700">
                                                 Bearbeiten
                                             </button>


### PR DESCRIPTION
### Motivation

- Improve the knowledge base UX by focusing on a single opened article and hiding the surrounding navigation to save space and reduce distraction.
- Provide a clear, in-UI way to return from the focused detail back to the category/list view.

### Description

- Make the knowledge grid responsive to `selectedEntry` by changing the layout class with `:class` so the detail view can take the full width when an article is open in `templates/knowledge.html`.
- Hide the categories pane and the entries list while an article is open by adding `x-show="!selectedEntry"` and `x-transition` to those blocks in `templates/knowledge.html`.
- Add a `Zurück` button to the detail header that calls a new `clearSelectedEntry()` method, and implement `clearSelectedEntry()` in `static/knowledge.js` which clears `selectedEntry`.

### Testing

- Attempted to start the app with `python app.py` but the process failed with `ModuleNotFoundError: No module named 'apscheduler'`, so a full end-to-end server test could not be completed.
- Attempted an automated Playwright screenshot of `/knowledge` which failed with `net::ERR_EMPTY_RESPONSE` because the server was not running, so visual verification was not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6978a916d8a8832eb9e159a17b3f685c)