### PR TITLE
Add asset hierarchy support

### DIFF
--- a/app.py
+++ b/app.py
@@ -2313,6 +2313,7 @@ def init_db():
             CREATE TABLE IF NOT EXISTS assets (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 name TEXT NOT NULL,
+                parent_asset_id INTEGER,
                 notes TEXT,
                 specs TEXT,
                 acquisition_date TEXT,
@@ -2321,7 +2322,8 @@ def init_db():
                 depreciation_months INTEGER,
                 retirement_date TEXT,
                 retirement_reason TEXT,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (parent_asset_id) REFERENCES assets(id)
             )
         ''')
 
@@ -2332,6 +2334,11 @@ def init_db():
 
         try:
             c.execute('ALTER TABLE assets ADD COLUMN specs TEXT')
+        except sqlite3.OperationalError:
+            pass
+
+        try:
+            c.execute('ALTER TABLE assets ADD COLUMN parent_asset_id INTEGER')
         except sqlite3.OperationalError:
             pass
 
@@ -6392,6 +6399,17 @@ def manage_assets():
         name = (data.get('name') or '').strip()
         notes = (data.get('notes') or '').strip()
         specs = json.dumps(data.get('specs', {}))
+        parent_asset_id = data.get('parent_asset_id')
+        if parent_asset_id in ("", None):
+            parent_asset_id = None
+        if parent_asset_id is not None:
+            try:
+                parent_asset_id = int(parent_asset_id)
+            except (TypeError, ValueError):
+                return jsonify({"error": "Ungültiges übergeordnetes Asset"}), 400
+            parent_asset = db.execute('SELECT id FROM assets WHERE id = ?', (parent_asset_id,)).fetchone()
+            if not parent_asset:
+                return jsonify({"error": "Übergeordnetes Asset nicht gefunden"}), 400
         acquisition_date = (data.get('acquisition_date') or '').strip() or None
         commissioning_date = (data.get('commissioning_date') or '').strip() or None
         warranty_end = (data.get('warranty_end') or '').strip() or None
@@ -6405,12 +6423,13 @@ def manage_assets():
         try:
             cursor = db.execute('''
                 INSERT INTO assets (
-                    name, notes, specs, acquisition_date, commissioning_date,
+                    name, parent_asset_id, notes, specs, acquisition_date, commissioning_date,
                     warranty_end, depreciation_months, retirement_date, retirement_reason
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ''', (
                 name,
+                parent_asset_id,
                 notes,
                 specs,
                 acquisition_date,
@@ -6445,8 +6464,9 @@ def manage_assets():
     if not (user_can('assets.view') or user_can('assets.manage')):
         return jsonify({"error": "Keine Berechtigung"}), 403
     assets = db.execute('''
-        SELECT a.*, COUNT(ad.device_id) as device_count
+        SELECT a.*, p.name AS parent_name, COUNT(ad.device_id) as device_count
         FROM assets a
+        LEFT JOIN assets p ON p.id = a.parent_asset_id
         LEFT JOIN asset_devices ad ON a.id = ad.asset_id
         GROUP BY a.id
         ORDER BY a.created_at DESC
@@ -6501,6 +6521,20 @@ def asset_detail(asset_id):
             item["direction"] = "outgoing" if item["asset_id"] == asset_id else "incoming"
             relations.append(item)
         asset["relations"] = relations
+        parent_asset = None
+        if asset_row["parent_asset_id"]:
+            parent_asset = db.execute(
+                'SELECT id, name FROM assets WHERE id = ?',
+                (asset_row["parent_asset_id"],)
+            ).fetchone()
+        child_assets = db.execute('''
+            SELECT id, name, created_at
+            FROM assets
+            WHERE parent_asset_id = ?
+            ORDER BY created_at DESC
+        ''', (asset_id,)).fetchall()
+        asset["parent_asset"] = dict(parent_asset) if parent_asset else None
+        asset["child_assets"] = [dict(row) for row in child_assets]
         open_ticket_rows = db.execute('''
             SELECT t.id, t.title, t.status, t.priority, t.created_at
             FROM tickets t
@@ -6518,6 +6552,20 @@ def asset_detail(asset_id):
         name = (data.get('name') or '').strip()
         notes = (data.get('notes') or '').strip()
         specs = json.dumps(data.get('specs', {}))
+        parent_asset_id = data.get('parent_asset_id')
+        if parent_asset_id in ("", None):
+            parent_asset_id = None
+        if parent_asset_id is not None:
+            try:
+                parent_asset_id = int(parent_asset_id)
+            except (TypeError, ValueError):
+                return jsonify({"error": "Ungültiges übergeordnetes Asset"}), 400
+        if parent_asset_id == asset_id:
+            return jsonify({"error": "Asset kann nicht sich selbst zugeordnet werden"}), 400
+        if parent_asset_id is not None:
+            parent_asset = db.execute('SELECT id FROM assets WHERE id = ?', (parent_asset_id,)).fetchone()
+            if not parent_asset:
+                return jsonify({"error": "Übergeordnetes Asset nicht gefunden"}), 400
         acquisition_date = (data.get('acquisition_date') or '').strip() or None
         commissioning_date = (data.get('commissioning_date') or '').strip() or None
         warranty_end = (data.get('warranty_end') or '').strip() or None
@@ -6530,11 +6578,12 @@ def asset_detail(asset_id):
             return jsonify({"error": "Name ist erforderlich"}), 400
         db.execute('''
             UPDATE assets
-            SET name = ?, notes = ?, specs = ?, acquisition_date = ?, commissioning_date = ?,
+            SET name = ?, parent_asset_id = ?, notes = ?, specs = ?, acquisition_date = ?, commissioning_date = ?,
                 warranty_end = ?, depreciation_months = ?, retirement_date = ?, retirement_reason = ?
             WHERE id = ?
         ''', (
             name,
+            parent_asset_id,
             notes,
             specs,
             acquisition_date,
@@ -6574,6 +6623,7 @@ def asset_detail(asset_id):
     ).fetchall()
     device_ids = [row["device_id"] for row in device_rows]
     mark_devices_as_in_stock(db, device_ids)
+    db.execute('UPDATE assets SET parent_asset_id = NULL WHERE parent_asset_id = ?', (asset_id,))
     db.execute('DELETE FROM ticket_assets WHERE asset_id = ?', (asset_id,))
     db.execute('DELETE FROM asset_devices WHERE asset_id = ?', (asset_id,))
     db.execute('DELETE FROM asset_relations WHERE asset_id = ? OR related_asset_id = ?', (asset_id, asset_id))

--- a/static/script.js
+++ b/static/script.js
@@ -1089,6 +1089,7 @@ document.addEventListener('alpine:init', () => {
             this.currentAsset = {
                 id: null,
                 name: '',
+                parent_asset_id: '',
                 notes: '',
                 specs: [],
                 device_ids: [],
@@ -1120,6 +1121,7 @@ document.addEventListener('alpine:init', () => {
                 this.currentAsset = {
                     id: data.id,
                     name: data.name,
+                    parent_asset_id: data.parent_asset_id || '',
                     notes: data.notes || '',
                     specs: Object.entries(data.specs || {}).map(([key, value]) => ({
                         id: crypto.randomUUID(),
@@ -1190,6 +1192,7 @@ document.addEventListener('alpine:init', () => {
 
                 const payload = {
                     name: this.currentAsset.name,
+                    parent_asset_id: this.currentAsset.parent_asset_id || null,
                     notes: this.currentAsset.notes,
                     specs,
                     device_ids: this.currentAsset.device_ids,

--- a/templates/index.html
+++ b/templates/index.html
@@ -445,7 +445,10 @@
                                     <div class="group grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 rounded-xl border border-transparent bg-white px-3 py-2 shadow-sm hover:border-slate-200">
                                         <button @click="openAssetDetail(asset)" class="flex items-start gap-3 min-w-0 text-left">
                                             <span class="inline-flex items-center justify-center w-7 h-7 rounded-lg bg-indigo-50 text-indigo-600 text-xs font-semibold" x-text="asset.device_count || 0"></span>
-                                            <span class="text-sm font-medium text-slate-700 whitespace-normal break-words leading-snug" x-text="asset.name"></span>
+                                            <span class="min-w-0">
+                                                <span class="text-sm font-medium text-slate-700 whitespace-normal break-words leading-snug" x-text="asset.name"></span>
+                                                <span class="block text-xs text-slate-400" x-show="asset.parent_name" x-text="`Eintrag unter ${asset.parent_name}`"></span>
+                                            </span>
                                         </button>
                                         <div class="flex items-center gap-2">
                                             <button @click="openEditAssetModal(asset)" class="icon-button text-slate-500 hover:text-slate-900" aria-label="Asset bearbeiten">
@@ -564,6 +567,7 @@
                                                     <td class="py-4 px-4 sm:px-6">
                                                         <p class="max-w-[14rem] truncate font-semibold text-slate-900 sm:max-w-none" x-text="asset.name"></p>
                                                         <p class="text-xs text-slate-500" x-text="asset.created_at?.slice(0, 10) || ''"></p>
+                                                        <p class="text-xs text-slate-400" x-show="asset.parent_name" x-text="`Kategorie: ${asset.parent_name}`"></p>
                                                     </td>
                                                     <td class="py-4 px-4 sm:px-6 text-slate-700">
                                                         <span class="inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700" x-text="`${asset.device_count || 0} Geräte`"></span>
@@ -879,6 +883,10 @@
                                 <span class="font-semibold text-slate-900" x-text="selectedAsset?.devices?.length || 0"></span>
                             </div>
                             <div class="flex justify-between">
+                                <span>Kategorie</span>
+                                <span class="font-semibold text-slate-900" x-text="selectedAsset?.parent_asset?.name || '-'"></span>
+                            </div>
+                            <div class="flex justify-between">
                                 <span>Erstellt</span>
                                 <span class="font-semibold text-slate-900" x-text="selectedAsset?.created_at?.slice(0, 10) || '-' "></span>
                             </div>
@@ -990,6 +998,31 @@
                                 </div>
                             </template>
                             <p x-show="(selectedAsset?.devices || []).length === 0" class="text-xs text-indigo-500">Keine Geräte zugeordnet.</p>
+                        </div>
+                    </div>
+                    <div class="rounded-2xl border border-slate-200 bg-white p-4">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-slate-900">Asset-Struktur</p>
+                                <p class="text-xs text-slate-500">Kategorie &amp; Einträge</p>
+                            </div>
+                            <i data-feather="folder" class="w-4 h-4 text-slate-400"></i>
+                        </div>
+                        <div class="mt-4 space-y-3 text-sm">
+                            <div>
+                                <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Kategorie</p>
+                                <p class="font-semibold text-slate-800" x-text="selectedAsset?.parent_asset?.name || 'Keine'"></p>
+                            </div>
+                            <div>
+                                <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Einträge</p>
+                                <template x-for="child in selectedAsset?.child_assets || []" :key="child.id">
+                                    <div class="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 mt-2">
+                                        <p class="font-semibold text-slate-800" x-text="child.name"></p>
+                                        <p class="text-xs text-slate-500" x-text="child.created_at?.slice(0, 10) || ''"></p>
+                                    </div>
+                                </template>
+                                <p x-show="(selectedAsset?.child_assets || []).length === 0" class="text-xs text-slate-400">Keine Einträge vorhanden.</p>
+                            </div>
                         </div>
                     </div>
                     <div class="rounded-2xl border border-slate-200 bg-white p-4">
@@ -1155,6 +1188,16 @@
                 <div>
                     <label class="text-sm font-semibold text-slate-700">Name*</label>
                     <input type="text" x-model="currentAsset.name" required class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-indigo-500 focus:ring-indigo-500">
+                </div>
+                <div>
+                    <label class="text-sm font-semibold text-slate-700">Übergeordnetes Asset (Kategorie)</label>
+                    <select x-model="currentAsset.parent_asset_id" class="mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        <option value="">Keine Kategorie</option>
+                        <template x-for="asset in assets.filter(item => item.id !== currentAsset.id)" :key="`parent-${asset.id}`">
+                            <option :value="asset.id" x-text="asset.name"></option>
+                        </template>
+                    </select>
+                    <p class="mt-1 text-xs text-slate-400">Nutze ein Asset als Kategorie und lege darunter Einträge an.</p>
                 </div>
                 <div>
                     <label class="text-sm font-semibold text-slate-700">Notizen</label>


### PR DESCRIPTION
### Motivation
- Provide a way to model assets as categories and entries so an asset can act as a parent/category and other assets can be entries beneath it (e.g. a top-level asset "Arbeitsplätze" with children like "Arbeitsplatz 1").

### Description
- Add a `parent_asset_id` column to the `assets` table (with migration `ALTER TABLE` where necessary) and enforce the foreign key to `assets(id)` in `app.py`.
- Extend asset CRUD to accept and validate `parent_asset_id` on create/update, prevent self-parenting, expose `parent_name`, `parent_asset` and `child_assets` in API responses, and clear parent links when a parent is deleted in `app.py`.
- Surface hierarchy in the UI by showing parent/category info in lists and detail views, adding an "Übergeordnetes Asset (Kategorie)" selector to the asset modal, and including `parent_asset_id` in the frontend payloads in `static/script.js` and `templates/index.html`.
- Updated files: `app.py`, `static/script.js`, and `templates/index.html`.

### Testing
- Launched the web server with `python app.py`, which started successfully and served the site (manual smoke run).; succeeded.
- Captured a site screenshot using a Playwright script to verify the UI renders after changes; screenshot run completed and artifact was produced.; succeeded.
- Database migration checks were applied by adding `parent_asset_id` via `ALTER TABLE` fallback logic during init; no DB errors observed when running the app.; succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697a76110e54832ea562b4112951523a)