### PR TITLE
Simplify inventory link connection flow and auto-resolve auth/display name

### DIFF
--- a/app.py
+++ b/app.py
@@ -1218,6 +1218,23 @@ def normalize_inventory_link_base_url(base_url):
         path = ""
     return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
 
+def derive_inventory_link_display_name(base_url):
+    parsed = urllib.parse.urlsplit(base_url)
+    hostname = parsed.hostname or parsed.netloc
+    if not hostname:
+        return "Inventory Pro"
+    return hostname
+
+def resolve_inventory_link_auth(auth_mode, secret):
+    mode = (auth_mode or "auto").strip()
+    if mode == "auto":
+        if not secret:
+            return "none", ""
+        if ":" in secret:
+            return "login", secret
+        return "apiKey", secret
+    return mode, secret
+
 def resolve_inventory_link_ips(hostname):
     try:
         infos = socket.getaddrinfo(hostname, None)
@@ -11410,28 +11427,29 @@ def inventory_links_api():
     data = request.get_json() or {}
     display_name = (data.get("displayName") or "").strip()
     base_url = (data.get("baseUrl") or "").strip()
-    auth_mode = data.get("authMode") or "apiKey"
+    auth_mode = data.get("authMode") or "auto"
     verify_tls = bool(data.get("verifyTls", True))
     allow_private_network = bool(data.get("allowPrivateNetwork", INVENTORY_LINKS_ALLOW_PRIVATE_NETWORKS_DEFAULT))
     secret = data.get("secret") or ""
 
-    if not display_name:
-        return jsonify({"error": "Display-Name ist erforderlich."}), 400
+    auth_mode, secret = resolve_inventory_link_auth(auth_mode, secret)
     if auth_mode not in {"apiKey", "bearerToken", "basic", "login", "none"}:
         return jsonify({"error": "Ungültiger Auth-Modus."}), 400
-    if auth_mode != "none" and not secret:
-        return jsonify({"error": "Secret ist erforderlich."}), 400
     if auth_mode == "login":
         try:
             parse_inventory_link_login_secret(secret)
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
-
+    if auth_mode != "none" and not secret:
+        return jsonify({"error": "Secret ist erforderlich."}), 400
     try:
         normalized = normalize_inventory_link_base_url(base_url)
         validate_inventory_link_target(normalized, allow_private_network)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
+
+    if not display_name:
+        display_name = derive_inventory_link_display_name(normalized)
 
     if normalized.startswith("http://"):
         verify_tls = True
@@ -11469,12 +11487,18 @@ def inventory_links_test_draft():
         return jsonify({"error": "Nicht angemeldet"}), 401
     data = request.get_json() or {}
     base_url = (data.get("baseUrl") or "").strip()
-    auth_mode = data.get("authMode") or "apiKey"
+    auth_mode = data.get("authMode") or "auto"
     verify_tls = bool(data.get("verifyTls", True))
     allow_private_network = bool(data.get("allowPrivateNetwork", INVENTORY_LINKS_ALLOW_PRIVATE_NETWORKS_DEFAULT))
     secret = data.get("secret") or ""
+    auth_mode, secret = resolve_inventory_link_auth(auth_mode, secret)
     if auth_mode not in {"apiKey", "bearerToken", "basic", "login", "none"}:
         return jsonify({"error": "Ungültiger Auth-Modus."}), 400
+    if auth_mode == "login":
+        try:
+            parse_inventory_link_login_secret(secret)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
     try:
         normalized = normalize_inventory_link_base_url(base_url)
         validate_inventory_link_target(normalized, allow_private_network)
@@ -11517,8 +11541,18 @@ def inventory_link_detail_api(link_id):
     allow_private_network = bool(data.get("allowPrivateNetwork", bool(link["allow_private_network"])))
     secret = data.get("secret")
 
-    if not display_name:
-        return jsonify({"error": "Display-Name ist erforderlich."}), 400
+    if auth_mode == "auto":
+        if secret is None:
+            existing_secret = ""
+            if link["secret_encrypted"]:
+                try:
+                    existing_secret = decrypt_inventory_link_secret(link["secret_encrypted"] or "")
+                except ValueError as exc:
+                    return jsonify({"error": str(exc)}), 400
+            auth_mode, secret = resolve_inventory_link_auth("auto", existing_secret)
+        else:
+            auth_mode, secret = resolve_inventory_link_auth("auto", secret or "")
+
     if auth_mode not in {"apiKey", "bearerToken", "basic", "login", "none"}:
         return jsonify({"error": "Ungültiger Auth-Modus."}), 400
     if auth_mode == "login" and secret is None:
