### PR TITLE
Fix same-origin validation for default ports

### DIFF
--- a/app.py
+++ b/app.py
@@ -5967,12 +5967,25 @@ def request_origin():
         return ""
     return f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
 
+def normalized_origin(scheme, host):
+    parsed = urllib.parse.urlsplit(f"{scheme}://{host}")
+    hostname = parsed.hostname or host
+    port = parsed.port
+    default_port = (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+    netloc = hostname if port is None or default_port else f"{hostname}:{port}"
+    return f"{scheme}://{netloc}".rstrip("/")
+
+
 def expected_request_origins():
     forwarded_proto = trusted_forwarded_header("X-Forwarded-Proto")
     forwarded_host = trusted_forwarded_header("X-Forwarded-Host")
     scheme = forwarded_proto or request.scheme
     host = forwarded_host or request.host
-    origins = {f"{scheme}://{host}".rstrip("/"), request.host_url.rstrip("/")}
+    origins = {
+        normalized_origin(scheme, host),
+        normalized_origin(request.scheme, request.host),
+        request.host_url.rstrip("/"),
+    }
     if PUBLIC_ORIGIN:
         origins.add(PUBLIC_ORIGIN)
     origins.update(ALLOWED_CORS_ORIGINS)

--- a/tests/test_stabilization_security.py
+++ b/tests/test_stabilization_security.py
@@ -157,6 +157,25 @@ class CsrfProtectionTestCase(TestCase):
         )
         self.assertEqual(cross_origin.status_code, 403)
 
+
+    def test_same_origin_accepts_default_port_normalization(self):
+        self.client.get("/login", base_url="http://localhost:80")
+        with self.client.session_transaction() as session:
+            token = session["_csrf_token"]
+
+        response = self.client.post(
+            "/login",
+            base_url="http://localhost:80",
+            data={"username": "admin", "password": "invalid"},
+            headers={"X-CSRF-Token": token, "Origin": "http://localhost"},
+        )
+
+        self.assertNotEqual(response.status_code, 403)
+
+    def test_expected_origins_normalize_https_default_port(self):
+        with inventory_app.app.test_request_context("/login", base_url="https://inventory.example:443"):
+            self.assertIn("https://inventory.example", inventory_app.expected_request_origins())
+
     def test_untrusted_forwarded_headers_are_not_used_for_client_identity(self):
         previous_networks = inventory_app.TRUSTED_PROXY_NETWORKS
         try:


### PR DESCRIPTION
### Motivation
- Same-origin checks treated explicit default ports (e.g. `:80`/`:443`) as different from browser origins that omit them, causing valid save/write requests to be rejected with "Anfrageursprung ist nicht zulässig.".
- The intent is to canonicalize origin comparisons so session-bound CSRF and same-origin protections accept browser-origin values that omit default ports.

### Description
- Add `normalized_origin(scheme, host)` to `app.py` and use it from `expected_request_origins()` to normalize host/port pairs and ignore default ports for `http` and `https`.
- Update `expected_request_origins()` to return normalized variants for forwarded and request origins alongside `request.host_url`.
- Add regression tests in `tests/test_stabilization_security.py` that verify HTTP default-port normalization for write requests and that HTTPS default-port origins are recognized.

### Testing
- Compiled the modified files with `python -m py_compile app.py tests/test_stabilization_security.py`, which succeeded.
- Ran the targeted security tests with `python -m pytest tests/test_stabilization_security.py::CsrfProtectionTestCase -q`, which passed.
- Ran the full test suite while ignoring browser/mobile interactions with `python -m pytest -q --ignore=tests/test_mobile_interactions.py`, which completed successfully with `212 passed, 2 warnings, 38 subtests passed`.
- Attempt to install dev dependencies (`pip install -r requirements-dev.txt`) failed to fetch `playwright` due to a package index/proxy error (`403`), so `tests/test_mobile_interactions.py` could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66296cc7b883278c96832e6ce4c934)