### PR TITLE
Hide insights sidebar when asset category is selected

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -461,7 +461,7 @@
                             </div>
                         </div>
                     </section>
-                    <section class="grid gap-6" :class="activeCategory ? 'lg:grid-cols-1' : 'lg:grid-cols-[minmax(0,1fr)_320px]'">
+                    <section class="grid gap-6" :class="(activeCategory || selectedAssetCategory) ? 'lg:grid-cols-1' : 'lg:grid-cols-[minmax(0,1fr)_320px]'">
                         <div class="space-y-4">
                             <div class="flex flex-wrap items-center justify-between gap-3">
                                 <div class="inline-flex rounded-full border border-slate-200 bg-white p-1 text-xs font-semibold">
@@ -607,7 +607,7 @@
                             </div>
                         </div>
 
-                        <aside class="space-y-4" x-show="!activeCategory">
+                        <aside class="space-y-4" x-show="!activeCategory && !selectedAssetCategory">
                             <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
                                 <div class="flex items-center justify-between">
                                     <div>


### PR DESCRIPTION
### Motivation
- When an asset category is selected the dashboard sidebar (Insights / AI Alerts / Aktivitäten) should be hidden, matching the existing device category behavior so users can focus on the selected asset list.

### Description
- Update `templates/index.html` to collapse the main grid to a single column when `selectedAssetCategory` is set by changing the `:class` expression to `(activeCategory || selectedAssetCategory) ? 'lg:grid-cols-1' : 'lg:grid-cols-[minmax(0,1fr)_320px]'`.
- Change the right-hand sidebar visibility to `x-show="!activeCategory && !selectedAssetCategory"` so Insights / AI Alerts / Aktivitäten are hidden while an asset category is active.

### Testing
- Launched the Flask development server and captured a full-page screenshot using Playwright to validate the layout change, producing the artifact `artifacts/asset-category-hide-aside.png` successfully.
- No automated unit tests were modified and the manual UI verification completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b4c0a2510832d8182862dc5cc1773)