@@ -11529,7 +11563,7 @@ def inventory_link_detail_api(link_id):
             parse_inventory_link_login_secret(existing_secret)
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
-    elif auth_mode == "login" and secret:
+    if auth_mode == "login" and secret:
         try:
             parse_inventory_link_login_secret(secret)
         except ValueError as exc:
@@ -11541,20 +11575,23 @@ def inventory_link_detail_api(link_id):
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 
+    if not display_name:
+        display_name = derive_inventory_link_display_name(normalized)
+
     if normalized.startswith("http://"):
         verify_tls = True
 
     secret_encrypted = link["secret_encrypted"]
-    if secret is not None:
-        if auth_mode != "none" and not secret and not secret_encrypted:
+    if auth_mode == "none":
+        secret_encrypted = ""
+    elif secret is not None:
+        if not secret and not secret_encrypted:
             return jsonify({"error": "Secret ist erforderlich."}), 400
         if secret:
             try:
                 secret_encrypted = encrypt_inventory_link_secret(secret)
             except ValueError as exc:
                 return jsonify({"error": str(exc)}), 400
-        elif auth_mode == "none":
-            secret_encrypted = ""
 
     db.execute(
         '''

--- a/templates/inventory_link_portal.html
+++ b/templates/inventory_link_portal.html
@@ -4,153 +4,28 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Inventory Pro - {{ link.displayName }}</title>
-    <script src="/static/theme.js"></script>
-    <script>
-        tailwind.config = { darkMode: 'class' };
-    </script>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/static/vendor/alpinejs.min.js" defer></script>
-    <link rel="stylesheet" href="/static/style.css">
+    <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+        }
+        body {
+            background: #0f172a;
+        }
+        .portal-frame {
+            display: block;
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
+    </style>
 </head>
-<body class="app-body">
-    <div class="app-shell">
-        <aside class="app-sidebar sidebar bg-white/90 backdrop-blur-xl border-r border-slate-200 shadow-sm">
-            <div class="sidebar-header p-6 border-b border-slate-200">
-                <a href="/" class="flex items-center gap-3">
-                    <span class="inline-flex items-center justify-center w-10 h-10 rounded-2xl bg-gradient-to-br from-blue-500 via-indigo-500 to-purple-500 text-white shadow-lg" data-brand-logo>
-                        <i data-feather="cpu" data-brand-logo-icon class="w-5 h-5"></i>
-                    </span>
-                    <div>
-                        <p class="text-lg font-semibold text-slate-900 sidebar-text" data-brand-name>Inventory Pro</p>
-                        <p class="text-xs text-slate-500 sidebar-text" data-brand-tagline>Smart Asset Hub</p>
-                    </div>
-                </a>
-            </div>
-            <nav class="p-4 space-y-4 sidebar-scroll sidebar-primary-links">
-                <div class="sidebar-panel">
-                    <p class="sidebar-panel-title">Hauptbereiche</p>
-                    <div class="mt-3 space-y-1">
-                        <a href="/" class="sidebar-link">
-                            <span>
-                                <span class="sidebar-link-icon"><i data-feather="home" class="w-4 h-4"></i></span>
-                                Dashboard
-                            </span>
-                        </a>
-                        {% if 'locations.view' in permissions or 'locations.manage' in permissions %}
-                        <a href="/locations" class="sidebar-link">
-                            <span>
-                                <span class="sidebar-link-icon"><i data-feather="map-pin" class="w-4 h-4"></i></span>
-                                Standorte
-                            </span>
-                        </a>
-                        {% endif %}
-                        {% if 'tickets.view_all' in permissions or 'tickets.view_own' in permissions or 'tickets.create' in permissions %}
-                        <a href="/tickets" class="sidebar-link">
-                            <span>
-                                <span class="sidebar-link-icon"><i data-feather="life-buoy" class="w-4 h-4"></i></span>
-                                Ticketsystem
-                            </span>
-                        </a>
-                        {% endif %}
-                        {% if 'knowledge.view' in permissions or 'knowledge.manage' in permissions %}
-                        <a href="/knowledge" class="sidebar-link">
-                            <span>
-                                <span class="sidebar-link-icon"><i data-feather="book-open" class="w-4 h-4"></i></span>
-                                Wissensbasis
-                            </span>
-                        </a>
-                        {% endif %}
-                        {% if 'roadmap.view' in permissions or 'roadmap.manage' in permissions %}
-                        <a href="/roadmap" class="sidebar-link">
-                            <span>
-                                <span class="sidebar-link-icon"><i data-feather="git-merge" class="w-4 h-4"></i></span>
-                                Roadmap
-                            </span>
-                        </a>
-                        {% endif %}
-                        {% if 'procurement.view' in permissions or 'procurement.manage' in permissions %}
-                        <a href="/procurement" class="sidebar-link">
-                            <span>
-                                <span class="sidebar-link-icon"><i data-feather="shopping-cart" class="w-4 h-4"></i></span>
-                                Beschaffung
-                            </span>
-                        </a>
-                        {% endif %}
-                        {% if 'ai.use' in permissions or 'ai.manage' in permissions %}
-                        <a href="/ai/activity" class="sidebar-link">
-                            <span>
-                                <span class="sidebar-link-icon"><i data-feather="message-circle" class="w-4 h-4"></i></span>
-                                PondSec AI
-                            </span>
-                        </a>
-                        {% endif %}
-                    </div>
-                </div>
-
-                <div class="sidebar-panel">
-                    <p class="sidebar-panel-title">Inventory Links</p>
-                    <div class="mt-3 space-y-1">
-                        {% if inventory_links %}
-                        {% for item in inventory_links %}
-                        <a href="/inventory-links/{{ item.id }}/portal" class="sidebar-link {% if item.id == link.id %}active{% endif %}">
-                            <span>
-                                <span class="sidebar-link-icon"><i data-feather="link-2" class="w-4 h-4"></i></span>
-                                {{ item.displayName }}
-                            </span>
-                            {% if item.healthStatus %}
-                            <span class="text-xs font-semibold rounded-full px-2 py-0.5 {% if item.healthStatus == 'ok' %}bg-emerald-100 text-emerald-700{% elif item.healthStatus == 'unauthorized' %}bg-amber-100 text-amber-700{% else %}bg-rose-100 text-rose-700{% endif %}">
-                                {{ item.healthStatus }}
-                            </span>
-                            {% endif %}
-                        </a>
-                        {% endfor %}
-                        {% else %}
-                        <a href="/settings?section=server#inventory-links" class="sidebar-link">
-                            <span>
-                                <span class="sidebar-link-icon"><i data-feather="plus-circle" class="w-4 h-4"></i></span>
-                                Link hinzufügen
-                            </span>
-                        </a>
-                        {% endif %}
-                    </div>
-                </div>
-            </nav>
-        </aside>
-
-        <div class="app-main app-main--fixed">
-            <header class="app-header bg-white/80 backdrop-blur-xl border-b border-slate-200 px-8 flex justify-between items-center fixed top-0 z-30 h-[82px]">
-                <div class="flex items-center gap-4">
-                    <button type="button" data-sidebar-toggle aria-label="Navigation umschalten" class="icon-button inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white p-2 text-slate-600 shadow-sm hover:bg-slate-50">
-                        <i data-feather="menu" class="w-4 h-4"></i>
-                    </button>
-                    <div>
-                        <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Linked Inventory</p>
-                        <h1 class="text-2xl font-semibold text-slate-900" x-text="`Portal: {{ link.displayName }}`">Portal: {{ link.displayName }}</h1>
-                    </div>
-                </div>
-                <div class="flex items-center gap-2 sm:gap-3">
-                    <a href="/" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50">
-                        <i data-feather="corner-up-left" class="w-4 h-4"></i>
-                        Zurück zu deinem Inventar
-                    </a>
-                </div>
-            </header>
-
-            <main class="app-content flex-1 overflow-hidden pt-[82px]">
-                <iframe
-                    title="Inventory Link Portal"
-                    src="/api/inventory-links/{{ link.id }}/proxy/"
-                    class="h-[calc(100vh-82px)] w-full border-0"
-                    referrerpolicy="no-referrer"
-                ></iframe>
-            </main>
-        </div>
-    </div>
-
-    <script src="https://unpkg.com/feather-icons"></script>
-    <script>
-        feather.replace();
-        function logout() { window.location.href = "/logout"; }
-    </script>
+<body>
+    <iframe
+        title="Inventory Link Portal"
+        src="/api/inventory-links/{{ link.id }}/proxy/"
+        class="portal-frame"
+        referrerpolicy="no-referrer"
+    ></iframe>
 </body>
 </html>

--- a/templates/server_settings.html
+++ b/templates/server_settings.html
@@ -506,8 +506,8 @@
                                         <i data-feather="link-2" class="h-5 w-5"></i>
                                     </span>
                                     <div>
-                                        <h2 class="text-xl font-semibold text-slate-900">Linked Inventory Pros</h2>
-                                        <p class="text-sm text-slate-500">Verknüpfe weitere Inventory Pro Instanzen und öffne sie im Portal.</p>
+                                        <h2 class="text-xl font-semibold text-slate-900">Inventory verbinden</h2>
+                                        <p class="text-sm text-slate-500">Zieladresse angeben, verbinden, fertig. Falls eine Anmeldung nötig ist, erscheint sie direkt im Zielsystem.</p>
                                     </div>
                                 </div>
 
@@ -520,80 +520,39 @@
                                                         <p class="text-sm font-semibold text-slate-900" x-text="link.displayName"></p>
                                                         <p class="text-xs text-slate-500" x-text="link.baseUrl"></p>
                                                         <div class="mt-2 flex flex-wrap items-center gap-2 text-xs">
-                                                            <span class="rounded-full bg-slate-100 px-2 py-0.5 text-slate-600" x-text="link.authMode"></span>
-                                                            <span class="rounded-full bg-slate-100 px-2 py-0.5 text-slate-600" x-text="link.verifyTls ? 'TLS geprüft' : 'TLS off'"></span>
-                                                            <template x-if="link.healthStatus">
-                                                                <span class="rounded-full px-2 py-0.5 text-xs font-semibold"
-                                                                      :class="link.healthStatus === 'ok' ? 'bg-emerald-100 text-emerald-700' : (link.healthStatus === 'unauthorized' ? 'bg-amber-100 text-amber-700' : 'bg-rose-100 text-rose-700')"
-                                                                      x-text="link.healthStatus"></span>
-                                                            </template>
+                                                            <span class="rounded-full px-2 py-0.5 text-xs font-semibold"
+                                                                  :class="inventoryLinkStatusClass(link)"
+                                                                  x-text="inventoryLinkStatusLabel(link)"></span>
                                                         </div>
                                                     </div>
                                                     <div class="flex flex-col gap-2">
-                                                        <button type="button" class="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-50" @click="editInventoryLink(link)">Bearbeiten</button>
+                                                        <a :href="`/inventory-links/${link.id}/portal`" class="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-50">Öffnen</a>
+                                                        <button type="button" class="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-50" @click="testInventoryLink(link)">Status prüfen</button>
                                                         <button type="button" class="rounded-full border border-rose-200 px-3 py-1 text-xs font-semibold text-rose-600 hover:bg-rose-50" @click="deleteInventoryLink(link)">Entfernen</button>
                                                     </div>
                                                 </div>
                                             </div>
                                         </template>
                                         <div x-show="inventoryLinks.length === 0" class="rounded-2xl border border-dashed border-slate-200 p-4 text-sm text-slate-500">
-                                            Noch keine verknüpften Instanzen. Lege rechts eine neue Verbindung an.
+                                            Noch keine Verbindung. Gib rechts nur die Zieladresse ein und klicke auf „Verbinden“.
                                         </div>
                                     </div>
 
                                     <div class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
                                         <div class="flex items-center justify-between">
-                                            <p class="text-sm font-semibold text-slate-700" x-text="editingInventoryLinkId ? 'Link bearbeiten' : 'Neuen Link hinzufügen'"></p>
+                                            <p class="text-sm font-semibold text-slate-700">Neue Verbindung</p>
                                             <button type="button" class="text-xs font-semibold text-slate-500 hover:text-slate-700" @click="resetInventoryLinkForm">Zurücksetzen</button>
                                         </div>
                                         <div class="mt-4 space-y-3">
                                             <div class="space-y-1">
-                                                <label class="text-xs font-semibold text-slate-600">Display Name</label>
-                                                <input type="text" x-model="inventoryLinkForm.displayName" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="HQ Inventory">
+                                                <label class="text-xs font-semibold text-slate-600">Zieladresse</label>
+                                                <input type="text" x-model="inventoryLinkForm.baseUrl" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="https://inventory-zielserver.de">
+                                                <p class="text-[11px] text-slate-400">Beispiel: https://inventory-zielserver.de</p>
                                             </div>
-                                            <div class="space-y-1">
-                                                <label class="text-xs font-semibold text-slate-600">Base URL</label>
-                                                <input type="text" x-model="inventoryLinkForm.baseUrl" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="https://inv.pondsec.com">
-                                            </div>
-                                            <div class="space-y-1">
-                                                <label class="text-xs font-semibold text-slate-600">Auth Mode</label>
-                                                <select x-model="inventoryLinkForm.authMode" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500">
-                                                    <option value="apiKey">API Key</option>
-                                                    <option value="bearerToken">Bearer Token</option>
-                                                    <option value="login">Login (Benutzer)</option>
-                                                    <option value="basic">Basic</option>
-                                                    <option value="none">None</option>
-                                                </select>
-                                            </div>
-                                            <div class="space-y-1">
-                                                <label class="text-xs font-semibold text-slate-600">Secret</label>
-                                                <input type="password" x-model="inventoryLinkForm.secret" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500" :placeholder="inventoryLinkForm.authMode === 'login' ? 'Benutzername:Passwort' : 'Nur bei Änderung neu eingeben'">
-                                                <p class="text-[11px] text-slate-400" x-show="inventoryLinkForm.authMode !== 'login'">Secrets werden serverseitig verschlüsselt gespeichert.</p>
-                                                <p class="text-[11px] text-slate-400">Ohne <code>INVENTORY_LINKS_ENCRYPTION_KEY</code> werden Secrets unverschlüsselt gespeichert.</p>
-                                                <p class="text-[11px] text-slate-400" x-show="inventoryLinkForm.authMode === 'login'">Login nutzt /login der Zielinstanz und speichert die Session serverseitig.</p>
-                                            </div>
-                                            <label class="flex items-start gap-3 rounded-2xl border border-slate-200 bg-white p-3">
-                                                <input type="checkbox" x-model="inventoryLinkForm.verifyTls" class="mt-1 h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500">
-                                                <div>
-                                                    <p class="text-xs font-semibold text-slate-700">TLS Zertifikate prüfen</p>
-                                                    <p class="text-[11px] text-slate-400">Deaktivieren nur für selbstsignierte HTTPS-Ziele.</p>
-                                                </div>
-                                            </label>
-                                            <label class="flex items-start gap-3 rounded-2xl border border-slate-200 bg-white p-3">
-                                                <input type="checkbox" x-model="inventoryLinkForm.allowPrivateNetwork" class="mt-1 h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500">
-                                                <div>
-                                                    <p class="text-xs font-semibold text-slate-700">Private Netzwerke zulassen</p>
-                                                    <p class="text-[11px] text-slate-400">Erlaubt RFC1918 (LAN), blockiert weiterhin Loopback & Metadata.</p>
-                                                </div>
-                                            </label>
                                             <div class="flex flex-wrap gap-2">
                                                 <button type="button" class="rounded-2xl bg-slate-900 px-4 py-2 text-xs font-semibold text-white" @click="saveInventoryLink" :disabled="inventoryLinkSaving">
-                                                    <span x-show="!inventoryLinkSaving">Speichern</span>
-                                                    <span x-show="inventoryLinkSaving">Speichert...</span>
-                                                </button>
-                                                <button type="button" class="rounded-2xl border border-slate-200 px-4 py-2 text-xs font-semibold text-slate-600 hover:bg-slate-50" @click="testInventoryLink" :disabled="inventoryLinkTesting">
-                                                    <span x-show="!inventoryLinkTesting">Verbindung testen</span>
-                                                    <span x-show="inventoryLinkTesting">Teste...</span>
+                                                    <span x-show="!inventoryLinkSaving">Verbinden</span>
+                                                    <span x-show="inventoryLinkSaving">Verbinde...</span>
                                                 </button>
                                             </div>
                                             <div x-show="inventoryLinkMessage" class="rounded-2xl border border-slate-200 bg-white p-3 text-xs text-slate-600" x-text="inventoryLinkMessage"></div>
@@ -1433,14 +1392,13 @@
                 },
                 inventoryLinks: [],
                 inventoryLinkForm: {
-                    displayName: '',
                     baseUrl: '',
-                    authMode: 'apiKey',
-                    secret: '',
+                    displayName: '',
+                    authMode: 'auto',
                     verifyTls: true,
-                    allowPrivateNetwork: true
+                    allowPrivateNetwork: false,
+                    secret: ''
                 },
-                editingInventoryLinkId: null,
                 inventoryLinkSaving: false,
                 inventoryLinkTesting: false,
                 inventoryLinkMessage: '',
@@ -1596,32 +1554,17 @@
 
                 resetInventoryLinkForm(clearMessages = true) {
                     this.inventoryLinkForm = {
-                        displayName: '',
                         baseUrl: '',
-                        authMode: 'apiKey',
-                        secret: '',
+                        displayName: '',
+                        authMode: 'auto',
                         verifyTls: true,
-                        allowPrivateNetwork: true
+                        allowPrivateNetwork: false,
+                        secret: ''
                     };
-                    this.editingInventoryLinkId = null;
                     if (clearMessages) {
                         this.inventoryLinkMessage = '';
                         this.inventoryLinkError = '';
                     }
-                },
-
-                editInventoryLink(link) {
-                    this.editingInventoryLinkId = link.id;
-                    this.inventoryLinkForm = {
-                        displayName: link.displayName,
-                        baseUrl: link.baseUrl,
-                        authMode: link.authMode,
-                        secret: '',
-                        verifyTls: link.verifyTls,
-                        allowPrivateNetwork: link.allowPrivateNetwork
-                    };
-                    this.inventoryLinkMessage = '';
-                    this.inventoryLinkError = '';
                 },
 
                 async saveInventoryLink() {
@@ -1630,31 +1573,22 @@
                     this.inventoryLinkMessage = '';
                     try {
                         const payload = { ...this.inventoryLinkForm };
-                        if (this.editingInventoryLinkId) {
-                            const response = await fetch(`/api/inventory-links/${this.editingInventoryLinkId}`, {
-                                method: 'PATCH',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify(payload)
-                            });
-                            if (!response.ok) {
-                                const error = await response.json();
-                                throw new Error(error.error || 'Konnte Link nicht speichern.');
-                            }
-                            this.inventoryLinkMessage = 'Link aktualisiert.';
-                        } else {
-                            const response = await fetch('/api/inventory-links', {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify(payload)
-                            });
-                            if (!response.ok) {
-                                const error = await response.json();
-                                throw new Error(error.error || 'Konnte Link nicht speichern.');
-                            }
-                            this.inventoryLinkMessage = 'Link hinzugefügt.';
+                        const response = await fetch('/api/inventory-links', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(payload)
+                        });
+                        const result = await response.json();
+                        if (!response.ok) {
+                            throw new Error(result.error || 'Konnte Verbindung nicht erstellen.');
                         }
+                        this.inventoryLinkMessage = 'Verbindung erstellt. Status wird geprüft...';
+                        const status = await this.testInventoryLink(result);
                         await this.fetchInventoryLinks();
                         this.resetInventoryLinkForm(false);
+                        if (status && ['ok', 'unauthorized'].includes(status)) {
+                            window.location.href = `/inventory-links/${result.id}/portal`;
+                        }
                     } catch (error) {
                         this.inventoryLinkError = error.message;
                     } finally {
@@ -1674,27 +1608,19 @@
                         }
                         this.inventoryLinkMessage = 'Link entfernt.';
                         await this.fetchInventoryLinks();
-                        if (this.editingInventoryLinkId === link.id) {
-                            this.resetInventoryLinkForm();
-                        }
                     } catch (error) {
                         this.inventoryLinkError = error.message;
                     }
                 },
 
-                async testInventoryLink() {
+                async testInventoryLink(link) {
                     this.inventoryLinkTesting = true;
                     this.inventoryLinkError = '';
-                    this.inventoryLinkMessage = '';
                     try {
-                        const payload = { ...this.inventoryLinkForm };
-                        const url = this.editingInventoryLinkId
-                            ? `/api/inventory-links/${this.editingInventoryLinkId}/test`
-                            : '/api/inventory-links/test';
+                        const url = `/api/inventory-links/${link.id}/test`;
                         const response = await fetch(url, {
                             method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify(payload)
+                            headers: { 'Content-Type': 'application/json' }
                         });
                         const result = await response.json();
                         if (!response.ok) {
@@ -1703,16 +1629,32 @@
                         if (result.status === 'ok') {
                             this.inventoryLinkMessage = 'Verbindung erfolgreich.';
                         } else if (result.status === 'unauthorized') {
-                            this.inventoryLinkError = 'Nicht autorisiert. Bitte Credentials prüfen.';
+                            this.inventoryLinkMessage = 'Anmeldung erforderlich.';
                         } else {
                             this.inventoryLinkError = result.error || 'Verbindung fehlgeschlagen.';
                         }
                         await this.fetchInventoryLinks();
+                        return result.status;
                     } catch (error) {
                         this.inventoryLinkError = error.message;
+                        return null;
                     } finally {
                         this.inventoryLinkTesting = false;
                     }
+                },
+
+                inventoryLinkStatusLabel(link) {
+                    if (!link.healthStatus) return 'Status unbekannt';
+                    if (link.healthStatus === 'ok') return 'Verbunden';
+                    if (link.healthStatus === 'unauthorized') return 'Anmeldung erforderlich';
+                    return 'Verbindung fehlgeschlagen';
+                },
+
+                inventoryLinkStatusClass(link) {
+                    if (!link.healthStatus) return 'bg-slate-100 text-slate-600';
+                    if (link.healthStatus === 'ok') return 'bg-emerald-100 text-emerald-700';
+                    if (link.healthStatus === 'unauthorized') return 'bg-amber-100 text-amber-700';
+                    return 'bg-rose-100 text-rose-700';
                 },
 
                 hasChanges() {


### PR DESCRIPTION
### Motivation
- Vereinfachung der Verbindungs-UX: Anwender sollen nur noch Zieladresse eingeben und auf „Verbinden“ klicken müssen; alle technischen Details werden automatisch im Hintergrund gehandhabt.
- Automatische Erkennung von Authentifizierung und Anzeigenamen, damit neue Links mit minimaler Eingabe korrekt angelegt werden.

### Description
- UI-Änderungen in `templates/server_settings.html` reduzieren das Formular auf ein einzelnes `baseUrl`-Eingabefeld, passen Button-Labels an und zeigen klare Status-Labels sowie eine „Verbinden“-Flow-Logik an.
- Portal-Template `templates/inventory_link_portal.html` wurde zu einer vollflächigen `iframe`-Seite vereinfacht, damit die Zielinstanz die Oberfläche vollständig übernehmen kann.
- Neue Hilfsfunktionen in `app.py`: `derive_inventory_link_display_name()` leitet standardmäßig einen lesbaren Namen aus der `base_url` ab, und `resolve_inventory_link_auth()` löst das neue `auth_mode: 'auto'` auf (`none` / `login` / `apiKey`) basierend auf dem optionalen `secret`.
- API-Änderungen in `app.py` für `POST /api/inventory-links`, `POST /api/inventory-links/test` und `PATCH /api/inventory-links/<id>` unterstützen jetzt `authMode: 'auto'`, wenden die automatische Auth-Auflösung an, setzen den abgeleiteten `display_name` falls leer und vereinfachen Secret-/Speicherlogik (inkl. Behandlung von `none`).
- Clientseitige Anpassungen: der Create-Flow sendet minimalen Payload, führt nach Erstellung einen Status-Test durch, zeigt klare Meldungen und leitet bei erfolgreicher Verbindung automatisch ins Portal weiter.

### Testing
- Dev-Server gestartet mit `python app.py`, der Prozess lief und war unter `http://127.0.0.1:5001` erreichbar (erfolgreich).
- Headless-UI-Check mit Playwright: Skript navigierte zu `http://localhost:5001/settings?section=server#inventory-links` und erzeugte ein Screenshot-Artefakt; die Seite leitete wegen fehlender Authentifizierung auf die Login-Seite weiter (Navigation + Screenshot erfolgreich).
- Keine automatisierten Unit-/Integrationstests geändert; keine zusätzlichen automatisierten Tests fehlgeschlagen.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a1fb084b48329bb0beeec3282f33f)