### PR TITLE
Refine knowledge view transitions and add back button

### DIFF
--- a/static/knowledge.js
+++ b/static/knowledge.js
@@ -73,6 +73,10 @@ document.addEventListener('alpine:init', () => {
             this.$nextTick(() => feather.replace());
         },
 
+        clearSelectedEntry() {
+            this.selectedEntry = null;
+        },
+
         setCategoryFilter(categoryId) {
             this.selectedCategoryId = categoryId;
             this.loadEntries();

--- a/templates/knowledge.html
+++ b/templates/knowledge.html
@@ -218,8 +218,8 @@
                     </div>
                 </section>
 
-                <section class="grid gap-6 xl:grid-cols-[0.8fr_1fr_1.2fr]">
-                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4">
+                <section class="grid gap-6" :class="selectedEntry ? 'grid-cols-1' : 'xl:grid-cols-[0.8fr_1fr_1.2fr]'">
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4" x-show="!selectedEntry" x-transition:enter="transition ease-out duration-300" x-transition:enter-start="opacity-0 -translate-x-3" x-transition:enter-end="opacity-100 translate-x-0" x-transition:leave="transition ease-in duration-200" x-transition:leave-start="opacity-100 translate-x-0" x-transition:leave-end="opacity-0 -translate-x-3">
                         <div class="flex items-center justify-between">
                             <div>
                                 <p class="text-xs uppercase text-slate-400">Kategorien</p>
@@ -249,7 +249,7 @@
                         </div>
                     </div>
 
-                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4">
+                    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4" x-show="!selectedEntry" x-transition:enter="transition ease-out duration-300" x-transition:enter-start="opacity-0 -translate-x-3" x-transition:enter-end="opacity-100 translate-x-0" x-transition:leave="transition ease-in duration-200" x-transition:leave-start="opacity-100 translate-x-0" x-transition:leave-end="opacity-0 -translate-x-3">
                         <div class="flex items-center justify-between gap-3">
                             <div>
                                 <p class="text-xs uppercase text-slate-400">Einträge</p>
@@ -275,7 +275,7 @@
                     </div>
 
                     <div class="space-y-6">
-                        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm" x-show="selectedEntry">
+                        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm" x-show="selectedEntry" x-transition:enter="transition ease-out duration-300" x-transition:enter-start="opacity-0 translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition ease-in duration-200" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 translate-y-2">
                             <template x-if="selectedEntry">
                                 <div class="space-y-4">
                                     <div class="flex items-start justify-between gap-4">
@@ -285,6 +285,9 @@
                                             <p class="text-sm text-slate-500" x-text="selectedEntry.summary || 'Keine Kurzbeschreibung.'"></p>
                                         </div>
                                         <div class="flex items-center gap-2" x-data="{ open: false }">
+                                            <button @click="clearSelectedEntry()" class="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-50">
+                                                Zurück
+                                            </button>
                                             <button x-show="can('knowledge.manage')" @click="openEntryModal(selectedEntry)" class="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700">
                                                 Bearbeiten
                                             </button>
@@ -320,7 +323,7 @@
                                 </div>
                             </template>
                         </div>
-                        <div class="rounded-3xl border border-dashed border-slate-200 bg-white/60 p-10 text-center text-slate-400" x-show="!selectedEntry">
+                        <div class="rounded-3xl border border-dashed border-slate-200 bg-white/60 p-10 text-center text-slate-400" x-show="!selectedEntry" x-transition:enter="transition ease-out duration-300" x-transition:enter-start="opacity-0 translate-y-1" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition ease-in duration-200" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 translate-y-1">
                             <p class="text-sm font-semibold text-slate-600">Wähle einen Artikel aus.</p>
                             <p class="mt-2 text-xs">Hier erscheint die Detailansicht mit Lösungsschritten, Workflows oder Themenwissen.</p>
                         </div>


### PR DESCRIPTION
### Motivation
- Improve UX when opening and closing knowledge categories and articles by providing smoother, consistent animations. 
- Provide a simple in-UI way to close the focused article and return to the list using a `Zurück` button.

### Description
- Add Alpine `x-transition` enter/leave classes to the categories panel, entries list, detail panel, and empty-state in `templates/knowledge.html` to smooth open/close motion. 
- Keep the knowledge grid responsive to `selectedEntry` via the existing `:class` so the detail view can expand to full width when an article is selected. 
- Add a `Zurück` button in the detail header that triggers the existing `clearSelectedEntry()` to exit the focused detail view. 
- Files changed: `templates/knowledge.html` (transitions and back button); `clearSelectedEntry()` is present in `static/knowledge.js` from the prior update.

### Testing
- No automated test suite was executed for this change. 
- A prior attempt to start the app with `python app.py` failed with `ModuleNotFoundError: No module named 'apscheduler'`, which prevented full end-to-end verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6978a916d8a8832eb9e159a17b3f685c)