### PR TITLE
Add `login` auth mode for inventory links and full-page portal view

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Linked Inventory Pros werden im Bereich **Einstellungen → Linked Inventory Pro
 
 **Hinweise**
 - Secrets werden serverseitig verschlüsselt gespeichert (`INVENTORY_LINKS_ENCRYPTION_KEY` erforderlich).
+- Alternativ ist `Login` möglich: Secret im Format `Benutzername:Passwort`, die Session wird serverseitig verwaltet.
 - Cookie-basierte Logins werden in v1 nicht geteilt; nutze Header-Auth für zuverlässige Verbindungen.
 
 ## Betrieb & Wartung

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ import shutil
 import time
 import subprocess
 import socket
+import http.cookiejar
 import urllib.request
 import urllib.error
 import urllib.parse
@@ -57,6 +58,7 @@ INVENTORY_LINK_PROXY_TIMEOUT_SECONDS = int(os.environ.get("INVENTORY_LINK_PROXY_
 INVENTORY_LINK_PROXY_RATE_LIMIT_WINDOW_SECONDS = 60
 INVENTORY_LINK_PROXY_RATE_LIMIT_MAX_REQUESTS = int(os.environ.get("INVENTORY_LINK_PROXY_RATE_LIMIT_MAX_REQUESTS", 120))
 INVENTORY_LINKS_ALLOW_PRIVATE_NETWORKS_DEFAULT = os.environ.get("INVENTORY_LINKS_ALLOW_PRIVATE_NETWORKS", "1").lower() not in {"0", "false", "no"}
+INVENTORY_LINK_LOGIN_TTL_SECONDS = int(os.environ.get("INVENTORY_LINK_LOGIN_TTL_SECONDS", 30 * 60))
 PRO_ENABLED = True
 APP_START_TIME = time.time()
 TERMINAL_RATE_LIMIT_WINDOW_SECONDS = 60
@@ -86,6 +88,7 @@ BACKUP_SCHEDULER = BackgroundScheduler()
 HEALTH_SCHEDULER = BackgroundScheduler()
 RATE_LIMIT_CACHE = {}
 INVENTORY_LINK_PROXY_RATE_LIMIT_CACHE = {}
+INVENTORY_LINK_LOGIN_SESSION_CACHE = {}
 
 HEALTH_STATUS_ORDER = {
     "OK": 0,
@@ -1255,6 +1258,67 @@ def validate_inventory_link_target(base_url, allow_private_network):
             raise ValueError("Zieladresse ist nicht erlaubt.")
     return parsed
 
+def parse_inventory_link_login_secret(secret):
+    if not secret or ":" not in secret:
+        raise ValueError("Login-Secret muss im Format Benutzername:Passwort vorliegen.")
+    username, password = secret.split(":", 1)
+    username = username.strip()
+    if not username or not password:
+        raise ValueError("Login-Secret muss Benutzername und Passwort enthalten.")
+    return username, password
+
+def extract_inventory_link_cookie_header(cookie_jar):
+    cookies = []
+    expiry_candidates = []
+    for cookie in cookie_jar:
+        cookies.append(f"{cookie.name}={cookie.value}")
+        if cookie.expires:
+            expiry_candidates.append(cookie.expires)
+    if not cookies:
+        return None, None
+    expires_at = min(expiry_candidates) if expiry_candidates else None
+    return "; ".join(cookies), expires_at
+
+def login_inventory_link_session(base_url, verify_tls, secret):
+    username, password = parse_inventory_link_login_secret(secret)
+    login_url = urllib.parse.urljoin(f"{base_url.rstrip('/')}/", "login")
+    payload = urllib.parse.urlencode({"username": username, "password": password}).encode("utf-8")
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Accept": "text/html",
+        "User-Agent": "InventoryPro-Link/1.0"
+    }
+    cookie_jar = http.cookiejar.CookieJar()
+    handlers = [urllib.request.HTTPCookieProcessor(cookie_jar)]
+    context = None
+    if base_url.startswith("https://"):
+        context = build_inventory_link_ssl_context(verify_tls)
+        handlers.append(urllib.request.HTTPSHandler(context=context))
+    opener = urllib.request.build_opener(*handlers)
+    req = urllib.request.Request(login_url, data=payload, headers=headers, method="POST")
+    opener.open(req, timeout=INVENTORY_LINK_PROXY_TIMEOUT_SECONDS).read(1024)
+    cookie_header, expires_at = extract_inventory_link_cookie_header(cookie_jar)
+    return cookie_header, expires_at
+
+def get_inventory_link_login_cookie(link, secret, user_id):
+    cache_key = f"{user_id}:{link['id']}"
+    cached = INVENTORY_LINK_LOGIN_SESSION_CACHE.get(cache_key)
+    if cached:
+        if cached["expires_at"] is None or cached["expires_at"] > time.time():
+            return cached["cookie"]
+    cookie_header, expires_at = login_inventory_link_session(
+        link["base_url"],
+        bool(link["verify_tls"]),
+        secret
+    )
+    if not cookie_header:
+        raise ValueError("Login fehlgeschlagen. Prüfe Benutzername/Passwort.")
+    INVENTORY_LINK_LOGIN_SESSION_CACHE[cache_key] = {
+        "cookie": cookie_header,
+        "expires_at": expires_at or (time.time() + INVENTORY_LINK_LOGIN_TTL_SECONDS)
+    }
+    return cookie_header
+
 def serialize_inventory_link(row):
     return {
         "id": row["id"],
@@ -1313,7 +1377,7 @@ def build_inventory_link_target_url(base_url, subpath, query_string):
         target = f"{target}?{query}"
     return target
 
-def build_inventory_link_request_headers(auth_mode, secret):
+def build_inventory_link_request_headers(auth_mode, secret, link=None, user_id=None):
     headers = {}
     for key, value in request.headers.items():
         lower = key.lower()
@@ -1327,6 +1391,10 @@ def build_inventory_link_request_headers(auth_mode, secret):
     elif auth_mode == "basic":
         encoded = base64.b64encode(secret.encode("utf-8")).decode("utf-8")
         headers["Authorization"] = f"Basic {encoded}"
+    elif auth_mode == "login" and link and user_id and secret:
+        cookie_header = get_inventory_link_login_cookie(link, secret, user_id)
+        if cookie_header:
+            headers["Cookie"] = cookie_header
     return headers
 
 def rewrite_inventory_link_location(location, link_id, base_url):
@@ -1382,7 +1450,7 @@ def stream_inventory_link_response(resp):
             resp.close()
     return generate()
 
-def build_inventory_link_static_headers(auth_mode, secret):
+def build_inventory_link_static_headers(auth_mode, secret, base_url=None, verify_tls=True):
     headers = {"Accept": "application/json"}
     if auth_mode == "apiKey":
         headers["X-API-Key"] = secret
@@ -1391,6 +1459,10 @@ def build_inventory_link_static_headers(auth_mode, secret):
     elif auth_mode == "basic":
         encoded = base64.b64encode(secret.encode("utf-8")).decode("utf-8")
         headers["Authorization"] = f"Basic {encoded}"
+    elif auth_mode == "login" and base_url and secret:
+        cookie_header, _ = login_inventory_link_session(base_url, verify_tls, secret)
+        if cookie_header:
+            headers["Cookie"] = cookie_header
     return headers
 
 def perform_inventory_link_test(config):
@@ -1404,7 +1476,10 @@ def perform_inventory_link_test(config):
     except ValueError as exc:
         return {"status": "down", "error": str(exc)}
 
-    headers = build_inventory_link_static_headers(auth_mode, secret)
+    try:
+        headers = build_inventory_link_static_headers(auth_mode, secret, base_url=base_url, verify_tls=verify_tls)
+    except ValueError as exc:
+        return {"status": "unauthorized", "error": str(exc)}
     paths = ["/api/health/summary", "/"]
     last_error = None
     for path in paths:
@@ -11332,10 +11407,15 @@ def inventory_links_api():
 
     if not display_name:
         return jsonify({"error": "Display-Name ist erforderlich."}), 400
-    if auth_mode not in {"apiKey", "bearerToken", "basic", "none"}:
+    if auth_mode not in {"apiKey", "bearerToken", "basic", "login", "none"}:
         return jsonify({"error": "Ungültiger Auth-Modus."}), 400
     if auth_mode != "none" and not secret:
         return jsonify({"error": "Secret ist erforderlich."}), 400
+    if auth_mode == "login":
+        try:
+            parse_inventory_link_login_secret(secret)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
 
     try:
         normalized = normalize_inventory_link_base_url(base_url)
@@ -11383,7 +11463,7 @@ def inventory_links_test_draft():
     verify_tls = bool(data.get("verifyTls", True))
     allow_private_network = bool(data.get("allowPrivateNetwork", INVENTORY_LINKS_ALLOW_PRIVATE_NETWORKS_DEFAULT))
     secret = data.get("secret") or ""
-    if auth_mode not in {"apiKey", "bearerToken", "basic", "none"}:
+    if auth_mode not in {"apiKey", "bearerToken", "basic", "login", "none"}:
         return jsonify({"error": "Ungültiger Auth-Modus."}), 400
     try:
         normalized = normalize_inventory_link_base_url(base_url)
@@ -11429,8 +11509,21 @@ def inventory_link_detail_api(link_id):
 
     if not display_name:
         return jsonify({"error": "Display-Name ist erforderlich."}), 400
-    if auth_mode not in {"apiKey", "bearerToken", "basic", "none"}:
+    if auth_mode not in {"apiKey", "bearerToken", "basic", "login", "none"}:
         return jsonify({"error": "Ungültiger Auth-Modus."}), 400
+    if auth_mode == "login" and secret is None:
+        if not link["secret_encrypted"]:
+            return jsonify({"error": "Secret ist erforderlich."}), 400
+        try:
+            existing_secret = decrypt_inventory_link_secret(link["secret_encrypted"] or "")
+            parse_inventory_link_login_secret(existing_secret)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+    elif auth_mode == "login" and secret:
+        try:
+            parse_inventory_link_login_secret(secret)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
 
     try:
         normalized = normalize_inventory_link_base_url(base_url)
@@ -11532,7 +11625,10 @@ def inventory_link_proxy(link_id, subpath):
         secret = ""
 
     target_url = build_inventory_link_target_url(link["base_url"], subpath, request.query_string)
-    headers = build_inventory_link_request_headers(link["auth_mode"], secret)
+    try:
+        headers = build_inventory_link_request_headers(link["auth_mode"], secret, link=link, user_id=user["id"])
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 401
     data = None
     if request.method not in {"GET", "HEAD"}:
         data = request.get_data()
@@ -11546,10 +11642,22 @@ def inventory_link_proxy(link_id, subpath):
     if context is not None:
         handlers.append(urllib.request.HTTPSHandler(context=context))
     opener = urllib.request.build_opener(*handlers)
+    def perform_proxy_request(request_obj):
+        try:
+            return opener.open(request_obj, timeout=INVENTORY_LINK_PROXY_TIMEOUT_SECONDS)
+        except urllib.error.HTTPError as exc:
+            return exc
+
     try:
-        resp = opener.open(req, timeout=INVENTORY_LINK_PROXY_TIMEOUT_SECONDS)
-    except urllib.error.HTTPError as exc:
-        resp = exc
+        resp = perform_proxy_request(req)
+        if link["auth_mode"] == "login" and resp.getcode() in {401, 403}:
+            INVENTORY_LINK_LOGIN_SESSION_CACHE.pop(f"{user['id']}:{link['id']}", None)
+            try:
+                headers = build_inventory_link_request_headers(link["auth_mode"], secret, link=link, user_id=user["id"])
+            except ValueError as exc:
+                return jsonify({"error": str(exc)}), 401
+            req = urllib.request.Request(target_url, data=data if data else None, headers=headers, method=request.method)
+            resp = perform_proxy_request(req)
     except urllib.error.URLError as exc:
         return jsonify({"error": f"Proxy-Fehler: {exc.reason}"}), 502
     except ssl.SSLError as exc:

--- a/templates/inventory_link_portal.html
+++ b/templates/inventory_link_portal.html
@@ -136,15 +136,13 @@
                 </div>
             </header>
 
-            <main class="app-content flex-1 overflow-hidden p-8 pt-24">
-                <section class="h-full rounded-3xl border border-slate-200 bg-white shadow-sm overflow-hidden">
-                    <iframe
-                        title="Inventory Link Portal"
-                        src="/api/inventory-links/{{ link.id }}/proxy/"
-                        class="h-[calc(100vh-12rem)] w-full"
-                        referrerpolicy="no-referrer"
-                    ></iframe>
-                </section>
+            <main class="app-content flex-1 overflow-hidden pt-[82px]">
+                <iframe
+                    title="Inventory Link Portal"
+                    src="/api/inventory-links/{{ link.id }}/proxy/"
+                    class="h-[calc(100vh-82px)] w-full border-0"
+                    referrerpolicy="no-referrer"
+                ></iframe>
             </main>
         </div>
     </div>

--- a/templates/server_settings.html
+++ b/templates/server_settings.html
@@ -560,14 +560,16 @@
                                                 <select x-model="inventoryLinkForm.authMode" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500">
                                                     <option value="apiKey">API Key</option>
                                                     <option value="bearerToken">Bearer Token</option>
+                                                    <option value="login">Login (Benutzer)</option>
                                                     <option value="basic">Basic</option>
                                                     <option value="none">None</option>
                                                 </select>
                                             </div>
                                             <div class="space-y-1">
                                                 <label class="text-xs font-semibold text-slate-600">Secret</label>
-                                                <input type="password" x-model="inventoryLinkForm.secret" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Nur bei Änderung neu eingeben">
-                                                <p class="text-[11px] text-slate-400">Secrets werden serverseitig verschlüsselt gespeichert.</p>
+                                                <input type="password" x-model="inventoryLinkForm.secret" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500" :placeholder="inventoryLinkForm.authMode === 'login' ? 'Benutzername:Passwort' : 'Nur bei Änderung neu eingeben'">
+                                                <p class="text-[11px] text-slate-400" x-show="inventoryLinkForm.authMode !== 'login'">Secrets werden serverseitig verschlüsselt gespeichert.</p>
+                                                <p class="text-[11px] text-slate-400" x-show="inventoryLinkForm.authMode === 'login'">Login nutzt /login der Zielinstanz und speichert die Session serverseitig.</p>
                                             </div>
                                             <label class="flex items-start gap-3 rounded-2xl border border-slate-200 bg-white p-3">
                                                 <input type="checkbox" x-model="inventoryLinkForm.verifyTls" class="mt-1 h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500">


### PR DESCRIPTION
### Motivation
- Enable linking to another Inventory Pro by reusing a real user login on the target so the target UI appears as the full site to the viewer instead of a small widget.  
- Provide a way to persist a server-side session for those logins and fall back if the session becomes unauthorized.  

### Description
- Add a new auth mode `login` for inventory links and validate `Secret` as `Benutzername:Passwort` via `parse_inventory_link_login_secret`.  
- Implement server-side login flow with `login_inventory_link_session`, cookie extraction and cache (`INVENTORY_LINK_LOGIN_SESSION_CACHE`) with TTL `INVENTORY_LINK_LOGIN_TTL_SECONDS`, and inject `Cookie` headers in `build_inventory_link_request_headers`/`build_inventory_link_static_headers`.  
- Retry proxy requests on `401/403` by clearing the cached session and re-authenticating, and propagate validation errors as `401` where appropriate.  
- UI changes: add `Login (Benutzer)` option in the server settings form and update secret placeholder/hints; change `templates/inventory_link_portal.html` to render the linked instance as a full-page iframe (fills content area) while keeping the header/back button.  
- Docs: note the new `Login` option in `README.md` and add `http.cookiejar` import.  

### Testing
- Launched the app with `python app.py` which started the Flask server successfully (listening on `127.0.0.1:5001`). — succeeded.  
- Ran an automated Playwright script that performed a login and navigated to the server settings page and produced a screenshot (`artifacts/inventory-link-settings.png`), showing the UI state; navigation to protected settings required authentication so the script captured the login/redirect behavior — succeeded (screenshot artifact produced).  
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a13b519608329982aa8e13da6485e)