### PR TITLE
Hide insights panels when asset group is selected

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -9,6 +9,7 @@ document.addEventListener('alpine:init', () => {
         assets: [],
         relationTypes: [],
         activeCategory: null,
+        activeAssetGroup: null,
         inventoryTab: 'devices',
         categoriesOpen: false,
         assetsOpen: false,
@@ -253,6 +254,7 @@ document.addEventListener('alpine:init', () => {
 
         async loadDevices(categoryId = null) {
             this.activeCategory = categoryId;
+            this.activeAssetGroup = null;
             if (categoryId) {
                 this.filtersOpen = false;
             }
@@ -1254,6 +1256,7 @@ document.addEventListener('alpine:init', () => {
 
         async openAssetDetail(asset) {
             try {
+                this.selectAssetGroup(asset);
                 const response = await fetch(`/api/assets/${asset.id}`);
                 if (!response.ok) {
                     throw new Error('Asset konnte nicht geladen werden');
@@ -1281,6 +1284,11 @@ document.addEventListener('alpine:init', () => {
         },
 
         // Helper Methods
+        selectAssetGroup(asset) {
+            this.activeCategory = null;
+            this.activeAssetGroup = asset?.id || null;
+        },
+
         getCategoryById(categoryId) {
             return this.categories.find(c => c.id === categoryId) || null;
         },
@@ -1288,6 +1296,25 @@ document.addEventListener('alpine:init', () => {
         getCategoryName(categoryId) {
             const category = this.getCategoryById(categoryId);
             return category ? category.name : 'Unknown';
+        },
+
+        getAssetById(assetId) {
+            return this.assets.find(asset => asset.id === assetId) || null;
+        },
+
+        getAssetName(assetId) {
+            const asset = this.getAssetById(assetId);
+            return asset ? asset.name : 'Unknown';
+        },
+
+        activeScopeLabel() {
+            if (this.activeCategory) {
+                return this.getCategoryName(this.activeCategory);
+            }
+            if (this.activeAssetGroup) {
+                return this.getAssetName(this.activeAssetGroup);
+            }
+            return 'Alle Geräte';
         },
 
         getCategoryFields(categoryId) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -205,7 +205,7 @@
                     </button>
                     <div>
                     <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Dashboard</p>
-                    <h1 class="text-2xl font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h1>
+                    <h1 class="text-2xl font-semibold text-slate-900" x-text="activeScopeLabel()"></h1>
                     </div>
                 </div>
                 <div class="flex items-center gap-2 sm:gap-3">
@@ -270,8 +270,8 @@
                             <div>
                                 <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Inventory</p>
                                 <div class="flex flex-wrap items-center gap-3">
-                                    <h2 class="text-2xl font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></h2>
-                                    <button x-show="activeCategory" @click="loadDevices()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-50">
+                                    <h2 class="text-2xl font-semibold text-slate-900" x-text="activeScopeLabel()"></h2>
+                                    <button x-show="activeCategory || activeAssetGroup" @click="loadDevices()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-50">
                                         <i data-feather="x-circle" class="h-3 w-3"></i>
                                         Alle Geräte anzeigen
                                     </button>
@@ -461,7 +461,7 @@
                             </div>
                         </div>
                     </section>
-                    <section class="grid gap-6 lg:grid-cols-2" x-show="!activeCategory">
+                    <section class="grid gap-6 lg:grid-cols-2" x-show="!activeCategory && !activeAssetGroup">
                         <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
                             <div class="flex items-center justify-between">
                                 <div>
@@ -488,7 +488,7 @@
                         </div>
                     </section>
 
-                    <section class="grid gap-6" :class="activeCategory ? 'lg:grid-cols-1' : 'lg:grid-cols-[minmax(0,1fr)_320px]'">
+                    <section class="grid gap-6" :class="activeCategory || activeAssetGroup ? 'lg:grid-cols-1' : 'lg:grid-cols-[minmax(0,1fr)_320px]'">
                         <div class="space-y-4">
                             <div class="flex flex-wrap items-center justify-between gap-3">
                                 <div class="inline-flex rounded-full border border-slate-200 bg-white p-1 text-xs font-semibold">
@@ -619,7 +619,7 @@
                             </div>
                         </div>
 
-                        <aside class="space-y-4" x-show="!activeCategory">
+                        <aside class="space-y-4" x-show="!activeCategory && !activeAssetGroup">
                             <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
                                 <div class="flex items-center justify-between">
                                     <div>
@@ -633,7 +633,7 @@
                                 <div class="mt-4 space-y-3 text-sm text-slate-600">
                                     <div class="flex items-center justify-between">
                                         <span>Aktive Kategorie</span>
-                                        <span class="font-semibold text-slate-900" x-text="activeCategory ? getCategoryName(activeCategory) : 'Alle Geräte'"></span>
+                                        <span class="font-semibold text-slate-900" x-text="activeScopeLabel()"></span>
                                     </div>
                                     <div class="flex items-center justify-between">
                                         <span>Geräte im Fokus</span>


### PR DESCRIPTION
### Motivation
- Make asset-group selection behave like category selection so selecting an asset group hides the right-hand insights/AI panels and shows a consistent scope label.
- Ensure the UI can be reset back to the global view with the existing "Alle Geräte anzeigen" button for both categories and assets.

### Description
- Added `activeAssetGroup` state and a `selectAssetGroup(asset)` helper in `static/script.js` to track asset-group selection and clear `activeCategory` when an asset is chosen.
- Reset `activeAssetGroup` to `null` inside `loadDevices()` so the global/category view restores when clicking `Alle Geräte anzeigen` via `loadDevices()`.
- Added `getAssetById`, `getAssetName` and `activeScopeLabel()` helpers and switched header/title bindings to `activeScopeLabel()` so the active scope shows category name, asset name, or `Alle Geräte`.
- Updated `templates/index.html` to use `activeScopeLabel()` for headings, to show the "Alle Geräte anzeigen" button when `activeCategory || activeAssetGroup`, to collapse the right column layout when either is active, and to hide the AI Alerts / Insights / Activity panels when an asset group is active.

### Testing
- No automated tests were executed for this change.
- Basic runtime validation commands were used (code inspected and application entry point confirmed) but no test suite or end-to-end checks were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b49eda5d0832db2a62d3cb682886f)