### PR TITLE
Disable proxies for inventory link requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -1293,7 +1293,10 @@ def login_inventory_link_session(base_url, verify_tls, secret):
         "User-Agent": "InventoryPro-Link/1.0"
     }
     cookie_jar = http.cookiejar.CookieJar()
-    handlers = [urllib.request.HTTPCookieProcessor(cookie_jar)]
+    handlers = [
+        urllib.request.ProxyHandler({}),
+        urllib.request.HTTPCookieProcessor(cookie_jar)
+    ]
     context = None
     if base_url.startswith("https://"):
         context = build_inventory_link_ssl_context(verify_tls)
@@ -1492,7 +1495,7 @@ def perform_inventory_link_test(config):
         context = None
         if base_url.startswith("https://"):
             context = build_inventory_link_ssl_context(verify_tls)
-        handlers = [InventoryLinkNoRedirect()]
+        handlers = [urllib.request.ProxyHandler({}), InventoryLinkNoRedirect()]
         if context is not None:
             handlers.append(urllib.request.HTTPSHandler(context=context))
         opener = urllib.request.build_opener(*handlers)
@@ -11648,7 +11651,7 @@ def inventory_link_proxy(link_id, subpath):
     if link["base_url"].startswith("https://"):
         context = build_inventory_link_ssl_context(bool(link["verify_tls"]))
 
-    handlers = [InventoryLinkNoRedirect()]
+    handlers = [urllib.request.ProxyHandler({}), InventoryLinkNoRedirect()]
     if context is not None:
         handlers.append(urllib.request.HTTPSHandler(context=context))
     opener = urllib.request.build_opener(*handlers)


### PR DESCRIPTION
### Motivation
- Environment HTTP(S) proxy settings caused inventory link requests to route incorrectly and time out when connecting to private/internal targets, producing 500 errors.
- The goal is to ensure direct connections for inventory link login, health checks and proxying so private endpoints are reachable.

### Description
- Add `urllib.request.ProxyHandler({})` to the opener handler lists used by `login_inventory_link_session`, `perform_inventory_link_test`, and `inventory_link_proxy` so those requests explicitly bypass environment proxies.
- The change inserts the proxy handler before cookie and redirect handlers and preserves existing TLS and auth handling behavior.
- No other request or header logic was changed.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a25d88f08832997c11764c6ec2fbb)