### PR TITLE
Add troubleshooting note for npm ERESOLVE conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ python app.py
 
 Die Anwendung läuft anschließend standardmäßig auf `http://localhost:5000`.
 
+## Troubleshooting
+### npm ERESOLVE bei Docker/Node-Builds (optional)
+Dieses Repository enthält **keinen** Node-/Docker-Build. Falls Sie jedoch in Ihrer Umgebung einen separaten Frontend-Container bauen und dabei `npm install` mit einem ERESOLVE-Fehler abbrechen sehen (z. B. Konflikte zwischen `xterm` und `xterm-addon-fit`), prüfen Sie die Versionen in `package.json` und `package-lock.json` auf Konsistenz. Ein typischer Workaround ist, die Peer-Dependencies explizit zu harmonisieren oder beim Build `npm install --legacy-peer-deps` zu verwenden. Damit bleibt der Python/Flask-Startpfad oben unverändert.
+
 ## Konfiguration
 ### Wichtige Umgebungsvariablen
 | Variable | Zweck | Default |


### PR DESCRIPTION
### Motivation
- Dokumentieren eines Workarounds für auftretende `npm`-`ERESOLVE`-Fehler beim separaten Docker/Node-Frontend-Build und klarstellen, dass dieses Repository keinen Node-/Docker-Frontend-Build enthält.

### Description
- `README.md` um einen `Troubleshooting`-Abschnitt erweitert, der auf Konflikte zwischen `xterm` und `xterm-addon-fit` hinweist, zur Prüfung von `package.json`/`package-lock.json` auffordert und den Workaround `npm install --legacy-peer-deps` sowie die Harmonisierung von Peer-Dependencies empfiehlt.

### Testing
- Nur Dokumentationsänderung vorgenommen; es wurden keine automatisierten Tests ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985ddab1fe0832db803e9742b9ff27d)