### PR TITLE
Fix unclosed SQL query string in asset entries endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -6978,7 +6978,7 @@ def manage_asset_categories():
 
     if not (user_can('assets.view') or user_can('assets.manage')):
         return jsonify({"error": "Keine Berechtigung"}), 403
-    assets = db.execute('''
+    query = '''
         SELECT a.*, ac.name as category_name, ac.icon as category_icon, ac.description as category_description,
                COUNT(ad.device_id) as device_count
         FROM assets a


### PR DESCRIPTION
### Motivation
- Fix a startup `SyntaxError` caused by an unclosed triple-quoted SQL string in the asset entries listing branch so `app.py` can compile and run.

### Description
- Replace the accidental `assets = db.execute('''` start with a proper `query = '''...'''` assignment and keep the dynamic `query += ...` logic, updating the `db.execute(query, params)` call in `app.py`.

### Testing
- Ran `python -m py_compile app.py` which completed successfully.
- Ran `PYTHONPATH=. pytest -q` which exercised the test suite but reported unrelated issues: the run ended with `3 failed, 22 passed, 3 errors` (failures due to application-level test data / DB state and errors due to missing Playwright browser binaries and a missing `agent_events` table), none of which are caused by the fixed syntax error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984dda502b0832da39e15c8a0c60779)